### PR TITLE
Gate UPDATE_TAG deductions by tag_format

### DIFF
--- a/middleware/app_state.py
+++ b/middleware/app_state.py
@@ -87,3 +87,4 @@ active_spool_uids: dict[str, str] = {}
 active_spool_devices: dict[str, str] = {}
 active_spool_diameters: dict[str, float] = {}   # mm, default 1.75
 active_spool_densities: dict[str, float] = {}   # g/cm³, default 1.24
+active_spool_formats: dict[str, str] = {}       # tag format — "openprinttag", "tigertag", etc.

--- a/middleware/filament_usage.py
+++ b/middleware/filament_usage.py
@@ -117,6 +117,16 @@ def _clear_pending() -> None:
         logger.exception("UPDATE_TAG: failed to clear pending variable")
 
 
+# Only these tag formats support writing weight back to the tag
+_WRITABLE_FORMATS = {"openprinttag", "opentag3d"}
+
+
+def _is_writable_tag(target: str) -> bool:
+    """Check if the tag on this target supports weight writes."""
+    fmt = app_state.active_spool_formats.get(target, "unknown")
+    return fmt in _WRITABLE_FORMATS
+
+
 def _publish_deduction(device_id: str, uid: str, deduct_g: float) -> None:
     """Publish a deduction command to the scanner via MQTT."""
     if not app_state.mqtt_client:
@@ -180,6 +190,10 @@ def _handle_afc() -> None:
         device_id = devices.get(lane)
         if not uid or not device_id:
             logger.debug(f"UPDATE_TAG: no UID or device for {lane}, skipping")
+            continue
+
+        if not _is_writable_tag(lane):
+            logger.debug(f"UPDATE_TAG: {lane} tag format is not writable, skipping deduction")
             continue
 
         _publish_deduction(device_id, uid, deduction)
@@ -275,6 +289,11 @@ def _handle_toolchanger() -> None:
                 logger.debug(f"UPDATE_TAG: no active spool on {tool_name}, skipping")
                 continue
 
+            # Only send deductions for tags that can store weight updates
+            if not _is_writable_tag(tool_name):
+                logger.debug(f"UPDATE_TAG: {tool_name} tag format is not writable, skipping deduction")
+                continue
+
             diameter = diameters.get(tool_name, 1.75)
             density = densities.get(tool_name, 1.24)
             usage_g = _mm_to_grams(usage_mm, diameter, density)
@@ -302,6 +321,10 @@ def _handle_toolchanger() -> None:
 
         if not uid or not device_id:
             logger.debug(f"UPDATE_TAG: no active spool on {tool_name}, skipping")
+            continue
+
+        if not _is_writable_tag(tool_name):
+            logger.debug(f"UPDATE_TAG: {tool_name} tag format is not writable, skipping deduction")
             continue
 
         _publish_deduction(device_id, uid, weight)

--- a/middleware/mqtt_handler.py
+++ b/middleware/mqtt_handler.py
@@ -69,8 +69,9 @@ def _record_spool_tracking(
     remaining: float | None,
     diameter_mm: float | None = None,
     density: float | None = None,
+    tag_format: str | None = None,
 ) -> None:
-    """Store initial weight, UID, device, and filament properties for UPDATE_TAG deduction tracking."""
+    """Store initial weight, UID, device, filament properties, and tag format for UPDATE_TAG deduction tracking."""
     if not target or not uid or remaining is None:
         return
     with app_state.state_lock:
@@ -79,6 +80,7 @@ def _record_spool_tracking(
         app_state.active_spool_devices[target]    = device_id or ""
         app_state.active_spool_diameters[target]  = diameter_mm or 1.75
         app_state.active_spool_densities[target]  = density or 1.24
+        app_state.active_spool_formats[target]    = tag_format or "unknown"
 
 
 # ── UID-only tag handling ────────────────────────────────────────────────────
@@ -130,7 +132,8 @@ def _handle_uid_only_tag(client: mqtt.Client, scanner_cfg: dict, uid: str, topic
 
     if target:
         app_state.active_spools[target] = spool_id
-        _record_spool_tracking(target, uid, device_id or "", remaining)
+        _record_spool_tracking(target, uid, device_id or "", remaining,
+                               tag_format="uid_only")
 
     if action in ("afc_lane", "toolhead"):
         publish_lock(target, "lock")
@@ -207,9 +210,12 @@ def _handle_rich_tag(client: mqtt.Client, scanner_cfg: dict, payload: dict, topi
 
         # Record initial weight for UPDATE_TAG filament deduction
         device_id = _extract_scanner_device_id(topic)
+        # tag_format comes from the scanner payload — tells us if this tag supports weight writes
+        tag_format = payload.get("tag_format", "unknown")
         _record_spool_tracking(
             target, scan.uid.lower() if scan.uid else None, device_id or "",
             scan.remaining_weight_g, scan.diameter_mm, scan.density,
+            tag_format=tag_format,
         )
 
         # Write updated weight back to tag if stale


### PR DESCRIPTION
## Summary

Only send filament deductions to the scanner for tags that can actually store weight updates (OpenPrintTag, OpenTag3D). Skip TigerTag, OpenSpool, and UID-only tags — their tracking is handled by Spoolman/Moonraker.

## Changes

- `app_state.py` — add `active_spool_formats` dict to track tag format per target
- `mqtt_handler.py` — record `tag_format` from scanner payload in `_record_spool_tracking`, UID-only path hardcodes `"uid_only"`
- `filament_usage.py` — check `_is_writable_tag()` before sending deductions in toolchanger, fallback, and AFC paths

## Depends on

Scanner SpoolSense/spoolsense_scanner#122 — scanner must include `tag_format` in the MQTT payload. Already implemented and tested.

Closes #54

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection and tracking of spool tag format types
  * Weight deductions now intelligently filter based on tag format compatibility to prevent failed updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->