### PR TITLE
Fix websocket not reconnecting after Klipper restart

### DIFF
--- a/middleware/moonraker_ws.py
+++ b/middleware/moonraker_ws.py
@@ -156,6 +156,14 @@ class MoonrakerWebsocket:
             if params and isinstance(params[0], dict):
                 self._dispatch_status(params[0])
 
+        # Klipper restarted — re-subscribe to get fresh object state
+        elif method == "notify_klippy_ready":
+            logger.info("MoonrakerWebsocket: Klipper ready — re-subscribing to printer objects")
+            self._on_open(ws)
+
+        elif method == "notify_klippy_disconnected":
+            logger.warning("MoonrakerWebsocket: Klipper disconnected — waiting for reconnect")
+
     def _on_close(self, ws, close_status_code, close_msg) -> None:
         logger.info(f"MoonrakerWebsocket: connection closed ({close_status_code})")
 


### PR DESCRIPTION
## Summary

Handle Moonraker's `notify_klippy_ready` and `notify_klippy_disconnected` websocket events. When Klipper restarts, the websocket to Moonraker stays connected but printer objects (gcode macros, AFC steppers) become unavailable. Without this fix, ASSIGN_SPOOL and UPDATE_TAG events are silently missed until the middleware is manually restarted.

## Root cause

Restarting Klipper doesn't drop the Moonraker websocket — Moonraker stays up. The middleware's reconnect loop never triggers because the connection is still alive. Moonraker sends `notify_klippy_disconnected` then `notify_klippy_ready` but the middleware only handled `notify_status_update`.

## Fix

On `notify_klippy_ready`: re-subscribe to printer objects (same subscription as initial connect). This gives us fresh state and resumes real-time updates.

On `notify_klippy_disconnected`: log a warning so users know Klipper went down.

## Changes

- `moonraker_ws.py` — 8 lines added to `_on_message`

## Test plan

- [ ] Start middleware, restart Klipper, run ASSIGN_SPOOL — verify macro event is received
- [ ] Check logs for "Klipper ready — re-subscribing" after Klipper restart
- [ ] Verify initial state received after re-subscribe

Closes #53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Klipper connectivity handling to properly detect when the printer becomes ready and refreshes printer state accordingly.
  * Enhanced disconnect event detection with appropriate logging for better system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->