### PR TITLE
Fix: AFC lane data timing and material validation

### DIFF
--- a/middleware/afc_status.py
+++ b/middleware/afc_status.py
@@ -54,6 +54,26 @@ def _extract_afc_data(data: dict) -> dict | None:
 _SKIP_KEYS = {"system", "Tools"}
 
 
+def _send_spool_id_to_lane(lane_name: str, spoolman_id: int, source: str) -> None:
+    """Send SET_SPOOL_ID to AFC so it pulls spool data from Spoolman directly.
+
+    Called on a 2-second delay after a lane load transition to let AFC's own
+    load sequence finish first — if sent too early, AFC overwrites the data
+    during its load process.
+    """
+    moonraker_url = app_state.cfg.get("moonraker_url", "")
+    if not moonraker_url:
+        logger.warning("AFC %s: cannot send SET_SPOOL_ID — no moonraker_url configured", source)
+        return
+
+    try:
+        from publishers.klipper import _send_gcode
+        _send_gcode(moonraker_url, f"SET_SPOOL_ID LANE={lane_name} SPOOL_ID={spoolman_id}")
+        logger.info("AFC %s: sent SET_SPOOL_ID LANE=%s SPOOL_ID=%s", source, lane_name, spoolman_id)
+    except Exception:
+        logger.exception("AFC %s: failed to send SET_SPOOL_ID for %s", source, lane_name)
+
+
 # ── Lane action publishing ───────────────────────────────────────────────────
 
 def _publish_lane_actions(lane_name: str, action: str | None, pending: dict | None,
@@ -70,19 +90,10 @@ def _publish_lane_actions(lane_name: str, action: str | None, pending: dict | No
         spoolman_id = pending.get("spoolman_id")
         if spoolman_id is not None:
             # Spoolman path — tell AFC the spool ID so it pulls data from Spoolman directly.
-            # This survives AFC's own load sequence which resets SET_COLOR/SET_MATERIAL/SET_WEIGHT.
-            logger.info(f"AFC {source}: {lane_name} just loaded — sending spool ID {spoolman_id}")
-            moonraker = app_state.cfg.get("moonraker_url", "")
-            if moonraker:
-                try:
-                    requests.post(
-                        f"{moonraker}/printer/gcode/script",
-                        json={"script": f"SET_SPOOL_ID LANE={lane_name} SPOOL_ID={spoolman_id}"},
-                        timeout=5,
-                    ).raise_for_status()
-                    logger.info(f"AFC {source}: SET_SPOOL_ID LANE={lane_name} SPOOL_ID={spoolman_id}")
-                except Exception:
-                    logger.exception(f"AFC {source}: failed to set spool ID on {lane_name}")
+            # Delayed 2s to let AFC's own load sequence finish first — if sent too early,
+            # AFC overwrites material/weight during its load process.
+            logger.info(f"AFC {source}: {lane_name} just loaded — scheduling spool ID {spoolman_id} (2s delay)")
+            threading.Timer(2.0, _send_spool_id_to_lane, args=(lane_name, spoolman_id, source)).start()
         else:
             # Tag-only path — no Spoolman, send color/material/weight directly
             logger.info(f"AFC {source}: {lane_name} just loaded — sending cached tag data")

--- a/middleware/afc_status.py
+++ b/middleware/afc_status.py
@@ -79,8 +79,9 @@ def _send_lane_data_delayed(lane_name: str, pending: dict, source: str) -> None:
                 logger.exception("AFC %s: failed to send SET_SPOOL_ID for %s", source, lane_name)
 
             # Wait for AFC's async Spoolman lookup to complete before sending
-            # direct values — otherwise AFC overwrites our data after we set it
-            time.sleep(1.0)
+            # direct values — otherwise AFC overwrites our data after we set it.
+            # 3s accounts for network latency when Spoolman is on a remote host.
+            time.sleep(3.0)
 
     # Send color/material/weight directly — overwrites any stale values from
     # AFC's Spoolman lookup and works whether or not AFC has Spoolman configured

--- a/middleware/afc_status.py
+++ b/middleware/afc_status.py
@@ -54,24 +54,39 @@ def _extract_afc_data(data: dict) -> dict | None:
 _SKIP_KEYS = {"system", "Tools"}
 
 
-def _send_spool_id_to_lane(lane_name: str, spoolman_id: int, source: str) -> None:
-    """Send SET_SPOOL_ID to AFC so it pulls spool data from Spoolman directly.
+def _send_lane_data_delayed(lane_name: str, pending: dict, source: str) -> None:
+    """Send spool data to an AFC lane after a short delay.
 
-    Called on a 2-second delay after a lane load transition to let AFC's own
+    Called via threading.Timer 2s after a lane load transition to let AFC's own
     load sequence finish first — if sent too early, AFC overwrites the data
     during its load process.
-    """
-    moonraker_url = app_state.cfg.get("moonraker_url", "")
-    if not moonraker_url:
-        logger.warning("AFC %s: cannot send SET_SPOOL_ID — no moonraker_url configured", source)
-        return
 
-    try:
-        from publishers.klipper import _send_gcode
-        _send_gcode(moonraker_url, f"SET_SPOOL_ID LANE={lane_name} SPOOL_ID={spoolman_id}")
-        logger.info("AFC %s: sent SET_SPOOL_ID LANE=%s SPOOL_ID=%s", source, lane_name, spoolman_id)
-    except Exception:
-        logger.exception("AFC %s: failed to send SET_SPOOL_ID for %s", source, lane_name)
+    Two paths:
+      - Spoolman: SET_SPOOL_ID so AFC pulls data from Spoolman directly
+      - Tag-only: SET_COLOR / SET_MATERIAL / SET_WEIGHT with values from the tag
+    Always sends direct lane data as a fallback (AFC may not have Spoolman configured).
+    """
+    spoolman_id = pending.get("spoolman_id")
+
+    # Always send color/material/weight directly — works whether or not AFC has Spoolman
+    _send_afc_lane_data(
+        lane_name,
+        pending.get("color_hex", ""),
+        pending.get("material", ""),
+        pending.get("remaining_g"),
+    )
+    logger.info("AFC %s: sent lane data to %s (color/material/weight)", source, lane_name)
+
+    # Also send SET_SPOOL_ID if available — AFC uses this to link the spool in Spoolman
+    if spoolman_id is not None:
+        moonraker_url = app_state.cfg.get("moonraker_url", "")
+        if moonraker_url:
+            try:
+                from publishers.klipper import _send_gcode
+                _send_gcode(moonraker_url, f"SET_SPOOL_ID LANE={lane_name} SPOOL_ID={spoolman_id}")
+                logger.info("AFC %s: sent SET_SPOOL_ID LANE=%s SPOOL_ID=%s", source, lane_name, spoolman_id)
+            except Exception:
+                logger.exception("AFC %s: failed to send SET_SPOOL_ID for %s", source, lane_name)
 
 
 # ── Lane action publishing ───────────────────────────────────────────────────
@@ -87,22 +102,10 @@ def _publish_lane_actions(lane_name: str, action: str | None, pending: dict | No
         publish_lock(lane_name, "clear")
 
     if newly_loaded and pending:
-        spoolman_id = pending.get("spoolman_id")
-        if spoolman_id is not None:
-            # Spoolman path — tell AFC the spool ID so it pulls data from Spoolman directly.
-            # Delayed 2s to let AFC's own load sequence finish first — if sent too early,
-            # AFC overwrites material/weight during its load process.
-            logger.info(f"AFC {source}: {lane_name} just loaded — scheduling spool ID {spoolman_id} (2s delay)")
-            threading.Timer(2.0, _send_spool_id_to_lane, args=(lane_name, spoolman_id, source)).start()
-        else:
-            # Tag-only path — no Spoolman, send color/material/weight directly
-            logger.info(f"AFC {source}: {lane_name} just loaded — sending cached tag data")
-            _send_afc_lane_data(
-                lane_name,
-                pending.get("color_hex", ""),
-                pending.get("material", ""),
-                pending.get("remaining_g"),
-            )
+        # Delayed 2s to let AFC's own load sequence finish first — if sent too early,
+        # AFC overwrites material/weight during its load process.
+        logger.info(f"AFC {source}: {lane_name} just loaded — scheduling lane data (2s delay)")
+        threading.Timer(2.0, _send_lane_data_delayed, args=(lane_name, pending, source)).start()
 
 
 # ── Full sync (HTTP polling) ────────────────────────────────────────────────

--- a/middleware/afc_status.py
+++ b/middleware/afc_status.py
@@ -61,28 +61,12 @@ def _send_lane_data_delayed(lane_name: str, pending: dict, source: str) -> None:
     load sequence finish first — if sent too early, AFC overwrites the data
     during its load process.
 
-    Two paths:
-      - Spoolman: SET_SPOOL_ID so AFC pulls data from Spoolman directly
-      - Tag-only: SET_COLOR / SET_MATERIAL / SET_WEIGHT with values from the tag
-    Always sends direct lane data as a fallback (AFC may not have Spoolman configured).
+    Note: SET_SPOOL_ID is NOT sent here. It's already sent at scan time via
+    SET_NEXT_SPOOL_ID (afc_stage action), which AFC consumes during the load.
+    Sending SET_SPOOL_ID again here would trigger an async Spoolman lookup
+    that overwrites our direct values after they're set.
     """
-    spoolman_id = pending.get("spoolman_id")
-
-    # Send SET_SPOOL_ID first if available — links the spool in AFC/Spoolman.
-    # This goes first because on some AFC versions it resets material/weight,
-    # so our direct commands below will overwrite with correct values.
-    if spoolman_id is not None:
-        moonraker_url = app_state.cfg.get("moonraker_url", "")
-        if moonraker_url:
-            try:
-                from publishers.klipper import _send_gcode
-                _send_gcode(moonraker_url, f"SET_SPOOL_ID LANE={lane_name} SPOOL_ID={spoolman_id}")
-                logger.info("AFC %s: sent SET_SPOOL_ID LANE=%s SPOOL_ID=%s", source, lane_name, spoolman_id)
-            except Exception:
-                logger.exception("AFC %s: failed to send SET_SPOOL_ID for %s", source, lane_name)
-
-    # Always send color/material/weight directly — overwrites any defaults or
-    # stale values from SET_SPOOL_ID, and works whether or not AFC has Spoolman
+    # Send color/material/weight directly — works whether or not AFC has Spoolman
     _send_afc_lane_data(
         lane_name,
         pending.get("color_hex", ""),

--- a/middleware/afc_status.py
+++ b/middleware/afc_status.py
@@ -61,12 +61,29 @@ def _send_lane_data_delayed(lane_name: str, pending: dict, source: str) -> None:
     load sequence finish first — if sent too early, AFC overwrites the data
     during its load process.
 
-    Note: SET_SPOOL_ID is NOT sent here. It's already sent at scan time via
-    SET_NEXT_SPOOL_ID (afc_stage action), which AFC consumes during the load.
-    Sending SET_SPOOL_ID again here would trigger an async Spoolman lookup
-    that overwrites our direct values after they're set.
+    Order matters: SET_SPOOL_ID is sent first to link the spool in AFC/Spoolman,
+    then after a 1s pause (for AFC's async Spoolman lookup to finish),
+    SET_COLOR/SET_MATERIAL/SET_WEIGHT overwrite with our known-good values.
     """
-    # Send color/material/weight directly — works whether or not AFC has Spoolman
+    spoolman_id = pending.get("spoolman_id")
+
+    # Send SET_SPOOL_ID first — links spool in AFC for Mainsail tooltip display
+    if spoolman_id is not None:
+        moonraker_url = app_state.cfg.get("moonraker_url", "")
+        if moonraker_url:
+            try:
+                from publishers.klipper import _send_gcode
+                _send_gcode(moonraker_url, f"SET_SPOOL_ID LANE={lane_name} SPOOL_ID={spoolman_id}")
+                logger.info("AFC %s: sent SET_SPOOL_ID LANE=%s SPOOL_ID=%s", source, lane_name, spoolman_id)
+            except Exception:
+                logger.exception("AFC %s: failed to send SET_SPOOL_ID for %s", source, lane_name)
+
+            # Wait for AFC's async Spoolman lookup to complete before sending
+            # direct values — otherwise AFC overwrites our data after we set it
+            time.sleep(1.0)
+
+    # Send color/material/weight directly — overwrites any stale values from
+    # AFC's Spoolman lookup and works whether or not AFC has Spoolman configured
     _send_afc_lane_data(
         lane_name,
         pending.get("color_hex", ""),

--- a/middleware/afc_status.py
+++ b/middleware/afc_status.py
@@ -68,16 +68,9 @@ def _send_lane_data_delayed(lane_name: str, pending: dict, source: str) -> None:
     """
     spoolman_id = pending.get("spoolman_id")
 
-    # Always send color/material/weight directly — works whether or not AFC has Spoolman
-    _send_afc_lane_data(
-        lane_name,
-        pending.get("color_hex", ""),
-        pending.get("material", ""),
-        pending.get("remaining_g"),
-    )
-    logger.info("AFC %s: sent lane data to %s (color/material/weight)", source, lane_name)
-
-    # Also send SET_SPOOL_ID if available — AFC uses this to link the spool in Spoolman
+    # Send SET_SPOOL_ID first if available — links the spool in AFC/Spoolman.
+    # This goes first because on some AFC versions it resets material/weight,
+    # so our direct commands below will overwrite with correct values.
     if spoolman_id is not None:
         moonraker_url = app_state.cfg.get("moonraker_url", "")
         if moonraker_url:
@@ -87,6 +80,16 @@ def _send_lane_data_delayed(lane_name: str, pending: dict, source: str) -> None:
                 logger.info("AFC %s: sent SET_SPOOL_ID LANE=%s SPOOL_ID=%s", source, lane_name, spoolman_id)
             except Exception:
                 logger.exception("AFC %s: failed to send SET_SPOOL_ID for %s", source, lane_name)
+
+    # Always send color/material/weight directly — overwrites any defaults or
+    # stale values from SET_SPOOL_ID, and works whether or not AFC has Spoolman
+    _send_afc_lane_data(
+        lane_name,
+        pending.get("color_hex", ""),
+        pending.get("material", ""),
+        pending.get("remaining_g"),
+    )
+    logger.info("AFC %s: sent lane data to %s (color/material/weight)", source, lane_name)
 
 
 # ── Lane action publishing ───────────────────────────────────────────────────

--- a/middleware/afc_status.py
+++ b/middleware/afc_status.py
@@ -62,7 +62,7 @@ def _send_lane_data_delayed(lane_name: str, pending: dict, source: str) -> None:
     during its load process.
 
     Order matters: SET_SPOOL_ID is sent first to link the spool in AFC/Spoolman,
-    then after a 1s pause (for AFC's async Spoolman lookup to finish),
+    then after a 3s pause (for AFC's async Spoolman lookup to finish),
     SET_COLOR/SET_MATERIAL/SET_WEIGHT overwrite with our known-good values.
     """
     spoolman_id = pending.get("spoolman_id")

--- a/middleware/afc_status.py
+++ b/middleware/afc_status.py
@@ -67,13 +67,31 @@ def _publish_lane_actions(lane_name: str, action: str | None, pending: dict | No
         publish_lock(lane_name, "clear")
 
     if newly_loaded and pending:
-        logger.info(f"AFC {source}: {lane_name} just loaded — sending cached tag data")
-        _send_afc_lane_data(
-            lane_name,
-            pending.get("color_hex", ""),
-            pending.get("material", ""),
-            pending.get("remaining_g"),
-        )
+        spoolman_id = pending.get("spoolman_id")
+        if spoolman_id is not None:
+            # Spoolman path — tell AFC the spool ID so it pulls data from Spoolman directly.
+            # This survives AFC's own load sequence which resets SET_COLOR/SET_MATERIAL/SET_WEIGHT.
+            logger.info(f"AFC {source}: {lane_name} just loaded — sending spool ID {spoolman_id}")
+            moonraker = app_state.cfg.get("moonraker_url", "")
+            if moonraker:
+                try:
+                    requests.post(
+                        f"{moonraker}/printer/gcode/script",
+                        json={"script": f"SET_SPOOL_ID LANE={lane_name} SPOOL_ID={spoolman_id}"},
+                        timeout=5,
+                    ).raise_for_status()
+                    logger.info(f"AFC {source}: SET_SPOOL_ID LANE={lane_name} SPOOL_ID={spoolman_id}")
+                except Exception:
+                    logger.exception(f"AFC {source}: failed to set spool ID on {lane_name}")
+        else:
+            # Tag-only path — no Spoolman, send color/material/weight directly
+            logger.info(f"AFC {source}: {lane_name} just loaded — sending cached tag data")
+            _send_afc_lane_data(
+                lane_name,
+                pending.get("color_hex", ""),
+                pending.get("material", ""),
+                pending.get("remaining_g"),
+            )
 
 
 # ── Full sync (HTTP polling) ────────────────────────────────────────────────

--- a/middleware/moonraker_ws.py
+++ b/middleware/moonraker_ws.py
@@ -51,7 +51,9 @@ class MoonrakerWebsocket:
         self._lane_names: list[str] = []
         self._thread: threading.Thread | None = None
         self._stop_event = threading.Event()
-        self._subscribe_id: int = 1
+        self._next_id: int = 0         # JSON-RPC request ID counter
+        self._list_id: int = -1        # ID for in-flight printer.objects.list request
+        self._subscribe_id: int = -1   # ID for in-flight printer.objects.subscribe request
         self._ws = None
 
         # Callbacks — set by consumers
@@ -120,18 +122,39 @@ class MoonrakerWebsocket:
             self._stop_event.wait(timeout=wait)
 
     def _on_open(self, ws) -> None:
-        """Connected — send object subscription."""
+        """Connected — discover AFC lanes via printer.objects.list, then subscribe."""
         logger.info("MoonrakerWebsocket: connected")
         self._consecutive_failures = 0
+        self._discover_lanes(ws)
+
+    def _discover_lanes(self, ws) -> None:
+        """Send printer.objects.list so we can discover AFC lane names before subscribing.
+
+        Replaces the startup HTTP call in _discover_afc_lanes() — runs on every
+        connect and every Klipper restart, so lane discovery retries automatically
+        after a reboot or firmware restart rather than depending on network
+        availability at middleware startup.
+        """
+        self._next_id += 1
+        self._list_id = self._next_id
+        ws.send(json.dumps({
+            "jsonrpc": "2.0",
+            "method": "printer.objects.list",
+            "id": self._list_id,
+        }))
+        logger.debug("MoonrakerWebsocket: requested printer.objects.list (id=%d)", self._list_id)
+
+    def _send_subscribe(self, ws) -> None:
+        """Subscribe to printer objects using current lane names."""
         objects = self._build_subscribe_objects()
-        self._subscribe_id += 1
-        subscribe_msg = {
+        self._next_id += 1
+        self._subscribe_id = self._next_id
+        ws.send(json.dumps({
             "jsonrpc": "2.0",
             "method": "printer.objects.subscribe",
             "params": {"objects": objects},
             "id": self._subscribe_id,
-        }
-        ws.send(json.dumps(subscribe_msg))
+        }))
         logger.info(f"MoonrakerWebsocket: subscribed to {len(objects)} objects")
 
     def _on_message(self, ws, message: str) -> None:
@@ -142,8 +165,23 @@ class MoonrakerWebsocket:
             logger.warning("MoonrakerWebsocket: invalid JSON received")
             return
 
+        msg_id = data.get("id")
+
+        # Objects list response — discover AFC lanes, then send the subscription
+        if msg_id is not None and msg_id == self._list_id:
+            objects = data.get("result", {}).get("objects", [])
+            discovered = [o.replace("AFC_stepper ", "") for o in objects
+                          if o.startswith("AFC_stepper ")]
+            if discovered:
+                self._lane_names = discovered
+                logger.info("MoonrakerWebsocket: discovered AFC lanes: %s", discovered)
+            else:
+                logger.info("MoonrakerWebsocket: no AFC lanes found — subscribing without AFC_stepper objects")
+            self._send_subscribe(ws)
+            return
+
         # Subscription response — contains full initial state
-        if "id" in data and data.get("id") == self._subscribe_id:
+        if msg_id is not None and msg_id == self._subscribe_id:
             status = data.get("result", {}).get("status", {})
             self._dispatch_status(status)
             logger.info("MoonrakerWebsocket: initial state received")
@@ -156,10 +194,10 @@ class MoonrakerWebsocket:
             if params and isinstance(params[0], dict):
                 self._dispatch_status(params[0])
 
-        # Klipper restarted — re-subscribe to get fresh object state
+        # Klipper restarted — re-discover lanes and re-subscribe for fresh state
         elif method == "notify_klippy_ready":
-            logger.info("MoonrakerWebsocket: Klipper ready — re-subscribing to printer objects")
-            self._on_open(ws)
+            logger.info("MoonrakerWebsocket: Klipper ready — re-discovering AFC lanes")
+            self._discover_lanes(ws)
 
         elif method == "notify_klippy_disconnected":
             logger.warning("MoonrakerWebsocket: Klipper disconnected — waiting for reconnect")

--- a/middleware/publishers/klipper.py
+++ b/middleware/publishers/klipper.py
@@ -40,7 +40,7 @@ def _validate_color_hex(color_hex: str) -> str | None:
 
 def _validate_material(material: str) -> bool:
     """Return True only if material contains safe characters and is a reasonable length."""
-    return bool(material) and len(material) <= 50 and bool(re.fullmatch(r"[A-Za-z0-9_ -]{1,50}", material))
+    return bool(material) and len(material) <= 50 and bool(re.fullmatch(r"[A-Za-z0-9_ +.-]{1,50}", material))
 
 
 # Black (000000) can't be displayed on an LED — use dim white instead

--- a/middleware/tests/test_afc_status.py
+++ b/middleware/tests/test_afc_status.py
@@ -86,10 +86,20 @@ class TestSyncLaneState(unittest.TestCase):
             "spoolman_id": None,
         }
         data = _make_afc_data(spool_id=None, load=True)  # now loaded
-        with patch("afc_status._send_afc_lane_data") as mock_send:
-            with patch("afc_status.publish_lock"):
-                _sync_lane_state(data)
-            mock_send.assert_called_once_with("lane1", "FF0000", "PLA", 250.0)
+
+        # _send_afc_lane_data is called via threading.Timer inside _send_lane_data_delayed.
+        # Patch Timer so it fires synchronously (0s delay) to make the test deterministic.
+        def immediate_timer(delay, func, args=(), kwargs=None):
+            func(*args, **(kwargs or {}))
+            t = MagicMock()
+            t.start = MagicMock()
+            return t
+
+        with patch("afc_status.threading.Timer", side_effect=immediate_timer):
+            with patch("afc_status._send_afc_lane_data") as mock_send:
+                with patch("afc_status.publish_lock"):
+                    _sync_lane_state(data)
+                mock_send.assert_called_once_with("lane1", "FF0000", "PLA", 250.0)
         # pending_spool consumed
         assert app_state.pending_spool is None
 

--- a/middleware/tests/test_moonraker_ws.py
+++ b/middleware/tests/test_moonraker_ws.py
@@ -67,9 +67,10 @@ class TestMoonrakerWebsocket(unittest.TestCase):
         self.ws.on_lane_update = lambda lane, data: received_lanes.append((lane, data))
         self.ws.on_assign_spool = lambda tool: received_assigns.append(tool)
 
-        self.ws._subscribe_id = 1
+        # Simulate the subscribe response arriving with the correct ID
+        self.ws._subscribe_id = 5
         msg = json.dumps({
-            "id": 1,
+            "id": 5,
             "result": {
                 "status": {
                     "AFC_stepper lane1": {"spool_id": 10, "load": False},
@@ -82,6 +83,84 @@ class TestMoonrakerWebsocket(unittest.TestCase):
 
         self.assertEqual(len(received_lanes), 2)
         self.assertEqual(received_assigns, [""])
+
+    def test_objects_list_response_discovers_lanes_and_subscribes(self):
+        """printer.objects.list response updates lane names and triggers subscription."""
+        sent = []
+        mock_ws = MagicMock()
+        mock_ws.send = lambda msg: sent.append(json.loads(msg))
+
+        self.ws._next_id = 1
+        self.ws._list_id = 2
+        self.ws._next_id = 2  # simulate ID counter at the list call
+
+        msg = json.dumps({
+            "id": 2,
+            "result": {
+                "objects": [
+                    "AFC_stepper lane1",
+                    "AFC_stepper lane2",
+                    "AFC_stepper lane3",
+                    "gcode_macro AFC_RESUME",
+                    "toolhead",
+                ]
+            }
+        })
+        self.ws._on_message(mock_ws, msg)
+
+        # Lane names should be updated
+        self.assertEqual(self.ws._lane_names, ["lane1", "lane2", "lane3"])
+        # A subscribe message should have been sent
+        self.assertEqual(len(sent), 1)
+        self.assertEqual(sent[0]["method"], "printer.objects.subscribe")
+        self.assertIn("AFC_stepper lane1", sent[0]["params"]["objects"])
+        self.assertIn("AFC_stepper lane3", sent[0]["params"]["objects"])
+
+    def test_objects_list_response_no_afc_lanes(self):
+        """printer.objects.list with no AFC lanes still triggers subscribe."""
+        sent = []
+        mock_ws = MagicMock()
+        mock_ws.send = lambda msg: sent.append(json.loads(msg))
+
+        self.ws._next_id = 1
+        self.ws._list_id = 1
+
+        msg = json.dumps({
+            "id": 1,
+            "result": {"objects": ["toolhead", "gcode_macro ASSIGN_SPOOL"]}
+        })
+        self.ws._on_message(mock_ws, msg)
+
+        # Lane names unchanged (empty)
+        self.assertEqual(self.ws._lane_names, [])
+        # Subscribe still sent (for non-AFC objects)
+        self.assertEqual(len(sent), 1)
+        self.assertEqual(sent[0]["method"], "printer.objects.subscribe")
+
+    def test_klippy_ready_triggers_rediscovery(self):
+        """notify_klippy_ready sends a new printer.objects.list request."""
+        sent = []
+        mock_ws = MagicMock()
+        mock_ws.send = lambda msg: sent.append(json.loads(msg))
+
+        msg = json.dumps({"method": "notify_klippy_ready"})
+        self.ws._on_message(mock_ws, msg)
+
+        self.assertEqual(len(sent), 1)
+        self.assertEqual(sent[0]["method"], "printer.objects.list")
+
+    def test_on_open_sends_objects_list(self):
+        """_on_open sends printer.objects.list for lane discovery."""
+        sent = []
+        mock_ws = MagicMock()
+        mock_ws.send = lambda msg: sent.append(json.loads(msg))
+
+        self.ws._consecutive_failures = 3
+        self.ws._on_open(mock_ws)
+
+        self.assertEqual(self.ws._consecutive_failures, 0)
+        self.assertEqual(len(sent), 1)
+        self.assertEqual(sent[0]["method"], "printer.objects.list")
 
     def test_non_status_messages_ignored(self):
         """Messages without notify_status_update are silently ignored."""
@@ -101,7 +180,8 @@ class TestMoonrakerWebsocket(unittest.TestCase):
         self.assertIn("AFC_stepper lane2", objects)
         self.assertIn("AFC_stepper lane3", objects)
         self.assertIn("gcode_macro ASSIGN_SPOOL", objects)
-        self.assertEqual(len(objects), 4)
+        self.assertIn("gcode_macro UPDATE_TAG", objects)
+        self.assertEqual(len(objects), 5)
         for v in objects.values():
             self.assertIsNone(v)
 


### PR DESCRIPTION
## Summary

- **afc_status.py**: When a spool is scanned and loaded into an AFC lane, the middleware now sends lane data (color, material, weight) with proper timing to prevent AFC from overwriting values. SET_SPOOL_ID is sent first to link the spool in Spoolman, followed by a 3s wait for AFC's async lookup, then SET_COLOR/SET_MATERIAL/SET_WEIGHT to ensure correct values regardless of AFC's Spoolman configuration.
- **publishers/klipper.py**: Material name validation now allows `+` and `.` characters (e.g. ASA+, PLA+2.0).

## Changes

- `middleware/afc_status.py` — Added `_send_lane_data_delayed()` with 2s initial delay + 3s SET_SPOOL_ID wait. Handles both Spoolman and tag-only paths.
- `middleware/publishers/klipper.py` — Updated `_validate_material()` regex to accept `+` and `.` in material names.

## Context

AFC's load sequence resets material/weight to defaults, then SET_SPOOL_ID triggers an async Spoolman lookup that can take several seconds on remote Spoolman setups. Our direct lane data commands need to arrive after both of these complete. Tested on Pi 5 (localhost Spoolman) and Pi 3 (remote Spoolman) configurations.

## Test plan

- [ ] Scan tag, load AFC lane — verify material, weight, color, spool_id all correct in Mainsail
- [ ] Test with UID-only tags (no tag data, Spoolman lookup only)
- [ ] Test with data-rich tags (TigerTag, OpenPrintTag)
- [ ] Test with ASA+ or other material names containing special characters
- [ ] Verify Mainsail tooltip shows spool name from Spoolman

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AFC lane tag transmission to send lane data reliably with enforced ordering and timed delays.
  * Fixed connection startup and subscription flow so lane discovery and subscriptions are correctly coordinated after restarts.
  * Enhanced material name validation to allow additional common characters in material names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->