### PR TITLE
Resync AFC lock state on MQTT reconnect

### DIFF
--- a/middleware/afc_status.py
+++ b/middleware/afc_status.py
@@ -223,6 +223,23 @@ def _fetch_afc_status() -> dict | None:
         return None
 
 
+def resync_lock_state() -> None:
+    """
+    Re-publishes the current lock/clear state for all tracked AFC lanes.
+
+    Called from on_connect() after an MQTT reconnect so that scanners
+    (and any other subscribers) get the correct lock state without
+    waiting for the next lane state change.
+    """
+    with app_state.state_lock:
+        snapshot = dict(app_state.lane_locks)
+
+    for lane, is_locked in snapshot.items():
+        state = "lock" if is_locked else "clear"
+        publish_lock(lane, state)
+        logger.info(f"AFC resync: re-published {state} for {lane}")
+
+
 class AfcStatusSync:
     """
     Monitors AFC lane state via Moonraker websocket (primary) or HTTP polling (fallback).

--- a/middleware/mqtt_handler.py
+++ b/middleware/mqtt_handler.py
@@ -9,7 +9,7 @@ import app_state
 from activation import activate_spool, publish_lock, _activate_from_scan  # activate_spool used for UID-only path
 from publishers.klipper import display_spoolcolor
 from spoolman_cache import find_spool_by_nfc, refresh_spool_cache
-from config import discover_klipper_var_path, has_toolhead_scanners
+from config import discover_klipper_var_path, has_afc_scanners, has_toolhead_scanners
 from var_watcher import sync_from_klipper_vars, start_klipper_watcher
 
 if app_state.DISPATCHER_AVAILABLE:
@@ -223,6 +223,11 @@ def on_connect(client: mqtt.Client, userdata: object, flags: dict, rc: int) -> N
                 app_state.watcher.stop()
                 app_state.watcher.join(timeout=2)
             app_state.watcher = start_klipper_watcher()
+
+        # Re-publish AFC lock state so scanners get current state after reconnect
+        if has_afc_scanners(app_state.cfg):
+            from afc_status import resync_lock_state
+            resync_lock_state()
     else:
         logger.error(f"MQTT connection failed: {rc}")
 

--- a/middleware/tests/test_afc_status.py
+++ b/middleware/tests/test_afc_status.py
@@ -16,7 +16,7 @@ sys.modules.setdefault("watchdog.observers", MagicMock())
 sys.modules.setdefault("watchdog.events", MagicMock())
 
 import app_state  # noqa: E402
-from afc_status import _sync_lane_state, _fetch_afc_status  # noqa: E402
+from afc_status import _sync_lane_state, _fetch_afc_status, resync_lock_state  # noqa: E402
 
 
 def _reset_app_state():
@@ -159,6 +159,36 @@ class TestSyncLaneState(unittest.TestCase):
         with patch("afc_status.publish_lock"):
             _sync_lane_state(data)
         assert app_state.active_spools.get("lane1") == 7
+
+
+class TestResyncLockState(unittest.TestCase):
+
+    def setUp(self):
+        _reset_app_state()
+
+    def test_resync_publishes_locked_lanes(self):
+        app_state.lane_locks["lane1"] = True
+        app_state.lane_locks["lane2"] = False
+        with patch("afc_status.publish_lock") as mock_lock:
+            resync_lock_state()
+            calls = {(c[0][0], c[0][1]) for c in mock_lock.call_args_list}
+            assert ("lane1", "lock") in calls
+            assert ("lane2", "clear") in calls
+
+    def test_resync_no_lanes_no_calls(self):
+        with patch("afc_status.publish_lock") as mock_lock:
+            resync_lock_state()
+            mock_lock.assert_not_called()
+
+    def test_resync_all_locked(self):
+        app_state.lane_locks["lane1"] = True
+        app_state.lane_locks["lane2"] = True
+        with patch("afc_status.publish_lock") as mock_lock:
+            resync_lock_state()
+            calls = {(c[0][0], c[0][1]) for c in mock_lock.call_args_list}
+            assert ("lane1", "lock") in calls
+            assert ("lane2", "lock") in calls
+            assert len(mock_lock.call_args_list) == 2
 
 
 class TestFetchAfcStatus(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Add `resync_lock_state()` to `afc_status.py` — re-publishes lock/clear for all tracked AFC lanes after MQTT reconnect
- Call it from `on_connect()` in `mqtt_handler.py` when AFC scanners are configured
- 3 new tests in `test_afc_status.py`

## Why

After an MQTT reconnect (network blip), scanners and other subscribers don't know the current lock state until the next lane state change. This re-emits the current state immediately on reconnect.

## Test plan

- [ ] Existing tests pass
- [ ] Disconnect/reconnect MQTT broker — verify scanners receive correct lock/clear state
- [ ] AFC lanes with active spools re-publish `lock`
- [ ] Empty lanes re-publish `clear`

Closes #13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * AFC lane lock states are now automatically resynchronized when the MQTT connection is reestablished, ensuring all tracked lanes remain consistent across reconnections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->