### PR TITLE
Fix: Cleanup script keeps oldest original spool (#68)

### DIFF
--- a/scripts/spoolman-cleanup.py
+++ b/scripts/spoolman-cleanup.py
@@ -12,7 +12,10 @@ Features:
 - Finds duplicate spools by NFC ID
 - Finds duplicate filaments by vendor + material + color
 - Finds duplicate vendors by name
-- Keeps most recently registered entry in each group
+- Keeps the oldest (original) entry in each group and deletes newer duplicates —
+  preserves references from other Spoolman objects (e.g. spools referencing a
+  filament, filaments referencing a vendor) and from external systems
+  (Klipper save_variables, AFC lane assignments)
 - Color output: green for KEEP, red for DELETE
 - Interactive prompt for each group
 - Dry-run mode to preview changes
@@ -78,7 +81,10 @@ def find_duplicate_vendors(vendors):
     return {k: v for k, v in groups.items() if len(v) > 1}
 
 def sort_by_registered(items):
-    return sorted(items, key=lambda x: x.get('registered', ''), reverse=True)
+    # Oldest first so the group[0] is the original entry we keep.
+    # Deleting the newer duplicates preserves references held by other
+    # Spoolman objects and external systems (Klipper, AFC) (#68).
+    return sorted(items, key=lambda x: x.get('registered', ''))
 
 def format_item(item, entity_type):
     """Format an item for display based on entity type."""

--- a/scripts/spoolman-cleanup.py
+++ b/scripts/spoolman-cleanup.py
@@ -84,7 +84,8 @@ def sort_by_registered(items):
     # Oldest first so the group[0] is the original entry we keep.
     # Deleting the newer duplicates preserves references held by other
     # Spoolman objects and external systems (Klipper, AFC) (#68).
-    return sorted(items, key=lambda x: x.get('registered', ''))
+    return sorted(items, key=lambda x: (x.get('registered') is None or x.get('registered') == '',
+                                        x.get('registered') or ''))
 
 def format_item(item, entity_type):
     """Format an item for display based on entity type."""


### PR DESCRIPTION
## Summary

Closes #68.

The `scripts/spoolman-cleanup.py` script was deleting the oldest (original) spool and keeping newer duplicates. This broke references from other Spoolman objects and external systems (Klipper `save_variables`, AFC lane assignments).

Flipped the sort order in `sort_by_registered` so `group[0]` is now the oldest entry and gets marked KEEP. Updated the docstring to match.

## Test plan

- [x] Verified sort logic with inline test — oldest entry lands at index 0
- [ ] Run on live Spoolman instance with duplicate spools in `--dry-run` mode
- [ ] Confirm duplicates section correctly labels the original as KEEP and newer as DELETE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated cleanup script's duplicate resolution logic to preserve oldest entries instead of newest ones, better protecting historical data and external system references.

* **Documentation**
  * Updated documentation to reflect revised duplicate handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->