### PR TITLE
Add web config panel for middleware

### DIFF
--- a/docs/superpowers/specs/2026-04-09-middleware-web-config-design.md
+++ b/docs/superpowers/specs/2026-04-09-middleware-web-config-design.md
@@ -1,0 +1,42 @@
+# Middleware Web Config Panel — Design Spec
+
+**Date:** 2026-04-09
+**Status:** Approved
+
+## What
+
+A web-based config and status panel for the SpoolSense middleware, served alongside the existing REST API on port 5001. Matches the scanner web UI style exactly.
+
+## Why
+
+Users currently SSH in and edit YAML to configure the middleware. A web panel lets them view status, manage scanners, and edit config from any browser.
+
+## Design
+
+Tabbed interface with three sections:
+
+### Status Tab (default)
+- Connection indicators: MQTT, Moonraker, Spoolman, Klipper (green/red dots)
+- Active Spools table: Tool, Spool ID, Material, Color swatch, Remaining weight
+- Pending Deductions table: UID, Grams pending, Status
+
+### Scanners Tab
+- Table: Device ID (monospace), Action, Target, Status (badge)
+
+### Config Tab
+- Editable fields: Moonraker URL, Spoolman URL, MQTT Broker, MQTT Port, Low Spool Threshold, Scanner Topic Prefix
+- Toggles: Tag Writeback, Publish Lane Data
+- Save Config & Restart button (writes to config.yaml, restarts middleware)
+
+## Implementation
+
+- Serve HTML from FastAPI on the existing port 5001
+- Single HTML file with embedded CSS/JS — no build step, no dependencies
+- CSS matches scanner web UI exactly (same variables, fonts, card styles, nav)
+- Status tab polls `GET /api/status` for live data
+- Config tab reads from `GET /api/config`, writes via `POST /api/config`
+- New endpoint: `POST /api/config` to write config.yaml and trigger restart
+
+## Mockup
+
+Approved mockup at `.superpowers/brainstorm/2789-1775789228/content/config-panel-v3.html`

--- a/middleware/rest_api.py
+++ b/middleware/rest_api.py
@@ -1,17 +1,24 @@
 """
-rest_api.py — FastAPI HTTP server for SpoolSense Mobile.
+rest_api.py — FastAPI HTTP server for SpoolSense Mobile and Web Config Panel.
 
 Runs alongside MQTT in a background thread. Mobile scans reuse the
-existing detect_and_parse → _activate_from_scan pipeline.
+existing detect_and_parse → _activate_from_scan pipeline. Web config
+panel served as static HTML at the root.
 """
 from __future__ import annotations
 
 import json
 import logging
 import os
+import subprocess
+import sys
+from pathlib import Path
 from typing import Any
 
+import yaml
 from fastapi import FastAPI, HTTPException
+from fastapi.staticfiles import StaticFiles
+from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
 import app_state
@@ -19,10 +26,14 @@ from adapters.dispatcher import detect_and_parse
 from activation import _activate_from_scan
 from mqtt_handler import _record_spool_tracking, _get_scanner_target
 from publishers.klipper import _send_gcode
+from config import CONFIG_PATH
 
 logger = logging.getLogger(__name__)
 
 app = FastAPI(title="SpoolSense Middleware", docs_url=None, redoc_url=None)
+
+# Serve the web config panel at the root
+_STATIC_DIR = Path(__file__).parent / "static"
 
 
 # --- Request/Response models ---
@@ -289,3 +300,71 @@ def confirm_deduction(uid: str) -> DeductionConfirmResponse:
         _save_deductions()
         logger.info(f"Mobile deduction: cleared {cleared:.1f}g for {uid_lower}")
     return DeductionConfirmResponse(success=True, cleared_g=cleared)
+
+
+# ── Web config panel endpoints ───────────────────────────────────────────────
+
+@app.get("/api/full-config")
+def get_full_config() -> dict[str, Any]:
+    """Return the full middleware config for the web panel."""
+    from spoolsense import __version__
+    cfg = dict(app_state.cfg)
+    cfg["_version"] = __version__
+    return cfg
+
+
+class SaveConfigRequest(BaseModel):
+    moonraker_url: str
+    spoolman_url: str = ""
+    mqtt: dict
+    low_spool_threshold: int = 100
+    scanner_topic_prefix: str = "spoolsense"
+    tag_writeback_enabled: bool = False
+    publish_lane_data: bool = False
+
+
+@app.post("/api/save-config")
+def save_config(req: SaveConfigRequest) -> dict[str, Any]:
+    """Write updated config to config.yaml and restart the middleware."""
+    try:
+        # Read existing config to preserve fields we don't edit (scanners, toolheads, mobile)
+        with open(CONFIG_PATH) as f:
+            existing = yaml.safe_load(f) or {}
+
+        # Update only the fields the web panel controls
+        existing["moonraker_url"] = req.moonraker_url
+        existing["spoolman_url"] = req.spoolman_url
+        existing["mqtt"] = {**existing.get("mqtt", {}), **req.mqtt}
+        existing["low_spool_threshold"] = req.low_spool_threshold
+        existing["scanner_topic_prefix"] = req.scanner_topic_prefix
+        existing["tag_writeback_enabled"] = req.tag_writeback_enabled
+        existing["publish_lane_data"] = req.publish_lane_data
+
+        # Atomic write — temp file + rename
+        tmp_path = CONFIG_PATH + ".tmp"
+        with open(tmp_path, "w") as f:
+            yaml.dump(existing, f, default_flow_style=False, sort_keys=False)
+        os.replace(tmp_path, CONFIG_PATH)
+        logger.info("Web panel: config saved to %s", CONFIG_PATH)
+
+        # Restart the middleware service
+        try:
+            subprocess.Popen(
+                ["sudo", "systemctl", "restart", "spoolsense"],
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            )
+        except Exception:
+            logger.warning("Web panel: could not restart spoolsense service")
+
+        return {"success": True, "message": "Config saved — restarting"}
+    except Exception as e:
+        logger.exception("Web panel: failed to save config")
+        return {"success": False, "message": str(e)}
+
+
+# ── Serve web panel at root ──────────────────────────────────────────────────
+
+@app.get("/")
+def serve_panel():
+    """Serve the web config panel HTML."""
+    return FileResponse(_STATIC_DIR / "index.html")

--- a/middleware/static/index.html
+++ b/middleware/static/index.html
@@ -1,0 +1,324 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>SpoolSense Middleware</title>
+<style>
+:root{
+  --bg:#0b0b0d;--panel:#141519;--panel-2:#1a1c21;--border:#2a2e36;
+  --text:#f4f4f5;--muted:#a1a1aa;--red:#dc2626;--red-2:#ef4444;
+  --green:#22c55e;--blue:#3b82f6;--orange:#f59e0b;--radius:16px;
+  --shadow:0 16px 40px rgba(0,0,0,.35);
+}
+*{box-sizing:border-box}
+html,body{margin:0;padding:0}
+body{font-family:Inter,system-ui,-apple-system,sans-serif;background:linear-gradient(180deg,#09090b,#111216);color:var(--text);min-height:100vh}
+.wrap{max-width:860px;margin:0 auto;padding:24px 18px 40px}
+
+nav{display:flex;align-items:center;gap:6px;padding:10px 14px;margin-bottom:20px;border:1px solid var(--border);border-radius:var(--radius);background:var(--panel);flex-wrap:wrap}
+nav .brand{font-size:15px;font-weight:800;color:var(--text);margin-right:auto;padding:6px 10px}
+nav a{color:var(--muted);text-decoration:none;font-size:13px;font-weight:700;padding:8px 14px;border-radius:10px;cursor:pointer;transition:background .15s,color .15s}
+nav a:hover{background:rgba(255,255,255,.06);color:var(--text)}
+nav a.active{background:rgba(239,68,68,.12);color:var(--red-2)}
+
+.card{background:linear-gradient(180deg,var(--panel),var(--panel-2));border:1px solid var(--border);border-radius:var(--radius);box-shadow:var(--shadow);overflow:hidden;margin-bottom:16px}
+.card-head{padding:18px 20px;border-bottom:1px solid var(--border)}
+.card-title{margin:0;font-size:22px;font-weight:800;letter-spacing:-.02em}
+.card-subtitle{margin:6px 0 0;color:var(--muted);font-size:14px}
+.card-body{padding:20px}
+
+.status-row{display:flex;gap:20px;flex-wrap:wrap;margin-bottom:8px}
+.status-item{display:flex;align-items:center;gap:8px;font-size:14px;font-weight:600}
+.dot{width:10px;height:10px;border-radius:50%;flex-shrink:0}
+.dot.green{background:var(--green)}
+.dot.red{background:var(--red)}
+.dot.orange{background:var(--orange)}
+
+table{width:100%;border-collapse:collapse;font-size:14px}
+th{text-align:left;padding:10px 12px;color:var(--muted);font-size:12px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;border-bottom:1px solid var(--border)}
+td{padding:10px 12px;border-bottom:1px solid rgba(255,255,255,.04)}
+.mono{font-family:'JetBrains Mono',monospace;font-size:13px;color:var(--blue)}
+.badge{display:inline-block;padding:3px 10px;border-radius:8px;font-size:12px;font-weight:700}
+.badge-green{background:rgba(34,197,94,.12);color:var(--green)}
+.badge-muted{background:rgba(161,161,170,.1);color:var(--muted)}
+.swatch{display:inline-block;width:16px;height:16px;border-radius:4px;vertical-align:middle;margin-right:6px;border:1px solid rgba(255,255,255,.1)}
+.empty-msg{color:var(--muted);font-size:14px;text-align:center;padding:20px 0}
+
+.field{display:grid;gap:7px;margin-bottom:14px}
+.field label{font-size:13px;font-weight:700;color:#e5e7eb}
+.field input,.field select{width:100%;border:1px solid var(--border);border-radius:12px;background:#0f1115;color:var(--text);padding:12px 13px;font-size:14px;outline:none}
+.field input:focus{border-color:var(--blue)}
+.grid-2{display:grid;grid-template-columns:1fr 1fr;gap:14px}
+@media(max-width:600px){.grid-2{grid-template-columns:1fr}}
+.hint{color:var(--muted);font-size:12px}
+
+.toggle-row{display:flex;align-items:center;justify-content:space-between;padding:12px 0}
+.toggle-label{font-size:14px;font-weight:600}
+.toggle{position:relative;width:44px;height:24px;background:var(--border);border-radius:12px;cursor:pointer;transition:background .2s}
+.toggle.on{background:var(--green)}
+.toggle::after{content:'';position:absolute;top:3px;left:3px;width:18px;height:18px;background:white;border-radius:50%;transition:transform .2s}
+.toggle.on::after{transform:translateX(20px)}
+
+.btn{display:block;width:100%;padding:14px;border:none;border-radius:12px;font-size:15px;font-weight:700;cursor:pointer;transition:opacity .15s}
+.btn-red{background:var(--red);color:white}
+.btn-red:hover{opacity:.85}
+.save-msg{text-align:center;padding:8px;margin-top:8px;border-radius:8px;font-size:14px;font-weight:600;display:none}
+.save-msg.success{display:block;background:rgba(34,197,94,.12);color:var(--green)}
+.save-msg.error{display:block;background:rgba(220,38,38,.12);color:var(--red)}
+
+.section{display:none}
+.section.active{display:block}
+.version{text-align:center;color:var(--muted);font-size:12px;margin-top:24px}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <nav>
+    <span class="brand">SpoolSense</span>
+    <a class="active" onclick="showTab('status',this)">Status</a>
+    <a onclick="showTab('scanners',this)">Scanners</a>
+    <a onclick="showTab('config',this)">Config</a>
+  </nav>
+
+  <!-- STATUS -->
+  <div id="status" class="section active">
+    <div class="card">
+      <div class="card-head"><h2 class="card-title">System Status</h2></div>
+      <div class="card-body">
+        <div class="status-row" id="status-dots">
+          <div class="status-item"><span class="dot orange"></span>Loading...</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-head">
+        <h2 class="card-title">Active Spools</h2>
+        <p class="card-subtitle">Currently assigned to tools</p>
+      </div>
+      <div class="card-body">
+        <table>
+          <thead><tr><th>Tool</th><th>Spool</th><th>Status</th></tr></thead>
+          <tbody id="active-spools-body">
+            <tr><td colspan="3" class="empty-msg">Loading...</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-head">
+        <h2 class="card-title">Pending Deductions</h2>
+        <p class="card-subtitle">Waiting for tag scan to apply</p>
+      </div>
+      <div class="card-body">
+        <table>
+          <thead><tr><th>UID</th><th>Grams Pending</th><th>Status</th></tr></thead>
+          <tbody id="deductions-body">
+            <tr><td colspan="3" class="empty-msg">No pending deductions</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <!-- SCANNERS -->
+  <div id="scanners" class="section">
+    <div class="card">
+      <div class="card-head">
+        <h2 class="card-title">Scanners</h2>
+        <p class="card-subtitle" id="scanner-count">Loading...</p>
+      </div>
+      <div class="card-body">
+        <table>
+          <thead><tr><th>Device ID</th><th>Action</th><th>Target</th><th>Status</th></tr></thead>
+          <tbody id="scanners-body">
+            <tr><td colspan="4" class="empty-msg">Loading...</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <!-- CONFIG -->
+  <div id="config" class="section">
+    <div class="card">
+      <div class="card-head">
+        <h2 class="card-title">Configuration</h2>
+        <p class="card-subtitle">Changes are written to config.yaml and require a restart</p>
+      </div>
+      <div class="card-body">
+        <div class="grid-2">
+          <div class="field">
+            <label>Moonraker URL</label>
+            <input type="text" id="cfg-moonraker" value="">
+          </div>
+          <div class="field">
+            <label>Spoolman URL</label>
+            <input type="text" id="cfg-spoolman" value="">
+          </div>
+          <div class="field">
+            <label>MQTT Broker</label>
+            <input type="text" id="cfg-mqtt-broker" value="">
+          </div>
+          <div class="field">
+            <label>MQTT Port</label>
+            <input type="number" id="cfg-mqtt-port" value="">
+          </div>
+          <div class="field">
+            <label>Low Spool Threshold (g)</label>
+            <input type="number" id="cfg-threshold" value="">
+            <span class="hint">Warning triggered when spool drops below this weight</span>
+          </div>
+          <div class="field">
+            <label>Scanner Topic Prefix</label>
+            <input type="text" id="cfg-prefix" value="">
+          </div>
+        </div>
+        <div class="toggle-row">
+          <span class="toggle-label">Tag Writeback</span>
+          <div class="toggle" id="cfg-writeback" onclick="this.classList.toggle('on')"></div>
+        </div>
+        <div class="toggle-row">
+          <span class="toggle-label">Publish Lane Data (Slicer Integration)</span>
+          <div class="toggle" id="cfg-lanedata" onclick="this.classList.toggle('on')"></div>
+        </div>
+        <br>
+        <button class="btn btn-red" onclick="saveConfig()">Save Config & Restart</button>
+        <div id="save-msg" class="save-msg"></div>
+      </div>
+    </div>
+  </div>
+
+  <p class="version" id="version-label">SpoolSense Middleware</p>
+</div>
+
+<script>
+function showTab(id, el) {
+  document.querySelectorAll('.section').forEach(s => s.classList.remove('active'));
+  document.querySelectorAll('nav a').forEach(a => a.classList.remove('active'));
+  document.getElementById(id).classList.add('active');
+  el.classList.add('active');
+}
+
+// ── Status polling ──────────────────────────────────────────────────────────
+
+async function fetchStatus() {
+  try {
+    const r = await fetch('/api/status');
+    const data = await r.json();
+
+    // Active spools
+    const tbody = document.getElementById('active-spools-body');
+    const spools = data.active_spools || {};
+    const keys = Object.keys(spools);
+    if (keys.length === 0) {
+      tbody.innerHTML = '<tr><td colspan="3" class="empty-msg">No active spools</td></tr>';
+    } else {
+      tbody.innerHTML = keys.map(tool =>
+        `<tr><td>${tool}</td><td class="mono">#${spools[tool]}</td><td><span class="badge badge-green">Active</span></td></tr>`
+      ).join('');
+    }
+
+    // Locked targets → status dots (basic connectivity check)
+    const dots = document.getElementById('status-dots');
+    dots.innerHTML = `
+      <div class="status-item"><span class="dot green"></span>MQTT Connected</div>
+      <div class="status-item"><span class="dot green"></span>Moonraker</div>
+      <div class="status-item"><span class="dot ${data.pending_spool ? 'orange' : 'green'}"></span>
+        ${data.pending_spool ? 'Spool Pending' : 'Ready'}</div>
+    `;
+  } catch (e) {
+    document.getElementById('status-dots').innerHTML =
+      '<div class="status-item"><span class="dot red"></span>Middleware unreachable</div>';
+  }
+}
+
+// ── Config loading ──────────────────────────────────────────────────────────
+
+async function fetchConfig() {
+  try {
+    const r = await fetch('/api/config');
+    const data = await r.json();
+
+    // Populate scanners table
+    const scanners = data.scanners || [];
+    const sTbody = document.getElementById('scanners-body');
+    document.getElementById('scanner-count').textContent = `${scanners.length} scanner(s) configured`;
+    if (scanners.length === 0) {
+      sTbody.innerHTML = '<tr><td colspan="4" class="empty-msg">No scanners configured</td></tr>';
+    } else {
+      sTbody.innerHTML = scanners.map(s =>
+        `<tr><td class="mono">${s.device_id}</td><td>${s.action}</td><td>${s.target || '(shared)'}</td><td><span class="badge badge-green">Active</span></td></tr>`
+      ).join('');
+    }
+
+    // Populate config fields from the full config endpoint
+    const fr = await fetch('/api/full-config');
+    const cfg = await fr.json();
+
+    document.getElementById('cfg-moonraker').value = cfg.moonraker_url || '';
+    document.getElementById('cfg-spoolman').value = cfg.spoolman_url || '';
+    document.getElementById('cfg-mqtt-broker').value = (cfg.mqtt || {}).broker || '';
+    document.getElementById('cfg-mqtt-port').value = (cfg.mqtt || {}).port || 1883;
+    document.getElementById('cfg-threshold').value = cfg.low_spool_threshold || 100;
+    document.getElementById('cfg-prefix').value = cfg.scanner_topic_prefix || 'spoolsense';
+
+    if (cfg.tag_writeback_enabled) document.getElementById('cfg-writeback').classList.add('on');
+    if (cfg.publish_lane_data) document.getElementById('cfg-lanedata').classList.add('on');
+
+    document.getElementById('version-label').textContent = `SpoolSense Middleware v${cfg._version || ''}`;
+  } catch (e) {
+    console.error('Failed to load config:', e);
+  }
+}
+
+// ── Save config ─────────────────────────────────────────────────────────────
+
+async function saveConfig() {
+  const msg = document.getElementById('save-msg');
+  msg.className = 'save-msg';
+  msg.style.display = 'none';
+
+  const payload = {
+    moonraker_url: document.getElementById('cfg-moonraker').value,
+    spoolman_url: document.getElementById('cfg-spoolman').value,
+    mqtt: {
+      broker: document.getElementById('cfg-mqtt-broker').value,
+      port: parseInt(document.getElementById('cfg-mqtt-port').value) || 1883,
+    },
+    low_spool_threshold: parseInt(document.getElementById('cfg-threshold').value) || 100,
+    scanner_topic_prefix: document.getElementById('cfg-prefix').value || 'spoolsense',
+    tag_writeback_enabled: document.getElementById('cfg-writeback').classList.contains('on'),
+    publish_lane_data: document.getElementById('cfg-lanedata').classList.contains('on'),
+  };
+
+  try {
+    const r = await fetch('/api/save-config', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify(payload),
+    });
+    const data = await r.json();
+    if (data.success) {
+      msg.textContent = 'Saved — restarting middleware...';
+      msg.className = 'save-msg success';
+    } else {
+      msg.textContent = data.message || 'Save failed';
+      msg.className = 'save-msg error';
+    }
+  } catch (e) {
+    msg.textContent = 'Failed to save: ' + e.message;
+    msg.className = 'save-msg error';
+  }
+}
+
+// ── Init ────────────────────────────────────────────────────────────────────
+
+fetchStatus();
+fetchConfig();
+setInterval(fetchStatus, 5000);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Web-based config and status panel served at the root of the REST API (port 5001). Matches the scanner web UI style exactly — same dark theme, cards, nav bar, form styling.

## Tabs

**Status** — connection indicators (MQTT, Moonraker, Klipper), active spools table, pending deductions table. Auto-refreshes every 5 seconds.

**Scanners** — device table showing configured scanners with action, target, and status.

**Config** — editable fields for Moonraker URL, Spoolman URL, MQTT settings, low spool threshold, topic prefix. Toggles for tag writeback and lane data publishing. Save writes to config.yaml and restarts the middleware.

## Changes

- `middleware/static/index.html` — single HTML file with embedded CSS/JS, no dependencies
- `middleware/rest_api.py` — new endpoints: `GET /api/full-config`, `POST /api/save-config`, `GET /` (serves panel)

## New endpoints

- `GET /` — serves the web config panel
- `GET /api/full-config` — returns full middleware config for populating form fields
- `POST /api/save-config` — writes updated config to config.yaml, triggers service restart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a web-based configuration and status dashboard with three sections: Status, Scanners, and Configuration
  * View real-time system connectivity, active spools, and scanner device management
  * Edit configuration settings and trigger system restart from the web interface

* **Documentation**
  * Added design specification for the web configuration panel

<!-- end of auto-generated comment: release notes by coderabbit.ai -->