### PR TITLE
Default toolhead to T0 when not specified

### DIFF
--- a/middleware/config.py
+++ b/middleware/config.py
@@ -144,6 +144,8 @@ def _validate_scanners(config: dict) -> None:
             _validate_targeted_scanner(device_id, scanner_cfg, action, "lane", "toolhead", toolheads_list)
 
         elif action == "toolhead":
+            # Single-toolhead users shouldn't need to specify toolhead: "T0"
+            scanner_cfg.setdefault("toolhead", "T0")
             _validate_targeted_scanner(device_id, scanner_cfg, action, "toolhead", "lane", toolheads_list)
 
         elif action in ("afc_stage", "toolhead_stage"):

--- a/middleware/config.py
+++ b/middleware/config.py
@@ -144,8 +144,6 @@ def _validate_scanners(config: dict) -> None:
             _validate_targeted_scanner(device_id, scanner_cfg, action, "lane", "toolhead", toolheads_list)
 
         elif action == "toolhead":
-            # Single-toolhead users shouldn't need to specify toolhead: "T0"
-            scanner_cfg.setdefault("toolhead", "T0")
             _validate_targeted_scanner(device_id, scanner_cfg, action, "toolhead", "lane", toolheads_list)
 
         elif action in ("afc_stage", "toolhead_stage"):
@@ -252,6 +250,11 @@ def load_config() -> dict:
 
     # Migrate legacy config if needed
     config = _migrate_legacy_config(config)
+
+    # Apply scanner defaults before derivation and validation
+    for scanner_cfg in config.get("scanners", {}).values():
+        if scanner_cfg.get("action") == "toolhead":
+            scanner_cfg.setdefault("toolhead", "T0")  # single-toolhead users don't need to specify
 
     # Derive toolheads from scanner entries if not explicitly provided
     if not config.get("toolheads"):

--- a/middleware/config.py
+++ b/middleware/config.py
@@ -253,7 +253,7 @@ def load_config() -> dict:
 
     # Apply scanner defaults before derivation and validation
     for scanner_cfg in config.get("scanners", {}).values():
-        if scanner_cfg.get("action") == "toolhead":
+        if isinstance(scanner_cfg, dict) and scanner_cfg.get("action") == "toolhead":
             scanner_cfg.setdefault("toolhead", "T0")  # single-toolhead users don't need to specify
 
     # Derive toolheads from scanner entries if not explicitly provided

--- a/middleware/tests/test_config.py
+++ b/middleware/tests/test_config.py
@@ -44,6 +44,12 @@ class TestValidateScanners(unittest.TestCase):
     def test_valid_toolhead(self):
         self._ok({"scanners": {"abc123": {"action": "toolhead", "toolhead": "T0"}}})
 
+    def test_toolhead_defaults_to_t0(self):
+        # Single-toolhead users shouldn't need to specify toolhead: "T0" (#44)
+        config = {"scanners": {"abc123": {"action": "toolhead"}}}
+        self._ok(config)
+        self.assertEqual(config["scanners"]["abc123"]["toolhead"], "T0")
+
     def test_valid_toolhead_stage(self):
         self._ok({"scanners": {"abc123": {"action": "toolhead_stage"}}})
 


### PR DESCRIPTION
## Summary

Single-toolhead users no longer need to specify `toolhead: "T0"` in their scanner config. If `action: "toolhead"` is set without a `toolhead` field, it defaults to T0.

## Before

```yaml
scanners:
  "ecb338":
    action: "toolhead"
    toolhead: "T0"    # required even for single-extruder printers
```

## After

```yaml
scanners:
  "ecb338":
    action: "toolhead"    # toolhead defaults to T0
```

Existing configs with `toolhead` set are unaffected — `setdefault` is a no-op when the key already exists.

## Changes

- `config.py` — one line: `scanner_cfg.setdefault("toolhead", "T0")` before validation
- `tests/test_config.py` — test verifying default is applied and config passes validation

Closes #44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scanner toolhead configurations now default to the primary toolhead when not explicitly specified, preventing validation failures for single-toolhead setups.
  * Single-toolhead installations are accepted automatically without manual edits; existing valid configurations continue to work unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->