### PR TITLE
Add tag-only activation path for toolhead action

### DIFF
--- a/middleware/activation.py
+++ b/middleware/activation.py
@@ -272,6 +272,9 @@ def _activate_from_scan(
     elif action == "toolhead":
         if spoolman_activated:
             publish_lock(target, "lock")
+        elif spool_info and spool_info.spoolman_id is not None:
+            # Activation failed — don't lock, allow rescan
+            logger.warning(f"Not locking {target} — activation failed, rescan allowed")
         else:
             # No Spoolman — send tag data directly to toolhead via gcode variables
             _send_toolhead_tag_data(target, color_hex, filament_label, remaining)


### PR DESCRIPTION
## Summary

- When Spoolman is not configured, `toolhead` action now sends tag data (color) to the toolhead via `SET_GCODE_VARIABLE` instead of silently doing nothing
- New `_send_toolhead_tag_data()` function mirrors the existing `_send_afc_lane_data()` pattern
- Scanner locks on scan regardless of Spoolman availability

## Problem

Previously, scanning a tag with `toolhead` action and no Spoolman resulted in a warning log and no action. The user saw nothing happen. AFC modes already had a tag-only fallback — toolhead did not.

## Test plan

- [ ] Scan tag with toolhead action, Spoolman disabled → verify SET_GCODE_VARIABLE sent
- [ ] Scan tag with toolhead action, Spoolman enabled → verify existing path unchanged
- [ ] Scanner locks after scan in both cases

Closes #7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toolhead tag data (color, material, weight) is now pushed when the primary service is unavailable, with validation and per-field resilience.

* **Bug Fixes**
  * Adjusted toolhead lock flow so locks are only applied after successful activation; failed activations allow rescans and avoid premature locking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->