### PR TITLE
Add lane to lane_data

### DIFF
--- a/middleware/toolchanger_status.py
+++ b/middleware/toolchanger_status.py
@@ -143,6 +143,7 @@ def _assign_spool_to_tool(tool_name: str, pending: dict) -> None:
         "nozzle_temp": None,
         "bed_temp": None,
         "spool_id": spoolman_id,
+        "lane": tool_number_str,
     }
     try:
         requests.post(


### PR DESCRIPTION
## Summary
Add lane field with tool number on lane_data.

## Changes
Add lane field with tool number on lane_data.

## How to Test
Scan a tag, assign it to a tool and then review lane_data to verify the "lane" field exists and contains a tool number a string.

## Checklist
- [x] Tested with live scanner hardware
- [x] Config examples updated if config format changed
- [ ] Works with Spoolman enabled and disabled

This was required for me to be able to sync filament data to orca slicer. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced spool data reporting by including additional tool identification information when publishing data to the database system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->