### PR TITLE
Fix SAVE_VARIABLE uppercase rejection from Klipper

### DIFF
--- a/middleware/activation.py
+++ b/middleware/activation.py
@@ -64,7 +64,7 @@ def activate_spool(spool_id: int, action: str, target: str | None = None) -> boo
             ).raise_for_status()
             requests.post(
                 f"{moonraker}/printer/gcode/script",
-                json={"script": f"SAVE_VARIABLE VARIABLE={target}_spool_id VALUE={spool_id}"},
+                json={"script": f"SAVE_VARIABLE VARIABLE={target.lower()}_spool_id VALUE={spool_id}"},
                 timeout=5,
             ).raise_for_status()
             logger.info(f"[toolhead] Activated spool {spool_id} on {target}")


### PR DESCRIPTION
## Summary

Klipper requires `SAVE_VARIABLE` names to be lowercase. The `toolhead` action was passing the raw target name (e.g. `T0_spool_id`) which Klipper rejects with "VARIABLE must not contain upper case". Now uses `target.lower()` to produce `t0_spool_id`.

`toolchanger_status.py` already used lowercase — only the dedicated `toolhead` action path was affected.

## Test plan

- [x] Scanned UID-only tag → Spoolman lookup found spool 56 → `SAVE_VARIABLE VARIABLE=t0_spool_id` succeeded
- [x] Spool activated on T0

One-line fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed variable naming format in toolhead activation to ensure proper spool identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->