### PR TITLE
fix: update active_spools on tool assignment for correct eject detection (#45)

### DIFF
--- a/middleware/toolchanger_status.py
+++ b/middleware/toolchanger_status.py
@@ -142,6 +142,13 @@ def _assign_spool_to_tool(tool_name: str, pending: dict) -> None:
     if remaining_g is not None:
         logger.info(f"[toolhead_stage] {macro} weight: {remaining_g:.0f}g")
 
+    # Track active spool for toolhead_status eject detection (#45)
+    # Must happen regardless of lane_data config — uses macro (uppercase) for consistent key
+    if spoolman_id is not None:
+        with app_state.state_lock:
+            app_state.active_spools[macro] = spoolman_id
+            logger.info(f"Updated active_spools[{macro}] = {spoolman_id}")
+
     # Write spool data to Moonraker's lane_data database for slicer integration.
     # AFC handles this for its lanes; for toolhead assignments we write directly.
     # Gated by publish_lane_data config flag (opt-in).
@@ -176,12 +183,6 @@ def _assign_spool_to_tool(tool_name: str, pending: dict) -> None:
         logger.info(f"[toolhead_stage] Published lane_data for {macro}: {safe_material} {safe_color}")
     except Exception:
         logger.exception(f"[toolhead_stage] Failed to publish lane_data for {macro}")
-
-    # Track active spool for toolhead_status eject detection (#45)
-    if spoolman_id is not None:
-        with app_state.state_lock:
-            app_state.active_spools[tool_name] = spoolman_id
-            logger.info(f"Updated active_spools[{tool_name}] = {spoolman_id}")
 
 
 def _fetch_pending_tool() -> str | None:


### PR DESCRIPTION
## Summary
- When ASSIGN_SPOOL macro assigns a spool to a tool, `app_state.active_spools[tool_name]` is now updated with the spoolman_id
- `toolhead_status.py` can now identify the correct tool on eject and only clear that tool's lock, instead of clearing all locks
- Guarded against `None` spoolman_id (tag-only mode without Spoolman)

## Root Cause
`_assign_spool_to_tool()` in `toolchanger_status.py` never wrote to `active_spools`. When `toolhead_status._check_transition()` searched `active_spools` for the ejected spool, it found no match and fell back to clearing all toolhead locks — breaking multi-tool setups.

## Test Plan
- [ ] Multi-tool setup: assign spools to T0, T1, T2 — eject T1 — only T1 lock clears
- [ ] Tag-only mode (no Spoolman) — no crash, active_spools not updated
- [ ] Single-tool setup — behavior unchanged

Closes #45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spool-to-tool tracking so active spool associations are reliably recorded during tool changes, even when lane data publishing is disabled. This ensures more accurate eject detection and overall state consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->