### PR TITLE
feat: add rotating log file (#42)

### DIFF
--- a/middleware/spoolsense.py
+++ b/middleware/spoolsense.py
@@ -26,6 +26,8 @@ Configuration is loaded from ~/SpoolSense/config.yaml — see config.example.*.y
 
 import json
 import logging
+from logging.handlers import RotatingFileHandler
+import os
 import signal
 import sys
 
@@ -43,8 +45,21 @@ from toolhead_status import ToolheadStatusSync
 from var_watcher import start_klipper_watcher
 from moonraker_ws import WEBSOCKET_AVAILABLE, MoonrakerWebsocket
 
-# Configure logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
+# Configure logging — stdout + rotating file
+LOG_FORMAT = '%(asctime)s %(levelname)s %(message)s'
+LOG_FILE = os.path.expanduser('~/SpoolSense/middleware/spoolsense.log')
+LOG_MAX_BYTES = 5 * 1024 * 1024  # 5MB
+LOG_BACKUP_COUNT = 3
+
+logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
+
+# Add rotating file handler
+os.makedirs(os.path.dirname(LOG_FILE), exist_ok=True)
+_file_handler = RotatingFileHandler(LOG_FILE, maxBytes=LOG_MAX_BYTES, backupCount=LOG_BACKUP_COUNT)
+_file_handler.setFormatter(logging.Formatter(LOG_FORMAT))
+_file_handler.setLevel(logging.INFO)
+logging.getLogger().addHandler(_file_handler)
+
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## Summary
- Logs now written to `~/SpoolSense/middleware/spoolsense.log` in addition to stdout
- RotatingFileHandler: 5MB max, 3 rotations (keeps last 20MB of logs)
- stdout logging unchanged — systemd journal still works
- No config needed — log file created automatically on startup

## Test Plan
- [ ] Start middleware — `spoolsense.log` created
- [ ] Logs appear in both stdout and file
- [ ] File rotates at 5MB

Closes #42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved logging infrastructure with persistent file storage and automatic rotation. Application logs are now saved to a file and automatically rotated to prevent excessive disk consumption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->