### PR TITLE
Filament usage deduction via UPDATE_TAG macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to SpoolSense are documented here.
 
 ---
 
+## [1.6.0] - 2026-04-06
+
+### Added
+
+- **Filament usage deduction via UPDATE_TAG macro** — add `UPDATE_TAG` to your PRINT_END macro for automatic filament tracking. After each print, the middleware grabs per-tool usage from the last completed job (toolchanger/single) or reads AFC lane weights directly. Deductions are sent to the scanner and written to the NFC tag (OpenPrintTag/OpenTag3D) on next scan. UID-only/TigerTag/OpenSpool tags are a no-op — Moonraker handles Spoolman sync. (#51)
+
+---
+
 ## [1.5.9] - 2026-04-05
 
 ### Fixed

--- a/middleware/app_state.py
+++ b/middleware/app_state.py
@@ -69,3 +69,10 @@ pending_spool: dict | None = None
 # Protected by state_lock.
 WRITE_COOLDOWN_SECONDS: int = 10
 tag_write_timestamps: dict[str, float] = {}
+
+# Filament usage tracking — used by UPDATE_TAG to calculate deductions.
+# Records the initial tag weight, UID, and scanner device_id per target
+# at scan time. Protected by state_lock.
+active_spool_weights: dict[str, float] = {}
+active_spool_uids: dict[str, str] = {}
+active_spool_devices: dict[str, str] = {}

--- a/middleware/app_state.py
+++ b/middleware/app_state.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from publisher_manager import PublisherManager
     from toolchanger_status import ToolchangerStatusSync
     from toolhead_status import ToolheadStatusSync
+    from filament_usage import FilamentUsageSync
 
 # Dispatcher availability — set at import time
 try:
@@ -32,6 +33,7 @@ watcher: Observer | None = None
 afc_status_sync: AfcStatusSync | None = None
 toolchanger_status_sync: ToolchangerStatusSync | None = None
 toolhead_status_sync: ToolheadStatusSync | None = None
+filament_usage_sync: FilamentUsageSync | None = None
 publisher_manager: PublisherManager | None = None
 moonraker_ws: MoonrakerWebsocket | None = None
 

--- a/middleware/app_state.py
+++ b/middleware/app_state.py
@@ -73,8 +73,10 @@ WRITE_COOLDOWN_SECONDS: int = 10
 tag_write_timestamps: dict[str, float] = {}
 
 # Filament usage tracking — used by UPDATE_TAG to calculate deductions.
-# Records the initial tag weight, UID, and scanner device_id per target
-# at scan time. Protected by state_lock.
+# Records the initial tag weight, UID, scanner device_id, and filament
+# properties per target at scan time. Protected by state_lock.
 active_spool_weights: dict[str, float] = {}
 active_spool_uids: dict[str, str] = {}
 active_spool_devices: dict[str, str] = {}
+active_spool_diameters: dict[str, float] = {}   # mm, default 1.75
+active_spool_densities: dict[str, float] = {}   # g/cm³, default 1.24

--- a/middleware/filament_usage.py
+++ b/middleware/filament_usage.py
@@ -55,8 +55,10 @@ def _fetch_last_job_weights() -> list[float] | None:
             return None
 
         job = jobs[0]
-        if job.get("status") != "completed":
-            logger.debug("UPDATE_TAG: last job status is '%s', not completed", job.get("status"))
+        # Count any job that actually extruded filament, regardless of status
+        # (cancelled/failed prints still use filament)
+        if job.get("filament_used", 0) <= 0:
+            logger.debug("UPDATE_TAG: last job used no filament, skipping")
             return None
 
         weights = job.get("metadata", {}).get("filament_weights", [])
@@ -214,14 +216,105 @@ def _handle_afc() -> None:
             app_state.active_spool_weights[lane] = current_weight
 
 
+def _fetch_tool_filament_used() -> dict[str, float] | None:
+    """
+    Query per-tool filament_used from klipper-toolchanger tool objects.
+
+    Returns dict like {"T0": 1250.5, "T1": 830.2} in mm, or None if
+    the tool objects don't expose filament_used (mod not installed).
+    """
+    moonraker = app_state.cfg.get("moonraker_url", "")
+    if not moonraker:
+        return None
+
+    # Build query for all active tools
+    with app_state.state_lock:
+        tool_names = list(app_state.active_spool_uids.keys())
+
+    if not tool_names:
+        return None
+
+    # Query tool objects — e.g. ?tool%20T0&tool%20T1
+    query_parts = "&".join(f"tool%20{t}" for t in tool_names)
+    try:
+        response = requests.get(
+            f"{moonraker}/printer/objects/query?{query_parts}",
+            timeout=5,
+        )
+        response.raise_for_status()
+        status = response.json().get("result", {}).get("status", {})
+
+        result: dict[str, float] = {}
+        for tool_name in tool_names:
+            tool_data = status.get(f"tool {tool_name}", {})
+            filament = tool_data.get("filament_used")
+            if filament is None:
+                # Tool object doesn't have filament_used — mod not installed
+                return None
+            result[tool_name] = float(filament)
+
+        return result if result else None
+
+    except requests.ConnectionError:
+        logger.debug("UPDATE_TAG: Moonraker not reachable for tool query")
+        return None
+    except Exception:
+        logger.exception("UPDATE_TAG: failed to fetch tool filament_used")
+        return None
+
+
+def _mm_to_grams(mm: float, diameter_mm: float, density_g_cm3: float) -> float:
+    """Convert filament length in mm to weight in grams."""
+    import math
+    radius_mm = diameter_mm / 2.0
+    volume_mm3 = math.pi * radius_mm * radius_mm * mm
+    return volume_mm3 * density_g_cm3 / 1000.0
+
+
 def _handle_toolchanger() -> None:
-    """Handle UPDATE_TAG for toolchanger/single — deduction from last job weights."""
-    weights = _fetch_last_job_weights()
-    if not weights:
-        logger.info("UPDATE_TAG: no completed job found — skipping")
+    """
+    Handle UPDATE_TAG for toolchanger/single.
+
+    Primary: read per-tool filament_used from klipper-toolchanger tool objects
+    (requires per-tool tracking mod). Values are in mm, converted to grams.
+
+    Fallback: read filament_weights from last completed job's slicer metadata
+    (always available, but slicer estimate only — inaccurate for cancelled prints).
+    """
+    # Try per-tool tracking first (klipper-toolchanger mod)
+    tool_usage = _fetch_tool_filament_used()
+
+    if tool_usage is not None:
+        logger.info("UPDATE_TAG: using per-tool filament_used from toolchanger")
+        with app_state.state_lock:
+            uids = dict(app_state.active_spool_uids)
+            devices = dict(app_state.active_spool_devices)
+            diameters = dict(app_state.active_spool_diameters)
+            densities = dict(app_state.active_spool_densities)
+
+        for tool_name, usage_mm in tool_usage.items():
+            if usage_mm <= 0:
+                continue
+
+            uid = uids.get(tool_name)
+            device_id = devices.get(tool_name)
+            if not uid or not device_id:
+                logger.debug(f"UPDATE_TAG: no active spool on {tool_name}, skipping")
+                continue
+
+            diameter = diameters.get(tool_name, 1.75)
+            density = densities.get(tool_name, 1.24)
+            usage_g = _mm_to_grams(usage_mm, diameter, density)
+            _publish_deduction(device_id, uid, usage_g)
         return
 
-    # Snapshot state under lock
+    # Fallback: slicer estimate from print history
+    logger.info("UPDATE_TAG: per-tool tracking not available, falling back to slicer estimates")
+    weights = _fetch_last_job_weights()
+    if not weights:
+        logger.info("UPDATE_TAG: no job with filament usage found — skipping")
+        return
+
     with app_state.state_lock:
         uids = dict(app_state.active_spool_uids)
         devices = dict(app_state.active_spool_devices)

--- a/middleware/filament_usage.py
+++ b/middleware/filament_usage.py
@@ -1,0 +1,352 @@
+"""
+filament_usage.py — Filament usage deduction via UPDATE_TAG macro.
+
+When UPDATE_TAG fires in PRINT_END, this module:
+1. Grabs the last completed job's per-tool filament weights (toolchanger/single)
+   or reads AFC lane weights (AFC)
+2. Sends deduction commands to the scanner via MQTT
+3. Scanner stores deductions and writes to the NFC tag on next scan
+
+Macro detection: websocket push (primary) or HTTP polling (fallback),
+same pattern as ASSIGN_SPOOL in toolchanger_status.py.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import threading
+
+import requests
+
+import app_state
+from config import has_afc_scanners
+
+logger = logging.getLogger(__name__)
+
+POLL_INTERVAL: float = 2.0
+RETRY_BASE: float = 2.0
+RETRY_MAX: float = 30.0
+
+MACRO_NAME = "UPDATE_TAG"
+VARIABLE_NAME = "pending"
+
+
+def _fetch_last_job_weights() -> list[float] | None:
+    """
+    Fetch filament_weights from the last completed print job.
+
+    Returns a list of per-tool weights in grams (slicer estimate),
+    or None if no completed job found or on error.
+    """
+    moonraker = app_state.cfg.get("moonraker_url", "")
+    if not moonraker:
+        return None
+
+    try:
+        response = requests.get(
+            f"{moonraker}/server/history/list",
+            params={"limit": 1, "order": "desc"},
+            timeout=10,
+        )
+        response.raise_for_status()
+        result = response.json().get("result", {})
+        jobs = result.get("jobs", [])
+        if not jobs:
+            return None
+
+        job = jobs[0]
+        if job.get("status") != "completed":
+            logger.debug("UPDATE_TAG: last job status is '%s', not completed", job.get("status"))
+            return None
+
+        weights = job.get("metadata", {}).get("filament_weights", [])
+        if not isinstance(weights, list):
+            return None
+        return weights
+
+    except requests.ConnectionError:
+        logger.debug("UPDATE_TAG: Moonraker not reachable")
+        return None
+    except Exception:
+        logger.exception("UPDATE_TAG: failed to fetch last job")
+        return None
+
+
+def _fetch_afc_lane_weights() -> dict[str, float] | None:
+    """
+    Fetch current per-lane weight from AFC status.
+
+    Returns dict like {"lane1": 550.0, "lane2": 720.0}, or None on error.
+    """
+    moonraker = app_state.cfg.get("moonraker_url", "")
+    if not moonraker:
+        return None
+
+    try:
+        response = requests.get(
+            f"{moonraker}/printer/afc/status",
+            timeout=5,
+        )
+        response.raise_for_status()
+        result = response.json()
+
+        # Unwrap Moonraker envelope
+        if isinstance(result, dict) and "result" in result:
+            result = result["result"]
+
+        # Navigate AFC status structure: status: -> AFC -> unit -> lane
+        status_block = result.get("status:") or result.get("status")
+        if not isinstance(status_block, dict):
+            return None
+        afc_data = status_block.get("AFC")
+        if not isinstance(afc_data, dict):
+            return None
+
+        skip_keys = {"system", "Tools"}
+        weights: dict[str, float] = {}
+
+        for unit_name, unit_data in afc_data.items():
+            if unit_name in skip_keys or not isinstance(unit_data, dict):
+                continue
+            for lane_name, lane_data in unit_data.items():
+                if lane_name == "system" or not isinstance(lane_data, dict):
+                    continue
+                weight = lane_data.get("weight")
+                if isinstance(weight, (int, float)):
+                    weights[lane_name] = float(weight)
+
+        return weights if weights else None
+
+    except requests.ConnectionError:
+        logger.debug("UPDATE_TAG: Moonraker not reachable for AFC status")
+        return None
+    except Exception:
+        logger.exception("UPDATE_TAG: failed to fetch AFC lane weights")
+        return None
+
+
+def _clear_pending() -> None:
+    """Clear the UPDATE_TAG macro variable back to 0."""
+    moonraker = app_state.cfg.get("moonraker_url", "")
+    if not moonraker:
+        return
+
+    try:
+        requests.post(
+            f"{moonraker}/printer/gcode/script",
+            json={"script": f"SET_GCODE_VARIABLE MACRO={MACRO_NAME} VARIABLE={VARIABLE_NAME} VALUE=0"},
+            timeout=5,
+        ).raise_for_status()
+        logger.debug("UPDATE_TAG: cleared pending variable")
+    except Exception:
+        logger.exception("UPDATE_TAG: failed to clear pending variable")
+
+
+def _publish_deduction(device_id: str, uid: str, deduct_g: float) -> None:
+    """Publish a deduction command to the scanner via MQTT."""
+    if not app_state.mqtt_client:
+        return
+
+    prefix = app_state.cfg.get("scanner_topic_prefix", "spoolsense")
+    topic = f"{prefix}/{device_id}/cmd/deduct/{uid}"
+    payload = json.dumps({"deduct_g": round(deduct_g, 2)})
+
+    try:
+        result = app_state.mqtt_client.publish(topic, payload, qos=1)
+        if result.rc == 0:
+            logger.info(f"UPDATE_TAG: sent deduction {deduct_g:.1f}g to {uid} via {device_id}")
+        else:
+            logger.warning(f"UPDATE_TAG: MQTT publish failed (rc={result.rc})")
+    except Exception:
+        logger.exception("UPDATE_TAG: failed to publish deduction")
+
+
+def _handle_update_tag() -> None:
+    """
+    Main handler — triggered when UPDATE_TAG macro fires.
+
+    For AFC: reads current lane weights, compares to initial scan weight,
+    sends difference as deduction.
+
+    For toolchanger/single: reads last completed job's per-tool filament_weights,
+    sends each as a deduction to the active spool on that tool.
+    """
+    if has_afc_scanners(app_state.cfg):
+        _handle_afc()
+    else:
+        _handle_toolchanger()
+
+    _clear_pending()
+
+
+def _handle_afc() -> None:
+    """Handle UPDATE_TAG for AFC setups — deduction from AFC weight tracking."""
+    lane_weights = _fetch_afc_lane_weights()
+    if not lane_weights:
+        logger.info("UPDATE_TAG: no AFC lane weights available — skipping")
+        return
+
+    # Snapshot state under lock
+    with app_state.state_lock:
+        initial_weights = dict(app_state.active_spool_weights)
+        uids = dict(app_state.active_spool_uids)
+        devices = dict(app_state.active_spool_devices)
+
+    for lane, current_weight in lane_weights.items():
+        initial = initial_weights.get(lane)
+        if initial is None:
+            continue
+
+        deduction = initial - current_weight
+        if deduction <= 0:
+            continue
+
+        uid = uids.get(lane)
+        device_id = devices.get(lane)
+        if not uid or not device_id:
+            logger.debug(f"UPDATE_TAG: no UID or device for {lane}, skipping")
+            continue
+
+        _publish_deduction(device_id, uid, deduction)
+
+        # Update initial weight so next UPDATE_TAG only deducts the delta
+        with app_state.state_lock:
+            app_state.active_spool_weights[lane] = current_weight
+
+
+def _handle_toolchanger() -> None:
+    """Handle UPDATE_TAG for toolchanger/single — deduction from last job weights."""
+    weights = _fetch_last_job_weights()
+    if not weights:
+        logger.info("UPDATE_TAG: no completed job found — skipping")
+        return
+
+    # Snapshot state under lock
+    with app_state.state_lock:
+        uids = dict(app_state.active_spool_uids)
+        devices = dict(app_state.active_spool_devices)
+
+    for index, weight in enumerate(weights):
+        if weight <= 0:
+            continue
+
+        tool_name = f"T{index}"
+        uid = uids.get(tool_name)
+        device_id = devices.get(tool_name)
+
+        if not uid or not device_id:
+            logger.debug(f"UPDATE_TAG: no active spool on {tool_name}, skipping")
+            continue
+
+        _publish_deduction(device_id, uid, weight)
+
+
+def _fetch_pending() -> int | None:
+    """Fetch the UPDATE_TAG macro pending variable. Returns 0/1, or None on error."""
+    moonraker = app_state.cfg.get("moonraker_url", "")
+    if not moonraker:
+        return None
+
+    try:
+        response = requests.get(
+            f"{moonraker}/printer/objects/query?gcode_macro%20{MACRO_NAME}",
+            timeout=5,
+        )
+        response.raise_for_status()
+        result = response.json()
+        macro_data = result.get("result", {}).get("status", {}).get(f"gcode_macro {MACRO_NAME}", {})
+        return macro_data.get(VARIABLE_NAME, 0)
+    except requests.ConnectionError:
+        logger.debug("UPDATE_TAG: Moonraker not reachable")
+        return None
+    except Exception:
+        logger.exception("UPDATE_TAG: unexpected error fetching macro state")
+        return None
+
+
+class FilamentUsageSync:
+    """
+    Monitors UPDATE_TAG macro via websocket (primary) or HTTP polling (fallback).
+    Same pattern as ToolchangerStatusSync for ASSIGN_SPOOL.
+    """
+
+    def __init__(self) -> None:
+        self._thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+        self._use_ws = False
+
+    def on_ws_update_tag(self, pending: int) -> None:
+        """Callback for MoonrakerWebsocket — processes UPDATE_TAG trigger."""
+        if not pending:
+            return
+        logger.info("UPDATE_TAG: triggered via websocket")
+        try:
+            _handle_update_tag()
+        except Exception:
+            logger.exception("UPDATE_TAG: error in handler")
+
+    def start(self, use_ws: bool = False) -> None:
+        """Start monitoring. If use_ws=True, skip polling."""
+        self._use_ws = use_ws
+
+        if use_ws:
+            logger.info("UPDATE_TAG: using websocket (no polling thread)")
+            return
+
+        # Check if macro exists
+        initial = _fetch_pending()
+        if initial is None:
+            logger.warning(
+                "UPDATE_TAG: macro not found — "
+                "add it to your printer.cfg (see docs)"
+            )
+        else:
+            logger.info("UPDATE_TAG: macro detected, polling started")
+
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._poll_loop,
+            name="update-tag-sync",
+            daemon=True,
+        )
+        self._thread.start()
+        logger.info(f"UPDATE_TAG: polling started (interval={POLL_INTERVAL}s)")
+
+    def stop(self) -> None:
+        """Signal the polling thread to stop."""
+        if self._use_ws:
+            logger.info("UPDATE_TAG: websocket mode stopped")
+            return
+        if self._thread is None:
+            return
+        self._stop_event.set()
+        self._thread.join(timeout=5)
+        if self._thread.is_alive():
+            logger.warning("UPDATE_TAG: polling thread did not stop cleanly")
+        else:
+            logger.info("UPDATE_TAG: polling stopped")
+        self._thread = None
+
+    def _poll_loop(self) -> None:
+        """Background loop that polls UPDATE_TAG macro state."""
+        consecutive_failures: int = 0
+
+        while not self._stop_event.is_set():
+            pending = _fetch_pending()
+
+            if pending is not None:
+                consecutive_failures = 0
+                if pending:
+                    logger.info("UPDATE_TAG: triggered via polling")
+                    try:
+                        _handle_update_tag()
+                    except Exception:
+                        logger.exception("UPDATE_TAG: error in handler")
+                wait = POLL_INTERVAL
+            else:
+                consecutive_failures += 1
+                wait = min(RETRY_BASE * (2 ** (consecutive_failures - 1)), RETRY_MAX)
+                if consecutive_failures == 1:
+                    logger.warning("UPDATE_TAG: poll failed, retrying with backoff")
+
+            self._stop_event.wait(timeout=wait)

--- a/middleware/klipper/spoolsense.cfg
+++ b/middleware/klipper/spoolsense.cfg
@@ -9,3 +9,12 @@
 variable_pending_tool: ""
 gcode:
   SET_GCODE_VARIABLE MACRO=ASSIGN_SPOOL VARIABLE=pending_tool VALUE="'{params.TOOL}'"
+
+# Signal the middleware to calculate filament usage and send a deduction
+# to the scanner. Add UPDATE_TAG to your PRINT_END macro for automatic
+# filament tracking. The scanner stores the deduction and writes it to
+# the NFC tag next time that spool is scanned.
+[gcode_macro UPDATE_TAG]
+variable_pending: 0
+gcode:
+  SET_GCODE_VARIABLE MACRO=UPDATE_TAG VARIABLE=pending VALUE=1

--- a/middleware/moonraker_ws.py
+++ b/middleware/moonraker_ws.py
@@ -57,6 +57,7 @@ class MoonrakerWebsocket:
         # Callbacks — set by consumers
         self.on_lane_update: Callable[[str, dict], None] | None = None
         self.on_assign_spool: Callable[[str], None] | None = None
+        self.on_update_tag: Callable[[int], None] | None = None
 
     def set_lane_names(self, names: list[str]) -> None:
         """Set AFC lane names to subscribe to (e.g. ['lane1', 'lane2'])."""
@@ -168,6 +169,7 @@ class MoonrakerWebsocket:
         for lane in self._lane_names:
             objects[f"AFC_stepper {lane}"] = None
         objects["gcode_macro ASSIGN_SPOOL"] = None
+        objects["gcode_macro UPDATE_TAG"] = None
         return objects
 
     def _dispatch_status(self, status: dict) -> None:
@@ -181,3 +183,6 @@ class MoonrakerWebsocket:
             elif key == "gcode_macro ASSIGN_SPOOL" and self.on_assign_spool:
                 pending_tool = value.get("pending_tool", "")
                 self.on_assign_spool(pending_tool)
+            elif key == "gcode_macro UPDATE_TAG" and self.on_update_tag:
+                pending = value.get("pending", 0)
+                self.on_update_tag(pending)

--- a/middleware/mqtt_handler.py
+++ b/middleware/mqtt_handler.py
@@ -132,6 +132,8 @@ def _handle_rich_tag(client: mqtt.Client, scanner_cfg: dict, payload: dict, topi
                                 app_state.active_spool_weights[target] = remaining
                                 app_state.active_spool_uids[target] = uid
                                 app_state.active_spool_devices[target] = device_id_for_tracking or ""
+                                app_state.active_spool_diameters[target] = 1.75
+                                app_state.active_spool_densities[target] = 1.24
                     if action in ("afc_lane", "toolhead"):
                         publish_lock(target, "lock")
                     if remaining is not None and remaining <= app_state.cfg["low_spool_threshold"]:
@@ -170,6 +172,8 @@ def _handle_rich_tag(client: mqtt.Client, scanner_cfg: dict, payload: dict, topi
                 app_state.active_spool_weights[target] = scan.remaining_weight_g
                 app_state.active_spool_uids[target] = scan.uid.lower()
                 app_state.active_spool_devices[target] = device_id or ""
+                app_state.active_spool_diameters[target] = scan.diameter_mm or 1.75
+                app_state.active_spool_densities[target] = scan.density or 1.24
 
         # --- Tag writeback (Phase 1: scan-time stale-tag reconciliation) ---
 

--- a/middleware/mqtt_handler.py
+++ b/middleware/mqtt_handler.py
@@ -125,6 +125,13 @@ def _handle_rich_tag(client: mqtt.Client, scanner_cfg: dict, payload: dict, topi
                 if activate_spool(spool_id, action, target):
                     if target:
                         app_state.active_spools[target] = spool_id
+                        # Record for UPDATE_TAG deduction tracking
+                        if remaining is not None:
+                            device_id_for_tracking = _extract_scanner_device_id(topic)
+                            with app_state.state_lock:
+                                app_state.active_spool_weights[target] = remaining
+                                app_state.active_spool_uids[target] = uid
+                                app_state.active_spool_devices[target] = device_id_for_tracking or ""
                     if action in ("afc_lane", "toolhead"):
                         publish_lock(target, "lock")
                     if remaining is not None and remaining <= app_state.cfg["low_spool_threshold"]:
@@ -155,8 +162,16 @@ def _handle_rich_tag(client: mqtt.Client, scanner_cfg: dict, payload: dict, topi
         # --- Activation path (always runs) ---
         _activate_from_scan(scanner_cfg, scan, spool_info=spool_info)
 
-        # --- Tag writeback (Phase 1: scan-time stale-tag reconciliation) ---
+        # --- Record initial weight for UPDATE_TAG deduction tracking ---
+        target = _get_scanner_target(scanner_cfg)
         device_id = _extract_scanner_device_id(topic)
+        if target and scan.uid and scan.remaining_weight_g is not None:
+            with app_state.state_lock:
+                app_state.active_spool_weights[target] = scan.remaining_weight_g
+                app_state.active_spool_uids[target] = scan.uid.lower()
+                app_state.active_spool_devices[target] = device_id or ""
+
+        # --- Tag writeback (Phase 1: scan-time stale-tag reconciliation) ---
 
         write_plan = build_write_plan(scan, spool_info, device_id=device_id)
         if write_plan:

--- a/middleware/spoolsense.py
+++ b/middleware/spoolsense.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
-__version__ = "1.5.9"
+__version__ = "1.6.0"
 """
 SpoolSense NFC Middleware
 =========================
@@ -42,6 +42,7 @@ from publisher_manager import PublisherManager
 from publishers.klipper import KlipperPublisher
 from toolchanger_status import ToolchangerStatusSync
 from toolhead_status import ToolheadStatusSync
+from filament_usage import FilamentUsageSync
 from var_watcher import start_klipper_watcher
 from moonraker_ws import WEBSOCKET_AVAILABLE, MoonrakerWebsocket
 
@@ -76,6 +77,8 @@ def on_shutdown(signum: int, frame: object) -> None:
         app_state.afc_status_sync.stop()
     if app_state.toolchanger_status_sync:
         app_state.toolchanger_status_sync.stop()
+    if app_state.filament_usage_sync:
+        app_state.filament_usage_sync.stop()
     if app_state.toolhead_status_sync:
         app_state.toolhead_status_sync.stop()
     if app_state.watcher:
@@ -139,6 +142,7 @@ def _log_startup() -> None:
         logger.info("Klipper sync: file watcher")
     if has_toolhead_scanners(app_state.cfg) or has_toolhead_stage_scanners(app_state.cfg):
         logger.info("Toolhead status: Moonraker spool eject polling")
+    logger.info(f"Filament usage: UPDATE_TAG macro tracking enabled")
     logger.info(f"Dispatcher: {'enabled' if app_state.DISPATCHER_AVAILABLE else 'disabled'}")
 
 
@@ -233,6 +237,12 @@ def _start_sync_services(use_ws: bool) -> None:
         if use_ws:
             app_state.moonraker_ws.on_assign_spool = app_state.toolchanger_status_sync.on_ws_assign_spool
         app_state.toolchanger_status_sync.start(use_ws=use_ws)
+
+    # UPDATE_TAG macro — calculates filament usage after each print, sends deduction to scanner
+    app_state.filament_usage_sync = FilamentUsageSync()
+    if use_ws:
+        app_state.moonraker_ws.on_update_tag = app_state.filament_usage_sync.on_ws_update_tag
+    app_state.filament_usage_sync.start(use_ws=use_ws)
 
     # Wire all websocket callbacks before starting the connection
     if use_ws:

--- a/middleware/tests/test_filament_usage.py
+++ b/middleware/tests/test_filament_usage.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+sys.modules.setdefault("paho", MagicMock())
+sys.modules.setdefault("paho.mqtt", MagicMock())
+sys.modules.setdefault("paho.mqtt.client", MagicMock())
+sys.modules.setdefault("watchdog", MagicMock())
+sys.modules.setdefault("watchdog.observers", MagicMock())
+sys.modules.setdefault("watchdog.events", MagicMock())
+
+import app_state  # noqa: E402
+from filament_usage import (  # noqa: E402
+    _fetch_last_job_weights,
+    _fetch_afc_lane_weights,
+    _handle_update_tag,
+    _handle_toolchanger,
+    _handle_afc,
+)
+
+
+def _reset_app_state():
+    app_state.cfg = {
+        "moonraker_url": "http://moonraker:7125",
+        "scanner_topic_prefix": "spoolsense",
+    }
+    app_state.state_lock = threading.Lock()
+    app_state.active_spool_weights = {}
+    app_state.active_spool_uids = {}
+    app_state.active_spool_devices = {}
+    app_state.mqtt_client = MagicMock()
+
+
+class TestFetchLastJobWeights(unittest.TestCase):
+
+    def setUp(self):
+        _reset_app_state()
+
+    @patch("requests.get")
+    def test_returns_weights_from_completed_job(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "result": {
+                "count": 1,
+                "jobs": [
+                    {
+                        "status": "completed",
+                        "metadata": {"filament_weights": [50.0, 0.0, 30.0, 0.0]},
+                    }
+                ],
+            }
+        }
+        mock_resp.raise_for_status = lambda: None
+        mock_get.return_value = mock_resp
+
+        weights = _fetch_last_job_weights()
+        self.assertEqual(weights, [50.0, 0.0, 30.0, 0.0])
+
+    @patch("requests.get")
+    def test_returns_none_for_non_completed_job(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "result": {
+                "jobs": [{"status": "cancelled", "metadata": {"filament_weights": [10.0]}}]
+            }
+        }
+        mock_resp.raise_for_status = lambda: None
+        mock_get.return_value = mock_resp
+
+        self.assertIsNone(_fetch_last_job_weights())
+
+    @patch("requests.get")
+    def test_returns_none_for_empty_jobs(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"result": {"count": 0, "jobs": []}}
+        mock_resp.raise_for_status = lambda: None
+        mock_get.return_value = mock_resp
+
+        self.assertIsNone(_fetch_last_job_weights())
+
+    def test_returns_none_when_no_moonraker_url(self):
+        app_state.cfg["moonraker_url"] = ""
+        self.assertIsNone(_fetch_last_job_weights())
+
+
+class TestFetchAfcLaneWeights(unittest.TestCase):
+
+    def setUp(self):
+        _reset_app_state()
+
+    @patch("requests.get")
+    def test_returns_lane_weights(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "result": {
+                "status:": {
+                    "AFC": {
+                        "Turtle_1": {
+                            "lane1": {"weight": 550.0, "status": "Loaded"},
+                            "lane2": {"weight": 720.0, "status": "Loaded"},
+                            "system": {"some": "data"},
+                        }
+                    }
+                }
+            }
+        }
+        mock_resp.raise_for_status = lambda: None
+        mock_get.return_value = mock_resp
+
+        weights = _fetch_afc_lane_weights()
+        self.assertEqual(weights, {"lane1": 550.0, "lane2": 720.0})
+
+    @patch("requests.get")
+    def test_skips_system_and_tools_keys(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "result": {
+                "status:": {
+                    "AFC": {
+                        "system": {"top": "level"},
+                        "Tools": {"T0": "data"},
+                        "Turtle_1": {
+                            "lane1": {"weight": 100.0},
+                        },
+                    }
+                }
+            }
+        }
+        mock_resp.raise_for_status = lambda: None
+        mock_get.return_value = mock_resp
+
+        weights = _fetch_afc_lane_weights()
+        self.assertEqual(weights, {"lane1": 100.0})
+
+
+class TestHandleToolchanger(unittest.TestCase):
+
+    def setUp(self):
+        _reset_app_state()
+
+    @patch("filament_usage._clear_pending")
+    @patch("filament_usage._fetch_last_job_weights")
+    def test_sends_deduction_for_single_tool(self, mock_fetch, mock_clear):
+        mock_fetch.return_value = [25.5]
+        app_state.active_spool_uids["T0"] = "abc123"
+        app_state.active_spool_devices["T0"] = "f3d360"
+
+        _handle_toolchanger()
+
+        app_state.mqtt_client.publish.assert_called_once()
+        call_args = app_state.mqtt_client.publish.call_args
+        self.assertEqual(call_args[0][0], "spoolsense/f3d360/cmd/deduct/abc123")
+
+    @patch("filament_usage._clear_pending")
+    @patch("filament_usage._fetch_last_job_weights")
+    def test_sends_per_tool_deductions(self, mock_fetch, mock_clear):
+        mock_fetch.return_value = [50.0, 0.0, 30.0, 0.0]
+        app_state.active_spool_uids["T0"] = "uid-aaa"
+        app_state.active_spool_devices["T0"] = "scanner1"
+        app_state.active_spool_uids["T2"] = "uid-bbb"
+        app_state.active_spool_devices["T2"] = "scanner1"
+
+        _handle_toolchanger()
+
+        self.assertEqual(app_state.mqtt_client.publish.call_count, 2)
+        topics = [c[0][0] for c in app_state.mqtt_client.publish.call_args_list]
+        self.assertIn("spoolsense/scanner1/cmd/deduct/uid-aaa", topics)
+        self.assertIn("spoolsense/scanner1/cmd/deduct/uid-bbb", topics)
+
+    @patch("filament_usage._clear_pending")
+    @patch("filament_usage._fetch_last_job_weights")
+    def test_skips_tools_with_zero_usage(self, mock_fetch, mock_clear):
+        mock_fetch.return_value = [0.0, 0.0, 0.0, 0.0]
+        app_state.active_spool_uids["T0"] = "uid-aaa"
+        app_state.active_spool_devices["T0"] = "scanner1"
+
+        _handle_toolchanger()
+
+        app_state.mqtt_client.publish.assert_not_called()
+
+    @patch("filament_usage._clear_pending")
+    @patch("filament_usage._fetch_last_job_weights")
+    def test_skips_tool_without_active_spool(self, mock_fetch, mock_clear):
+        mock_fetch.return_value = [25.0]
+        # No active spool on T0
+
+        _handle_toolchanger()
+
+        app_state.mqtt_client.publish.assert_not_called()
+
+    @patch("filament_usage._clear_pending")
+    @patch("filament_usage._fetch_last_job_weights")
+    def test_no_completed_job_does_nothing(self, mock_fetch, mock_clear):
+        mock_fetch.return_value = None
+
+        _handle_toolchanger()
+
+        app_state.mqtt_client.publish.assert_not_called()
+
+
+class TestHandleAfc(unittest.TestCase):
+
+    def setUp(self):
+        _reset_app_state()
+
+    @patch("filament_usage._clear_pending")
+    @patch("filament_usage._fetch_afc_lane_weights")
+    def test_sends_deduction_from_weight_delta(self, mock_fetch, mock_clear):
+        mock_fetch.return_value = {"lane1": 550.0, "lane2": 720.0}
+        app_state.active_spool_weights = {"lane1": 800.0, "lane2": 750.0}
+        app_state.active_spool_uids = {"lane1": "uid-aaa", "lane2": "uid-bbb"}
+        app_state.active_spool_devices = {"lane1": "scanner1", "lane2": "scanner1"}
+
+        _handle_afc()
+
+        self.assertEqual(app_state.mqtt_client.publish.call_count, 2)
+        topics = [c[0][0] for c in app_state.mqtt_client.publish.call_args_list]
+        self.assertIn("spoolsense/scanner1/cmd/deduct/uid-aaa", topics)
+        self.assertIn("spoolsense/scanner1/cmd/deduct/uid-bbb", topics)
+
+    @patch("filament_usage._clear_pending")
+    @patch("filament_usage._fetch_afc_lane_weights")
+    def test_updates_initial_weight_after_deduction(self, mock_fetch, mock_clear):
+        mock_fetch.return_value = {"lane1": 550.0}
+        app_state.active_spool_weights = {"lane1": 800.0}
+        app_state.active_spool_uids = {"lane1": "uid-aaa"}
+        app_state.active_spool_devices = {"lane1": "scanner1"}
+
+        _handle_afc()
+
+        self.assertEqual(app_state.active_spool_weights["lane1"], 550.0)
+
+    @patch("filament_usage._clear_pending")
+    @patch("filament_usage._fetch_afc_lane_weights")
+    def test_skips_lanes_with_no_usage(self, mock_fetch, mock_clear):
+        mock_fetch.return_value = {"lane1": 800.0}  # same as initial
+        app_state.active_spool_weights = {"lane1": 800.0}
+        app_state.active_spool_uids = {"lane1": "uid-aaa"}
+        app_state.active_spool_devices = {"lane1": "scanner1"}
+
+        _handle_afc()
+
+        app_state.mqtt_client.publish.assert_not_called()
+
+    @patch("filament_usage._clear_pending")
+    @patch("filament_usage._fetch_afc_lane_weights")
+    def test_skips_lanes_without_initial_weight(self, mock_fetch, mock_clear):
+        mock_fetch.return_value = {"lane1": 550.0}
+        # No initial weight recorded
+        app_state.active_spool_weights = {}
+
+        _handle_afc()
+
+        app_state.mqtt_client.publish.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/middleware/tests/test_filament_usage.py
+++ b/middleware/tests/test_filament_usage.py
@@ -19,6 +19,8 @@ import app_state  # noqa: E402
 from filament_usage import (  # noqa: E402
     _fetch_last_job_weights,
     _fetch_afc_lane_weights,
+    _fetch_tool_filament_used,
+    _mm_to_grams,
     _handle_update_tag,
     _handle_toolchanger,
     _handle_afc,
@@ -34,6 +36,8 @@ def _reset_app_state():
     app_state.active_spool_weights = {}
     app_state.active_spool_uids = {}
     app_state.active_spool_devices = {}
+    app_state.active_spool_diameters = {}
+    app_state.active_spool_densities = {}
     app_state.mqtt_client = MagicMock()
 
 
@@ -51,6 +55,7 @@ class TestFetchLastJobWeights(unittest.TestCase):
                 "jobs": [
                     {
                         "status": "completed",
+                        "filament_used": 5000.0,
                         "metadata": {"filament_weights": [50.0, 0.0, 30.0, 0.0]},
                     }
                 ],
@@ -63,11 +68,33 @@ class TestFetchLastJobWeights(unittest.TestCase):
         self.assertEqual(weights, [50.0, 0.0, 30.0, 0.0])
 
     @patch("requests.get")
-    def test_returns_none_for_non_completed_job(self, mock_get):
+    def test_returns_weights_from_cancelled_job_with_extrusion(self, mock_get):
         mock_resp = MagicMock()
         mock_resp.json.return_value = {
             "result": {
-                "jobs": [{"status": "cancelled", "metadata": {"filament_weights": [10.0]}}]
+                "jobs": [{
+                    "status": "cancelled",
+                    "filament_used": 3000.0,
+                    "metadata": {"filament_weights": [10.0]},
+                }]
+            }
+        }
+        mock_resp.raise_for_status = lambda: None
+        mock_get.return_value = mock_resp
+
+        weights = _fetch_last_job_weights()
+        self.assertEqual(weights, [10.0])
+
+    @patch("requests.get")
+    def test_returns_none_for_job_with_no_extrusion(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "result": {
+                "jobs": [{
+                    "status": "cancelled",
+                    "filament_used": 0,
+                    "metadata": {"filament_weights": [10.0]},
+                }]
             }
         }
         mock_resp.raise_for_status = lambda: None
@@ -139,15 +166,89 @@ class TestFetchAfcLaneWeights(unittest.TestCase):
         self.assertEqual(weights, {"lane1": 100.0})
 
 
-class TestHandleToolchanger(unittest.TestCase):
+class TestHandleToolchangerPrimary(unittest.TestCase):
+    """Tests for per-tool filament_used path (klipper-toolchanger mod installed)."""
+
+    def setUp(self):
+        _reset_app_state()
+
+    @patch("filament_usage._clear_pending")
+    @patch("filament_usage._fetch_tool_filament_used")
+    def test_sends_deduction_from_tool_objects(self, mock_fetch_tool, mock_clear):
+        mock_fetch_tool.return_value = {"T0": 5000.0}  # 5000mm
+        app_state.active_spool_uids["T0"] = "abc123"
+        app_state.active_spool_devices["T0"] = "f3d360"
+        app_state.active_spool_diameters["T0"] = 1.75
+        app_state.active_spool_densities["T0"] = 1.24
+
+        _handle_toolchanger()
+
+        app_state.mqtt_client.publish.assert_called_once()
+        call_args = app_state.mqtt_client.publish.call_args
+        self.assertEqual(call_args[0][0], "spoolsense/f3d360/cmd/deduct/abc123")
+
+    @patch("filament_usage._clear_pending")
+    @patch("filament_usage._fetch_tool_filament_used")
+    def test_sends_per_tool_deductions_from_tool_objects(self, mock_fetch_tool, mock_clear):
+        mock_fetch_tool.return_value = {"T0": 3000.0, "T2": 2000.0}
+        app_state.active_spool_uids["T0"] = "uid-aaa"
+        app_state.active_spool_devices["T0"] = "scanner1"
+        app_state.active_spool_diameters["T0"] = 1.75
+        app_state.active_spool_densities["T0"] = 1.24
+        app_state.active_spool_uids["T2"] = "uid-bbb"
+        app_state.active_spool_devices["T2"] = "scanner1"
+        app_state.active_spool_diameters["T2"] = 1.75
+        app_state.active_spool_densities["T2"] = 1.24
+
+        _handle_toolchanger()
+
+        self.assertEqual(app_state.mqtt_client.publish.call_count, 2)
+        topics = [c[0][0] for c in app_state.mqtt_client.publish.call_args_list]
+        self.assertIn("spoolsense/scanner1/cmd/deduct/uid-aaa", topics)
+        self.assertIn("spoolsense/scanner1/cmd/deduct/uid-bbb", topics)
+
+    @patch("filament_usage._clear_pending")
+    @patch("filament_usage._fetch_tool_filament_used")
+    def test_uses_tag_diameter_and_density(self, mock_fetch_tool, mock_clear):
+        mock_fetch_tool.return_value = {"T0": 1000.0}  # 1000mm
+        app_state.active_spool_uids["T0"] = "abc123"
+        app_state.active_spool_devices["T0"] = "f3d360"
+        app_state.active_spool_diameters["T0"] = 2.85
+        app_state.active_spool_densities["T0"] = 1.27
+
+        _handle_toolchanger()
+
+        app_state.mqtt_client.publish.assert_called_once()
+        # Verify the conversion used the correct values
+        import json
+        payload = json.loads(app_state.mqtt_client.publish.call_args[0][1])
+        expected_g = _mm_to_grams(1000.0, 2.85, 1.27)
+        self.assertAlmostEqual(payload["deduct_g"], round(expected_g, 2), places=2)
+
+    @patch("filament_usage._clear_pending")
+    @patch("filament_usage._fetch_tool_filament_used")
+    def test_skips_tools_with_zero_usage(self, mock_fetch_tool, mock_clear):
+        mock_fetch_tool.return_value = {"T0": 0.0, "T1": 0.0}
+        app_state.active_spool_uids["T0"] = "uid-aaa"
+        app_state.active_spool_devices["T0"] = "scanner1"
+
+        _handle_toolchanger()
+
+        app_state.mqtt_client.publish.assert_not_called()
+
+
+class TestHandleToolchangerFallback(unittest.TestCase):
+    """Tests for filament_weights fallback path (mod not installed)."""
 
     def setUp(self):
         _reset_app_state()
 
     @patch("filament_usage._clear_pending")
     @patch("filament_usage._fetch_last_job_weights")
-    def test_sends_deduction_for_single_tool(self, mock_fetch, mock_clear):
-        mock_fetch.return_value = [25.5]
+    @patch("filament_usage._fetch_tool_filament_used")
+    def test_falls_back_to_slicer_weights(self, mock_fetch_tool, mock_fetch_job, mock_clear):
+        mock_fetch_tool.return_value = None  # mod not installed
+        mock_fetch_job.return_value = [25.5]
         app_state.active_spool_uids["T0"] = "abc123"
         app_state.active_spool_devices["T0"] = "f3d360"
 
@@ -159,8 +260,10 @@ class TestHandleToolchanger(unittest.TestCase):
 
     @patch("filament_usage._clear_pending")
     @patch("filament_usage._fetch_last_job_weights")
-    def test_sends_per_tool_deductions(self, mock_fetch, mock_clear):
-        mock_fetch.return_value = [50.0, 0.0, 30.0, 0.0]
+    @patch("filament_usage._fetch_tool_filament_used")
+    def test_fallback_per_tool_deductions(self, mock_fetch_tool, mock_fetch_job, mock_clear):
+        mock_fetch_tool.return_value = None
+        mock_fetch_job.return_value = [50.0, 0.0, 30.0, 0.0]
         app_state.active_spool_uids["T0"] = "uid-aaa"
         app_state.active_spool_devices["T0"] = "scanner1"
         app_state.active_spool_uids["T2"] = "uid-bbb"
@@ -169,16 +272,13 @@ class TestHandleToolchanger(unittest.TestCase):
         _handle_toolchanger()
 
         self.assertEqual(app_state.mqtt_client.publish.call_count, 2)
-        topics = [c[0][0] for c in app_state.mqtt_client.publish.call_args_list]
-        self.assertIn("spoolsense/scanner1/cmd/deduct/uid-aaa", topics)
-        self.assertIn("spoolsense/scanner1/cmd/deduct/uid-bbb", topics)
 
     @patch("filament_usage._clear_pending")
     @patch("filament_usage._fetch_last_job_weights")
-    def test_skips_tools_with_zero_usage(self, mock_fetch, mock_clear):
-        mock_fetch.return_value = [0.0, 0.0, 0.0, 0.0]
-        app_state.active_spool_uids["T0"] = "uid-aaa"
-        app_state.active_spool_devices["T0"] = "scanner1"
+    @patch("filament_usage._fetch_tool_filament_used")
+    def test_fallback_no_job_does_nothing(self, mock_fetch_tool, mock_fetch_job, mock_clear):
+        mock_fetch_tool.return_value = None
+        mock_fetch_job.return_value = None
 
         _handle_toolchanger()
 
@@ -186,22 +286,28 @@ class TestHandleToolchanger(unittest.TestCase):
 
     @patch("filament_usage._clear_pending")
     @patch("filament_usage._fetch_last_job_weights")
-    def test_skips_tool_without_active_spool(self, mock_fetch, mock_clear):
-        mock_fetch.return_value = [25.0]
+    @patch("filament_usage._fetch_tool_filament_used")
+    def test_fallback_skips_tool_without_active_spool(self, mock_fetch_tool, mock_fetch_job, mock_clear):
+        mock_fetch_tool.return_value = None
+        mock_fetch_job.return_value = [25.0]
         # No active spool on T0
 
         _handle_toolchanger()
 
         app_state.mqtt_client.publish.assert_not_called()
 
-    @patch("filament_usage._clear_pending")
-    @patch("filament_usage._fetch_last_job_weights")
-    def test_no_completed_job_does_nothing(self, mock_fetch, mock_clear):
-        mock_fetch.return_value = None
 
-        _handle_toolchanger()
+class TestMmToGrams(unittest.TestCase):
 
-        app_state.mqtt_client.publish.assert_not_called()
+    def test_pla_1_75mm(self):
+        # 1000mm of 1.75mm PLA at 1.24 g/cm³
+        result = _mm_to_grams(1000.0, 1.75, 1.24)
+        self.assertAlmostEqual(result, 2.98, places=1)
+
+    def test_petg_2_85mm(self):
+        # 1000mm of 2.85mm PETG at 1.27 g/cm³
+        result = _mm_to_grams(1000.0, 2.85, 1.27)
+        self.assertAlmostEqual(result, 8.10, places=1)
 
 
 class TestHandleAfc(unittest.TestCase):


### PR DESCRIPTION
## Summary

Add `UPDATE_TAG` Klipper macro for automatic filament usage tracking. After each print, the middleware calculates per-tool usage and sends deductions to the scanner via MQTT. The scanner stores deductions persistently and writes updated weight to OpenPrintTag/OpenTag3D tags on next scan.

## Three paths by setup

- **Toolchanger/single (primary):** Read per-tool `filament_used` from klipper-toolchanger tool objects, convert mm to grams using tag's diameter + density
- **Toolchanger/single (fallback):** If per-tool tracking mod not installed, use slicer `filament_weights` from Moonraker print history
- **AFC:** Read current per-lane weight from `/printer/afc/status`, compare to initial tag weight, send difference as deduction
- **UID-only/TigerTag/OpenSpool:** No-op — Moonraker handles Spoolman sync

## Changes

- **filament_usage.py** (new) — UPDATE_TAG handler, Moonraker history query, AFC weight query, per-tool deduction logic, FilamentUsageSync class (websocket + polling)
- **app_state.py** — tracking fields for initial weight, UID, device, diameter, density per tool/lane
- **mqtt_handler.py** — record initial tag weight/UID/device on scan
- **moonraker_ws.py** — subscribe to `gcode_macro UPDATE_TAG`
- **spoolsense.py** — wire FilamentUsageSync into startup/shutdown
- **klipper/spoolsense.cfg** — UPDATE_TAG macro definition
- **tests/test_filament_usage.py** — primary path, fallback path, AFC path, mm-to-grams conversion

## Test plan

- [ ] Single toolhead: scan tag, print, verify deduction sent to scanner
- [ ] Multi-tool: scan tags on T0/T2, print multi-tool job, verify per-tool deductions
- [ ] AFC: scan tags, print with lane swaps, verify deductions from AFC weight delta
- [ ] UID-only tag: verify UPDATE_TAG is a no-op
- [ ] Cancelled print: verify filament_used > 0 check works
- [ ] Websocket mode: verify UPDATE_TAG detected via websocket push
- [ ] Polling fallback: verify polling detects pending=1

Closes #51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic filament usage deduction: system now automatically deducts filament usage after prints by reading usage data from completed jobs or weight sensors, then writes deductions to NFC tags on next scan. Compatible with OpenPrintTag and OpenTag3D tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->