### PR TITLE
Make SpoolmanClient read-only — remove duplicate spool creation

### DIFF
--- a/middleware/spoolman/client.py
+++ b/middleware/spoolman/client.py
@@ -1,9 +1,10 @@
 """
-client.py — SpoolmanClient for spool sync and management.
+client.py — SpoolmanClient for spool lookup and enrichment.
 
-Handles NFC UID → spool lookup, spool creation (vendor + filament + spool),
-weight updates via PATCH, and tag data enrichment. All Spoolman REST API
-calls live here.
+Read-only interface to Spoolman. Looks up spools by NFC UID and enriches
+tag data with Spoolman's color, material, and weight info. Does NOT create
+or modify spools — the scanner handles all Spoolman writes, and Moonraker
+handles filament usage tracking via sync_rate.
 """
 import logging
 import time
@@ -15,7 +16,7 @@ from state.models import SpoolInfo
 
 logger = logging.getLogger(__name__)
 
-CACHE_TTL = 3600  # Seconds before forcing a full Spoolman re-sync
+CACHE_TTL = 3600  # seconds before forcing a full Spoolman re-sync
 
 
 class SpoolmanClient:
@@ -24,10 +25,12 @@ class SpoolmanClient:
         self.cache = {}
         self._last_refresh = 0
 
-    def _fetch_all_spools(self):
-        """Pulls all spools to find NFC UIDs stored in the 'extra' fields."""
+    def _fetch_all_spools(self) -> None:
+        """Pulls all active (non-archived) spools to build the NFC UID lookup cache."""
         try:
-            response = requests.get(f"{self.base_url}/api/v1/spool", timeout=5)
+            # Only index active spools — archived spools with the same nfc_id
+            # would overwrite the active entry and cause lookup failures (#49)
+            response = requests.get(f"{self.base_url}/api/v1/spool?archived=false", timeout=5)
             response.raise_for_status()
             self.cache = {}
             for spool in response.json():
@@ -55,17 +58,10 @@ class SpoolmanClient:
 
     def sync_spool_from_scan(self, scan, prefer_tag: bool = True) -> Optional[SpoolInfo]:
         """
-        Bridge between the new ScanEvent model and Spoolman sync.
+        Look up the scanned spool in Spoolman and enrich tag data.
 
-        Takes a ScanEvent from the dispatcher, converts it to a SpoolInfo,
-        then runs the standard sync_spool merge logic.
-
-        Args:
-            scan: A ScanEvent from the dispatcher.
-            prefer_tag: If True, tag weight wins. Spoolman color always wins if set.
-
-        Returns:
-            SpoolInfo with spoolman_id populated, or None if sync failed.
+        Returns SpoolInfo with spoolman_id and enriched fields, or None if the
+        spool isn't in Spoolman yet (scanner will create it on its side).
         """
         tag_spool = SpoolInfo(
             spool_uid=scan.uid,
@@ -86,53 +82,34 @@ class SpoolmanClient:
         )
 
         if not tag_spool.spool_uid:
-            logger.warning("ScanEvent has no UID — cannot sync with Spoolman")
+            logger.warning("ScanEvent has no UID — cannot look up in Spoolman")
             return None
 
-        return self.sync_spool(tag_spool, prefer_tag=prefer_tag)
-
-    def sync_spool(self, tag_spool: SpoolInfo, prefer_tag: bool = True) -> SpoolInfo:
-        """
-        The Merger: Takes a parsed SpoolInfo from a tag, checks Spoolman, and syncs them.
-
-        If the spool is not in Spoolman yet, it creates a new entry and writes the
-        NFC UID back so future scans find it.
-
-        If the spool already exists:
-          prefer_tag=True  — Tag data wins for weight/material. But Spoolman's
-                             color_hex always takes priority if set, since a human
-                             likely chose it deliberately (vs our best-guess
-                             conversion from a color name like "Galaxy Black").
-          prefer_tag=False — Spoolman data wins for everything.
-
-        Always returns a SpoolInfo with spoolman_id populated.
-        """
         existing = self.find_by_nfc(tag_spool.spool_uid)
 
         if not existing:
-            logger.info(f"NFC {tag_spool.spool_uid} not in Spoolman. Creating new spool...")
-            return self._create_spool_from_tag(tag_spool)
+            # Spool not in Spoolman yet — scanner handles creation.
+            # Return None so activation runs in tag-only mode.
+            logger.info(f"NFC {tag_spool.spool_uid} not in Spoolman — running tag-only (scanner creates)")
+            return None
 
+        # Enrich tag data with Spoolman's stored values
         spoolman_id = existing["id"]
         filament = existing.get("filament", {})
         tag_spool.spoolman_id = spoolman_id
 
-        # Spoolman's color always wins if it has one set — a human chose it
-        # deliberately, and it's likely more accurate than our color name → hex guess
+        # Spoolman's color always wins if set — a human chose it deliberately
         spoolman_color = filament.get("color_hex")
         if spoolman_color:
             logger.info(f"Using Spoolman color #{spoolman_color} over tag color '{tag_spool.color_name or tag_spool.color_hex}'")
             tag_spool.color_hex = spoolman_color
 
         if prefer_tag:
-            # Tag is the source of truth for weight. Push tag weight to Spoolman.
-            logger.info(f"Updating Spoolman ID {spoolman_id} with fresh tag data...")
-            nominal_g = filament.get("weight")
-            self._update_spoolman_weight(spoolman_id, tag_spool.remaining_weight_g, nominal_g)
+            # Tag weight is source of truth — don't write to Spoolman,
+            # just use the tag value. Moonraker handles weight sync.
             tag_spool.source = "merged (tag preferred)"
         else:
-            # Spoolman is the source of truth. Pull its data into SpoolInfo.
-            logger.info(f"Using existing Spoolman data for ID {spoolman_id}.")
+            # Spoolman data wins for everything
             tag_spool.remaining_weight_g = existing.get("remaining_weight", tag_spool.remaining_weight_g)
             if spoolman_color is not None:
                 tag_spool.color_hex = spoolman_color
@@ -145,247 +122,3 @@ class SpoolmanClient:
             tag_spool.source = "merged (spoolman preferred)"
 
         return tag_spool
-
-    def _create_spool_from_tag(self, tag_spool: SpoolInfo) -> SpoolInfo:
-        """
-        Creates a vendor (if needed), filament (if needed), and spool in Spoolman
-        based on tag data, then writes the NFC UID back so future scans find it.
-
-        Deduplication strategy:
-          - Vendor: matched case-insensitively by name. Created if not found.
-          - Filament: matched by vendor_id + material + color_hex + name (all four
-            must match). Created if not found.
-          - Spool: always created fresh — a new physical spool is a new Spoolman entry.
-        """
-        # --- Vendor ---
-        vendor_name = tag_spool.brand or "Unknown"
-        vendor = self._get_vendor_by_name(vendor_name)
-        if vendor is None:
-            logger.info(f"Vendor '{vendor_name}' not found in Spoolman — creating.")
-            vendor = self._create_vendor(vendor_name)
-        vendor_id = vendor["id"]
-
-        # --- Filament ---
-        filament = self._get_filament(
-            vendor_id=vendor_id,
-            material=tag_spool.material_type or "",
-            color_hex=tag_spool.color_hex or "",
-            name=tag_spool.material_name,
-        )
-        if filament is None:
-            logger.info(f"No matching filament found for vendor {vendor_id} / "
-                        f"{tag_spool.material_type} / {tag_spool.color_hex} — creating.")
-            filament = self._create_filament(
-                vendor_id=vendor_id,
-                material=tag_spool.material_type or "",
-                color_hex=tag_spool.color_hex or "",
-                name=tag_spool.material_name,
-                diameter=tag_spool.diameter_mm,
-                density=getattr(tag_spool, "density", None),
-            )
-        filament_id = filament["id"]
-
-        # --- Spool ---
-        spool = self._create_spool(
-            filament_id=filament_id,
-            weight=tag_spool.full_weight_g,
-        )
-        tag_spool.spoolman_id = spool["id"]
-        tag_spool.source = "created"
-
-        # Write NFC UID back so the cache finds it on the next scan
-        self._write_nfc_id(tag_spool.spoolman_id, tag_spool.spool_uid)
-        logger.info(f"Created Spoolman spool {tag_spool.spoolman_id} for UID {tag_spool.spool_uid} "
-                    f"({vendor_name} {tag_spool.material_type} / filament {filament_id})")
-        return tag_spool
-
-    def _get_vendor_by_name(self, name: str) -> Optional[dict]:
-        """
-        Returns the first Spoolman vendor whose name matches case-insensitively,
-        or None if not found.
-        """
-        try:
-            response = requests.get(f"{self.base_url}/api/v1/vendor", timeout=5)
-            response.raise_for_status()
-            name_lower = name.lower()
-            for vendor in response.json():
-                if vendor.get("name", "").lower() == name_lower:
-                    return vendor
-            return None
-        except Exception as e:
-            logger.error(f"Failed to fetch vendors from Spoolman: {e}")
-            raise
-
-    def _create_vendor(self, name: str) -> dict:
-        """
-        Creates a new vendor in Spoolman and returns the created object.
-        """
-        try:
-            response = requests.post(
-                f"{self.base_url}/api/v1/vendor",
-                json={"name": name},
-                timeout=5,
-            )
-            response.raise_for_status()
-            vendor = response.json()
-            logger.info(f"Created Spoolman vendor '{name}' (id={vendor['id']})")
-            return vendor
-        except Exception as e:
-            logger.error(f"Failed to create vendor '{name}' in Spoolman: {e}")
-            raise
-
-    def _get_filament(
-        self,
-        vendor_id: int,
-        material: str,
-        color_hex: str,
-        name: Optional[str] = None,
-    ) -> Optional[dict]:
-        """
-        Returns the first Spoolman filament matching all four criteria:
-            vendor_id + material + color_hex + name
-        Returns None if no match is found.
-
-        Matching is normalized before comparison to avoid duplicates from formatting noise:
-          - vendor_id: exact integer match
-          - material:  strip() only — case is meaningful (PLA != pla)
-          - color_hex: strip(), lstrip("#"), lower() — 1A1A2E matches 1a1a2e
-          - name:      strip(), casefold(), empty string normalized to None
-
-        A filament with the same vendor/material/color but a different name is still a miss
-        — treat as user error and create a new entry rather than silently merging.
-        """
-        target_material = (material or "").strip()
-        target_color = (color_hex or "").strip().lstrip("#").lower()
-        target_name = (name or "").strip().casefold() or None
-
-        try:
-            response = requests.get(
-                f"{self.base_url}/api/v1/filament",
-                params={"vendor_id": vendor_id},
-                timeout=5,
-            )
-            response.raise_for_status()
-            for filament in response.json():
-                filament_material = (filament.get("material") or "").strip()
-                filament_color = (filament.get("color_hex") or "").strip().lstrip("#").lower()
-                filament_name = (filament.get("name") or "").strip().casefold() or None
-                if (
-                    filament.get("vendor", {}).get("id") == vendor_id
-                    and filament_material == target_material
-                    and filament_color == target_color
-                    and filament_name == target_name
-                ):
-                    return filament
-            return None
-        except Exception as e:
-            logger.error(f"Failed to fetch filaments from Spoolman: {e}")
-            raise
-
-    def _create_filament(
-        self,
-        vendor_id: int,
-        material: str,
-        color_hex: str,
-        name: Optional[str] = None,
-        diameter: Optional[float] = None,
-        density: Optional[float] = None,
-    ) -> dict:
-        """
-        Creates a new filament in Spoolman and returns the created object.
-        Only includes optional fields (name, diameter, density) when provided.
-        """
-        normalized_material = (material or "").strip()
-        normalized_color_hex = (color_hex or "").strip().lstrip("#").lower()
-        normalized_name = (name or "").strip() or None
-
-        payload: dict = {
-            "vendor_id": vendor_id,
-            "material": normalized_material,
-            "color_hex": normalized_color_hex,
-        }
-        if normalized_name is not None:
-            payload["name"] = normalized_name
-        if diameter is not None:
-            payload["diameter"] = diameter
-        if density is not None:
-            payload["density"] = density
-
-        try:
-            response = requests.post(
-                f"{self.base_url}/api/v1/filament",
-                json=payload,
-                timeout=5,
-            )
-            response.raise_for_status()
-            filament = response.json()
-            logger.info(f"Created Spoolman filament '{name or material}' (id={filament['id']}, "
-                        f"vendor={vendor_id}, color={color_hex})")
-            return filament
-        except Exception as e:
-            logger.error(f"Failed to create filament in Spoolman: {e}")
-            raise
-
-    def _create_spool(self, filament_id: int, weight: Optional[float] = None) -> dict:
-        """
-        Creates a new spool in Spoolman linked to the given filament_id.
-        weight is the nominal full weight in grams — stored as Spoolman's
-        initial_weight. Omitted if not provided.
-        """
-        payload: dict = {"filament_id": filament_id}
-        if weight is not None:
-            payload["initial_weight"] = weight
-
-        try:
-            response = requests.post(
-                f"{self.base_url}/api/v1/spool",
-                json=payload,
-                timeout=5,
-            )
-            response.raise_for_status()
-            spool = response.json()
-            logger.info(f"Created Spoolman spool (id={spool['id']}, filament={filament_id})")
-            return spool
-        except Exception as e:
-            logger.error(f"Failed to create spool in Spoolman: {e}")
-            raise
-
-    def _update_spoolman_weight(self, spoolman_id: int, remaining_g: Optional[float], nominal_g: Optional[float]):
-        """
-        Updates the consumed weight in Spoolman.
-
-        Spoolman stores 'used_weight', not 'remaining_weight', so we calculate:
-            used_weight = nominal_g (filament["weight"]) - remaining_g
-        Both values are required — if either is missing we skip the update.
-        """
-        if remaining_g is None or nominal_g is None:
-            logger.debug(f"Skipping weight update for spool {spoolman_id}: missing remaining or nominal weight.")
-            return
-        used_weight = max(0.0, nominal_g - remaining_g)
-        try:
-            requests.patch(
-                f"{self.base_url}/api/v1/spool/{spoolman_id}",
-                json={"used_weight": used_weight},
-                timeout=5
-            ).raise_for_status()
-            logger.info(f"Spoolman spool {spoolman_id}: used_weight set to {used_weight:.1f}g")
-        except Exception as e:
-            logger.warning(f"Failed to update weight for spool {spoolman_id}: {e}")
-
-    def _write_nfc_id(self, spoolman_id: int, nfc_uid: str):
-        """
-        Writes the NFC UID into Spoolman's extra fields so the spool can be found
-        by NFC lookup on future scans.
-        """
-        try:
-            requests.patch(
-                f"{self.base_url}/api/v1/spool/{spoolman_id}",
-                json={"extra": {"nfc_id": nfc_uid.lower()}},
-                timeout=5
-            ).raise_for_status()
-            logger.info(f"Wrote NFC UID {nfc_uid} to Spoolman spool {spoolman_id}.")
-            # Update the local cache so we don't need a full refresh
-            self.cache[nfc_uid.lower()] = {"id": spoolman_id}
-        except Exception as e:
-            logger.error(f"Failed to write NFC UID to Spoolman spool {spoolman_id}: {e}")
-            raise

--- a/middleware/spoolman_cache.py
+++ b/middleware/spoolman_cache.py
@@ -41,8 +41,10 @@ def refresh_spool_cache() -> bool:
         return False
     try:
         logger.info("Refreshing Spoolman cache...")
+        # Only index active spools — archived spools with the same nfc_id
+        # would overwrite the active entry and cause lookup failures (#49)
         response = requests.get(
-            f"{app_state.cfg['spoolman_url']}/api/v1/spool", timeout=5
+            f"{app_state.cfg['spoolman_url']}/api/v1/spool?archived=false", timeout=5
         )
         response.raise_for_status()
         spools = response.json()

--- a/middleware/tests/test_spoolman_client.py
+++ b/middleware/tests/test_spoolman_client.py
@@ -1,19 +1,11 @@
-"""
-Tests for spoolman/client.py — SpoolmanClient spool sync, lookup, and write logic.
-
-Covers the public sync surface (sync_spool_from_scan, sync_spool), the internal
-filament deduplication logic (_get_filament), weight calculation
-(_update_spoolman_weight), and NFC writeback (_write_nfc_id).
-
-HTTP calls are patched at the requests level. No real Spoolman server is needed.
-"""
+"""Tests for spoolman/client.py — SpoolmanClient spool lookup and enrichment (read-only)."""
 from __future__ import annotations
 
 import os
 import sys
 import threading
 import unittest
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
@@ -26,55 +18,169 @@ sys.modules.setdefault("watchdog.events", MagicMock())
 
 import app_state  # noqa: E402
 from spoolman.client import SpoolmanClient  # noqa: E402
-from state.models import ScanEvent, SpoolInfo  # noqa: E402
-
+from state.models import ScanEvent  # noqa: E402
 
 BASE_URL = "http://spoolman:7912"
 
 
-def _reset_app_state() -> None:
-    app_state.cfg = {"moonraker_url": "http://moonraker:7125"}
-    app_state.lane_locks = {}
-    app_state.active_spools = {}
+def _reset_app_state():
+    app_state.cfg = {"spoolman_url": BASE_URL}
     app_state.state_lock = threading.Lock()
 
 
+def _ok_response(data):
+    mock = MagicMock()
+    mock.json.return_value = data
+    mock.raise_for_status = lambda: None
+    mock.status_code = 200
+    return mock
+
+
 def _make_scan_event(**kwargs) -> ScanEvent:
-    """Minimal ScanEvent that represents a scanned PLA spool."""
-    defaults = dict(
-        source="spoolsense_scanner",
-        target_id="lane1",
-        scanned_at="2026-01-01T00:00:00Z",
-        uid="aabbccdd",
-        brand_name="PolyMaker",
-        material_type="PLA",
-        material_name="PolyLite PLA",
-        color_name="Red",
-        color_hex="FF0000",
-        diameter_mm=1.75,
-        full_weight_g=1000.0,
-        remaining_weight_g=750.0,
-    )
+    defaults = {
+        "source": "spoolsense_scanner",
+        "target_id": "T0",
+        "scanned_at": "2026-04-09T00:00:00Z",
+        "uid": "aabbccdd",
+        "present": True,
+        "tag_data_valid": True,
+        "brand_name": "PolyMaker",
+        "material_type": "PLA",
+        "material_name": "PolyLite PLA",
+        "color_hex": "FF0000",
+        "full_weight_g": 1000.0,
+        "remaining_weight_g": 800.0,
+    }
     defaults.update(kwargs)
     return ScanEvent(**defaults)
 
 
-def _ok_response(data: object) -> MagicMock:
-    """Build a mock requests.Response that succeeds and returns data."""
-    resp = MagicMock()
-    resp.json.return_value = data
-    resp.raise_for_status = lambda: None
-    return resp
+# ── Cache and lookup ─────────────────────────────────────────────────────────
 
+class TestFetchAllSpools(unittest.TestCase):
 
-class TestSyncSpoolFromScan(unittest.TestCase):
-    """Tests for sync_spool_from_scan — the ScanEvent → SpoolInfo bridge."""
-
-    def setUp(self) -> None:
+    def setUp(self):
         _reset_app_state()
 
-    def test_returns_none_when_uid_missing(self) -> None:
-        # A scan with no UID cannot be linked to a Spoolman entry
+    @patch("requests.get")
+    def test_indexes_spools_by_nfc_id(self, mock_get):
+        spools = [
+            {"id": 1, "extra": {"nfc_id": '"AABBCCDD"'}},
+            {"id": 2, "extra": {"nfc_id": '"11223344"'}},
+        ]
+        mock_get.return_value = _ok_response(spools)
+        client = SpoolmanClient(BASE_URL)
+
+        client._fetch_all_spools()
+
+        self.assertEqual(len(client.cache), 2)
+        self.assertEqual(client.cache["aabbccdd"]["id"], 1)
+
+    @patch("requests.get")
+    def test_filters_archived_spools(self, mock_get):
+        # The URL should include ?archived=false to exclude archived spools (#49)
+        mock_get.return_value = _ok_response([])
+        client = SpoolmanClient(BASE_URL)
+
+        client._fetch_all_spools()
+
+        call_url = mock_get.call_args[0][0]
+        self.assertIn("archived=false", call_url)
+
+    @patch("requests.get")
+    def test_skips_spools_without_nfc_id(self, mock_get):
+        spools = [{"id": 5, "extra": {}}, {"id": 6, "extra": {"nfc_id": '""'}}]
+        mock_get.return_value = _ok_response(spools)
+        client = SpoolmanClient(BASE_URL)
+
+        client._fetch_all_spools()
+
+        self.assertEqual(len(client.cache), 0)
+
+
+class TestFindByNfc(unittest.TestCase):
+
+    def setUp(self):
+        _reset_app_state()
+
+    @patch("requests.get")
+    def test_returns_cached_spool(self, mock_get):
+        spool = {"id": 10, "extra": {"nfc_id": '"aabbccdd"'}}
+        mock_get.return_value = _ok_response([spool])
+        client = SpoolmanClient(BASE_URL)
+
+        result = client.find_by_nfc("AABBCCDD")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["id"], 10)
+
+    @patch("requests.get")
+    def test_returns_none_for_unknown_uid(self, mock_get):
+        mock_get.return_value = _ok_response([])
+        client = SpoolmanClient(BASE_URL)
+
+        result = client.find_by_nfc("deadbeef")
+
+        self.assertIsNone(result)
+
+    @patch("requests.get")
+    def test_forces_refresh_on_cache_miss(self, mock_get):
+        # First call returns empty, second returns the spool (scanner just created it)
+        mock_get.side_effect = [
+            _ok_response([]),
+            _ok_response([{"id": 99, "extra": {"nfc_id": '"aabbccdd"'}}]),
+        ]
+        client = SpoolmanClient(BASE_URL)
+
+        result = client.find_by_nfc("aabbccdd")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["id"], 99)
+        self.assertEqual(mock_get.call_count, 2)
+
+
+# ── Sync from scan ──────────────────────────────────────────────────────────
+
+class TestSyncSpoolFromScan(unittest.TestCase):
+
+    def setUp(self):
+        _reset_app_state()
+
+    @patch("requests.get")
+    def test_returns_enriched_spool_info_when_found(self, mock_get):
+        existing = {
+            "id": 3,
+            "filament": {
+                "color_hex": "0000FF",
+                "material": "PLA",
+                "name": "PolyLite PLA",
+                "weight": 1000.0,
+            },
+            "extra": {"nfc_id": '"aabbccdd"'},
+        }
+        mock_get.return_value = _ok_response([existing])
+        client = SpoolmanClient(BASE_URL)
+        scan = _make_scan_event(color_hex="FF0000")
+
+        result = client.sync_spool_from_scan(scan)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result.spoolman_id, 3)
+        # Spoolman color wins over tag color
+        self.assertEqual(result.color_hex, "0000FF")
+
+    @patch("requests.get")
+    def test_returns_none_when_spool_not_found(self, mock_get):
+        # Spool not in Spoolman — scanner will create it, middleware runs tag-only
+        mock_get.return_value = _ok_response([])
+        client = SpoolmanClient(BASE_URL)
+        scan = _make_scan_event()
+
+        result = client.sync_spool_from_scan(scan)
+
+        self.assertIsNone(result)
+
+    def test_returns_none_when_no_uid(self):
         client = SpoolmanClient(BASE_URL)
         scan = _make_scan_event(uid=None)
 
@@ -83,264 +189,77 @@ class TestSyncSpoolFromScan(unittest.TestCase):
         self.assertIsNone(result)
 
     @patch("requests.get")
-    def test_finds_existing_spool_by_nfc_uid(self, mock_get: MagicMock) -> None:
-        # Cache returns a hit — sync_spool must use the existing Spoolman record
-        existing_spool = {
-            "id": 7,
-            "filament": {
-                "color_hex": "FF0000",
-                "material": "PLA",
-                "name": "PolyLite PLA",
-                "weight": 1000.0,
-            },
+    def test_tag_weight_preserved_when_prefer_tag(self, mock_get):
+        existing = {
+            "id": 5,
+            "remaining_weight": 500.0,
+            "filament": {"material": "PLA", "name": "PLA"},
             "extra": {"nfc_id": '"aabbccdd"'},
         }
-        mock_get.return_value = _ok_response([existing_spool])
-
+        mock_get.return_value = _ok_response([existing])
         client = SpoolmanClient(BASE_URL)
-        scan = _make_scan_event()
+        scan = _make_scan_event(remaining_weight_g=800.0)
 
-        result = client.sync_spool_from_scan(scan)
+        result = client.sync_spool_from_scan(scan, prefer_tag=True)
 
-        self.assertIsNotNone(result)
-        self.assertEqual(result.spoolman_id, 7)
+        # Tag weight (800g) preserved — Moonraker handles Spoolman weight sync
+        self.assertEqual(result.remaining_weight_g, 800.0)
+
+    @patch("requests.get")
+    def test_spoolman_weight_used_when_not_prefer_tag(self, mock_get):
+        existing = {
+            "id": 5,
+            "remaining_weight": 500.0,
+            "filament": {"material": "PETG", "name": "PETG", "vendor": {"name": "Sunlu"}},
+            "extra": {"nfc_id": '"aabbccdd"'},
+        }
+        mock_get.return_value = _ok_response([existing])
+        client = SpoolmanClient(BASE_URL)
+        scan = _make_scan_event(remaining_weight_g=800.0)
+
+        result = client.sync_spool_from_scan(scan, prefer_tag=False)
+
+        self.assertEqual(result.remaining_weight_g, 500.0)
+        self.assertEqual(result.material_type, "PETG")
+
+
+# ── No writes ────────────────────────────────────────────────────────────────
+
+class TestNoWrites(unittest.TestCase):
+    """Verify the client never writes to Spoolman — scanner and Moonraker handle that."""
+
+    def setUp(self):
+        _reset_app_state()
 
     @patch("requests.patch")
     @patch("requests.post")
     @patch("requests.get")
-    def test_creates_new_spool_when_not_found(
-        self, mock_get: MagicMock, mock_post: MagicMock, mock_patch: MagicMock
-    ) -> None:
-        # Cache is empty — full create path: vendor → filament → spool → NFC writeback
-        mock_get.side_effect = [
-            _ok_response([]),           # _fetch_all_spools (cache miss)
-            _ok_response([]),           # _fetch_all_spools (forced refresh)
-            _ok_response([]),           # _get_vendor_by_name
-            _ok_response([]),           # _get_filament
-        ]
-        mock_post.side_effect = [
-            _ok_response({"id": 1, "name": "PolyMaker"}),   # _create_vendor
-            _ok_response({"id": 10, "name": "PolyLite PLA"}),  # _create_filament
-            _ok_response({"id": 50}),                        # _create_spool
-        ]
-        mock_patch.return_value = _ok_response({"id": 50})  # _write_nfc_id
-
+    def test_no_post_or_patch_on_existing_spool(self, mock_get, mock_post, mock_patch):
+        existing = {
+            "id": 1,
+            "filament": {"material": "PLA", "name": "PLA"},
+            "extra": {"nfc_id": '"aabbccdd"'},
+        }
+        mock_get.return_value = _ok_response([existing])
         client = SpoolmanClient(BASE_URL)
-        scan = _make_scan_event()
 
-        result = client.sync_spool_from_scan(scan)
+        client.sync_spool_from_scan(_make_scan_event())
 
-        self.assertIsNotNone(result)
-        self.assertEqual(result.spoolman_id, 50)
-        self.assertEqual(result.source, "created")
+        mock_post.assert_not_called()
+        mock_patch.assert_not_called()
 
     @patch("requests.patch")
     @patch("requests.post")
     @patch("requests.get")
-    def test_spoolman_color_overrides_tag_color(
-        self, mock_get: MagicMock, mock_post: MagicMock, mock_patch: MagicMock
-    ) -> None:
-        # When Spoolman has a color set, it wins over the tag — a human set it deliberately
-        existing_spool = {
-            "id": 3,
-            "filament": {
-                "color_hex": "0000FF",  # blue in Spoolman, not red from tag
-                "material": "PLA",
-                "name": "PolyLite PLA",
-                "weight": 1000.0,
-            },
-            "extra": {"nfc_id": '"aabbccdd"'},
-        }
-        mock_get.return_value = _ok_response([existing_spool])
-        mock_patch.return_value = _ok_response({})
-
+    def test_no_post_or_patch_on_missing_spool(self, mock_get, mock_post, mock_patch):
+        mock_get.return_value = _ok_response([])
         client = SpoolmanClient(BASE_URL)
-        scan = _make_scan_event(color_hex="FF0000")  # tag says red
 
-        result = client.sync_spool_from_scan(scan)
-
-        self.assertEqual(result.color_hex, "0000FF")  # Spoolman won
-
-
-class TestGetFilament(unittest.TestCase):
-    """Tests for _get_filament — deduplication logic for filament lookup."""
-
-    def setUp(self) -> None:
-        _reset_app_state()
-
-    @patch("requests.get")
-    def test_finds_matching_filament(self, mock_get: MagicMock) -> None:
-        filament = {
-            "id": 10,
-            "vendor": {"id": 1},
-            "material": "PLA",
-            "color_hex": "FF0000",
-            "name": "PolyLite PLA",
-        }
-        mock_get.return_value = _ok_response([filament])
-
-        client = SpoolmanClient(BASE_URL)
-        result = client._get_filament(
-            vendor_id=1, material="PLA", color_hex="FF0000", name="PolyLite PLA"
-        )
-
-        self.assertEqual(result["id"], 10)
-
-    @patch("requests.get")
-    def test_color_hex_matching_is_case_insensitive(self, mock_get: MagicMock) -> None:
-        # Tag may emit lowercase hex; Spoolman stores mixed case — must match
-        filament = {
-            "id": 11,
-            "vendor": {"id": 1},
-            "material": "PETG",
-            "color_hex": "1A1A2E",
-            "name": None,
-        }
-        mock_get.return_value = _ok_response([filament])
-
-        client = SpoolmanClient(BASE_URL)
-        result = client._get_filament(
-            vendor_id=1, material="PETG", color_hex="#1a1a2e", name=None
-        )
-
-        self.assertIsNotNone(result)
-        self.assertEqual(result["id"], 11)
-
-    @patch("requests.get")
-    def test_returns_none_when_no_match(self, mock_get: MagicMock) -> None:
-        # Different material — should not match, return None so a new filament is created
-        filament = {
-            "id": 12,
-            "vendor": {"id": 1},
-            "material": "ABS",
-            "color_hex": "FF0000",
-            "name": "ABS Pro",
-        }
-        mock_get.return_value = _ok_response([filament])
-
-        client = SpoolmanClient(BASE_URL)
-        result = client._get_filament(
-            vendor_id=1, material="PLA", color_hex="FF0000", name="ABS Pro"
-        )
+        result = client.sync_spool_from_scan(_make_scan_event())
 
         self.assertIsNone(result)
-
-    @patch("requests.get")
-    def test_returns_none_when_name_differs(self, mock_get: MagicMock) -> None:
-        # Same vendor/material/color but different name — treat as a distinct filament
-        # to avoid silently merging different product lines
-        filament = {
-            "id": 13,
-            "vendor": {"id": 2},
-            "material": "PLA",
-            "color_hex": "FFFFFF",
-            "name": "PolyLite PLA",
-        }
-        mock_get.return_value = _ok_response([filament])
-
-        client = SpoolmanClient(BASE_URL)
-        result = client._get_filament(
-            vendor_id=2, material="PLA", color_hex="FFFFFF", name="PolyMax PLA"
-        )
-
-        self.assertIsNone(result)
-
-
-class TestUpdateSpoolmanWeight(unittest.TestCase):
-    """Tests for _update_spoolman_weight — used_weight calculation."""
-
-    def setUp(self) -> None:
-        _reset_app_state()
-
-    @patch("requests.patch")
-    def test_calculates_used_weight_correctly(self, mock_patch: MagicMock) -> None:
-        # used_weight = nominal_g - remaining_g
-        mock_patch.return_value = _ok_response({})
-        client = SpoolmanClient(BASE_URL)
-
-        client._update_spoolman_weight(spoolman_id=5, remaining_g=650.0, nominal_g=1000.0)
-
-        call_kwargs = mock_patch.call_args[1]
-        self.assertEqual(call_kwargs["json"]["used_weight"], 350.0)
-
-    @patch("requests.patch")
-    def test_used_weight_clamped_to_zero(self, mock_patch: MagicMock) -> None:
-        # Tag weight can exceed nominal (scale drift, spool weight included) — clamp at 0
-        mock_patch.return_value = _ok_response({})
-        client = SpoolmanClient(BASE_URL)
-
-        client._update_spoolman_weight(spoolman_id=5, remaining_g=1200.0, nominal_g=1000.0)
-
-        call_kwargs = mock_patch.call_args[1]
-        self.assertEqual(call_kwargs["json"]["used_weight"], 0.0)
-
-    @patch("requests.patch")
-    def test_skips_update_when_remaining_is_none(self, mock_patch: MagicMock) -> None:
-        # Both weights required — if tag had no weight field, do not write garbage to Spoolman
-        client = SpoolmanClient(BASE_URL)
-
-        client._update_spoolman_weight(spoolman_id=5, remaining_g=None, nominal_g=1000.0)
-
+        mock_post.assert_not_called()
         mock_patch.assert_not_called()
-
-    @patch("requests.patch")
-    def test_skips_update_when_nominal_is_none(self, mock_patch: MagicMock) -> None:
-        client = SpoolmanClient(BASE_URL)
-
-        client._update_spoolman_weight(spoolman_id=5, remaining_g=500.0, nominal_g=None)
-
-        mock_patch.assert_not_called()
-
-
-class TestWriteNfcId(unittest.TestCase):
-    """Tests for _write_nfc_id — NFC UID writeback to Spoolman extras."""
-
-    def setUp(self) -> None:
-        _reset_app_state()
-
-    @patch("requests.patch")
-    def test_writes_nfc_uid_to_spool_extras(self, mock_patch: MagicMock) -> None:
-        mock_patch.return_value = _ok_response({})
-        client = SpoolmanClient(BASE_URL)
-
-        client._write_nfc_id(spoolman_id=99, nfc_uid="AABBCCDD")
-
-        call_kwargs = mock_patch.call_args[1]
-        self.assertEqual(call_kwargs["json"]["extra"]["nfc_id"], "aabbccdd")
-
-    @patch("requests.patch")
-    def test_nfc_uid_lowercased_before_write(self, mock_patch: MagicMock) -> None:
-        # UIDs are always stored lowercase — inconsistent casing from the scanner
-        # would cause cache misses on the next scan
-        mock_patch.return_value = _ok_response({})
-        client = SpoolmanClient(BASE_URL)
-
-        client._write_nfc_id(spoolman_id=1, nfc_uid="FF112233")
-
-        call_kwargs = mock_patch.call_args[1]
-        self.assertEqual(call_kwargs["json"]["extra"]["nfc_id"], "ff112233")
-
-    @patch("requests.patch")
-    def test_updates_local_cache_after_write(self, mock_patch: MagicMock) -> None:
-        # Cache must be updated immediately so the next scan can find the spool
-        # without waiting for a full TTL refresh
-        mock_patch.return_value = _ok_response({})
-        client = SpoolmanClient(BASE_URL)
-
-        client._write_nfc_id(spoolman_id=42, nfc_uid="deadbeef")
-
-        self.assertIn("deadbeef", client.cache)
-        self.assertEqual(client.cache["deadbeef"]["id"], 42)
-
-    @patch("requests.patch")
-    def test_raises_on_http_failure(self, mock_patch: MagicMock) -> None:
-        import requests as req
-        mock_patch.side_effect = req.HTTPError("403")
-
-        client = SpoolmanClient(BASE_URL)
-
-        with self.assertRaises(Exception):
-            client._write_nfc_id(spoolman_id=1, nfc_uid="aabbccdd")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Remove all Spoolman write methods from the middleware. The scanner handles spool creation (vendor, filament, spool, NFC UID writeback) and Moonraker handles filament usage tracking via sync_rate. The middleware only needs to read from Spoolman for enrichment.

## Problem

Both the scanner and middleware independently created spools in Spoolman, racing each other. Scanner creates the spool, then milliseconds later the middleware tries to create it too because its cache hasn't refreshed. Result: duplicate spools. (#49)

Additionally, the cache fetched all spools including archived ones. If an archived spool shared an NFC UID with an active one, the cache could return the wrong entry.

## Fix

- Remove 7 write methods from SpoolmanClient: _create_spool_from_tag, _get_vendor_by_name, _create_vendor, _get_filament, _create_filament, _create_spool, _update_spoolman_weight, _write_nfc_id
- sync_spool_from_scan returns None when spool not found (tag-only mode) instead of creating
- Add ?archived=false to cache fetch URL in both spoolman_cache.py and spoolman/client.py
- Tests rewritten to verify read-only behavior (no POST or PATCH calls)

## Changes

- `spoolman/client.py` — 532 lines removed, 186 remaining. Read-only lookup and enrichment only.
- `spoolman_cache.py` — ?archived=false added to fetch URL
- `tests/test_spoolman_client.py` — rewritten for read-only tests + explicit no-writes verification

Closes #49

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified spool synchronization from write-enabled to read-only lookup. NFC scanner no longer automatically creates or updates spools in Spoolman; creation is now handled independently on the scanner side.
  * Cache updated to fetch only non-archived spools, preventing archived entries from interfering with active spool data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->