### PR TITLE
fix: add missing requirements.txt for Python dependencies

### DIFF
--- a/middleware/requirements.txt
+++ b/middleware/requirements.txt
@@ -1,4 +1,4 @@
-paho-mqtt>=1.6,<3
+paho-mqtt>=1.6,<2
 pyyaml>=6.0
 requests>=2.28
 watchdog>=3.0


### PR DESCRIPTION
## Summary

The middleware has no `requirements.txt`, causing the installer to silently skip dependency installation. The service then crashes on startup with `ModuleNotFoundError: No module named 'paho'`.

Adds `requirements.txt` with: `paho-mqtt`, `pyyaml`, `requests`, `watchdog`.

Companion fix in installer: SpoolSense/spoolsense-installer#8

## Test plan

- [ ] Fresh install via installer — deps install correctly
- [ ] `pip install -r middleware/requirements.txt` works standalone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added dependency declarations for middleware components to ensure proper package versions are installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->