### PR TITLE
Fix: Low-spool LED MQTT publish for mid-print detection (#61)

### DIFF
--- a/middleware/app_state.py
+++ b/middleware/app_state.py
@@ -86,6 +86,12 @@ tag_write_timestamps: dict[str, float] = {}
 active_spool_weights: dict[str, float] = {}
 active_spool_uids: dict[str, str] = {}
 active_spool_devices: dict[str, str] = {}
+
+# Low-spool LED state — tracks whether the low-spool retained MQTT command
+# has been sent to each scanner. Edge-triggered: we only publish on state
+# transitions to avoid flooding the broker. Keyed by device_id (not lane)
+# because the MQTT cmd topic is per-scanner.
+low_spool_latched: dict[str, bool] = {}
 active_spool_diameters: dict[str, float] = {}   # mm, default 1.75
 active_spool_densities: dict[str, float] = {}   # g/cm³, default 1.24
 active_spool_formats: dict[str, str] = {}       # tag format — "openprinttag", "tigertag", etc.

--- a/middleware/filament_usage.py
+++ b/middleware/filament_usage.py
@@ -146,6 +146,50 @@ def _publish_deduction(device_id: str, uid: str, deduct_g: float) -> None:
         logger.exception("UPDATE_TAG: failed to publish deduction")
 
 
+LOW_SPOOL_HYSTERESIS_G: float = 50.0
+
+
+def _publish_low_spool(device_id: str, latched: bool) -> None:
+    """Publish retained low_spool command to the scanner LED."""
+    if not app_state.mqtt_client:
+        return
+
+    safe_device = device_id.replace("/", "").replace("+", "").replace("#", "")
+    topic = f"spoolsense/{safe_device}/cmd/low_spool"
+    payload = "true" if latched else "false"
+
+    try:
+        result = app_state.mqtt_client.publish(topic, payload, qos=1, retain=True)
+        if result.rc == 0:
+            logger.info(
+                "low_spool: published %s to %s (device_id=%r)",
+                payload, topic, device_id,
+            )
+        else:
+            logger.warning(
+                "low_spool: MQTT publish failed (rc=%d) topic=%s",
+                result.rc, topic,
+            )
+    except Exception:
+        logger.exception("low_spool: failed to publish to topic=%s", topic)
+
+
+def _check_low_spool(device_id: str, new_weight: float) -> None:
+    """Edge-triggered low-spool state machine. Publishes only on state transition."""
+    if not device_id:
+        return
+
+    threshold: float = float(app_state.cfg.get("low_spool_threshold", 100))
+    latched: bool = app_state.low_spool_latched.get(device_id, False)
+
+    if new_weight <= threshold and not latched:
+        _publish_low_spool(device_id, True)
+        app_state.low_spool_latched[device_id] = True
+    elif new_weight > threshold + LOW_SPOOL_HYSTERESIS_G and latched:
+        _publish_low_spool(device_id, False)
+        app_state.low_spool_latched[device_id] = False
+
+
 def _handle_update_tag() -> None:
     """
     Main handler — triggered when UPDATE_TAG macro fires.
@@ -205,6 +249,9 @@ def _handle_afc() -> None:
         # Update initial weight so next UPDATE_TAG only deducts the delta
         with app_state.state_lock:
             app_state.active_spool_weights[lane] = current_weight
+
+        if device_id:
+            _check_low_spool(device_id, current_weight)
 
 
 def _fetch_tool_filament_used() -> dict[str, float] | None:

--- a/middleware/filament_usage.py
+++ b/middleware/filament_usage.py
@@ -149,13 +149,14 @@ def _publish_deduction(device_id: str, uid: str, deduct_g: float) -> None:
 LOW_SPOOL_HYSTERESIS_G: float = 50.0
 
 
-def _publish_low_spool(device_id: str, latched: bool) -> None:
-    """Publish retained low_spool command to the scanner LED."""
+def _publish_low_spool(device_id: str, latched: bool) -> bool:
+    """Publish retained low_spool command to the scanner LED. Returns True on success."""
     if not app_state.mqtt_client:
-        return
+        return False
 
+    prefix = app_state.cfg.get("scanner_topic_prefix", "spoolsense")
     safe_device = device_id.replace("/", "").replace("+", "").replace("#", "")
-    topic = f"spoolsense/{safe_device}/cmd/low_spool"
+    topic = f"{prefix}/{safe_device}/cmd/low_spool"
     payload = "true" if latched else "false"
 
     try:
@@ -165,13 +166,16 @@ def _publish_low_spool(device_id: str, latched: bool) -> None:
                 "low_spool: published %s to %s (device_id=%r)",
                 payload, topic, device_id,
             )
+            return True
         else:
             logger.warning(
                 "low_spool: MQTT publish failed (rc=%d) topic=%s",
                 result.rc, topic,
             )
+            return False
     except Exception:
         logger.exception("low_spool: failed to publish to topic=%s", topic)
+        return False
 
 
 def _check_low_spool(device_id: str, new_weight: float) -> None:
@@ -183,11 +187,11 @@ def _check_low_spool(device_id: str, new_weight: float) -> None:
     latched: bool = app_state.low_spool_latched.get(device_id, False)
 
     if new_weight <= threshold and not latched:
-        _publish_low_spool(device_id, True)
-        app_state.low_spool_latched[device_id] = True
+        if _publish_low_spool(device_id, True):
+            app_state.low_spool_latched[device_id] = True
     elif new_weight > threshold + LOW_SPOOL_HYSTERESIS_G and latched:
-        _publish_low_spool(device_id, False)
-        app_state.low_spool_latched[device_id] = False
+        if _publish_low_spool(device_id, False):
+            app_state.low_spool_latched[device_id] = False
 
 
 def _handle_update_tag() -> None:
@@ -222,6 +226,9 @@ def _handle_afc() -> None:
         devices = dict(app_state.active_spool_devices)
 
     for lane, current_weight in lane_weights.items():
+        device_id = devices.get(lane)
+        _check_low_spool(device_id, current_weight)
+
         initial = initial_weights.get(lane)
         if initial is None:
             continue
@@ -231,7 +238,6 @@ def _handle_afc() -> None:
             continue
 
         uid = uids.get(lane)
-        device_id = devices.get(lane)
         if not uid:
             logger.debug(f"UPDATE_TAG: no UID for {lane}, skipping")
             continue
@@ -249,9 +255,6 @@ def _handle_afc() -> None:
         # Update initial weight so next UPDATE_TAG only deducts the delta
         with app_state.state_lock:
             app_state.active_spool_weights[lane] = current_weight
-
-        if device_id:
-            _check_low_spool(device_id, current_weight)
 
 
 def _fetch_tool_filament_used() -> dict[str, float] | None:

--- a/middleware/mqtt_handler.py
+++ b/middleware/mqtt_handler.py
@@ -21,6 +21,7 @@ from activation import activate_spool, publish_lock, _activate_from_scan
 from publishers.klipper import display_spoolcolor
 from spoolman_cache import find_spool_by_nfc, refresh_spool_cache
 from config import discover_klipper_var_path, has_afc_scanners, has_toolhead_scanners
+from filament_usage import _check_low_spool
 
 if TYPE_CHECKING:
     from spoolman.client import SpoolInfo
@@ -81,6 +82,12 @@ def _record_spool_tracking(
         app_state.active_spool_diameters[target]  = diameter_mm or 1.75
         app_state.active_spool_densities[target]  = density or 1.24
         app_state.active_spool_formats[target]    = tag_format or "unknown"
+
+    # Check low-spool threshold at scan time — if a new spool has plenty of
+    # filament, this also clears any latched low-spool state from the same
+    # device so the LED stops breathing after a spool swap.
+    if device_id:
+        _check_low_spool(device_id, remaining)
 
 
 # ── UID-only tag handling ────────────────────────────────────────────────────

--- a/middleware/tests/test_filament_usage.py
+++ b/middleware/tests/test_filament_usage.py
@@ -25,6 +25,9 @@ from filament_usage import (  # noqa: E402
     _handle_update_tag,
     _handle_toolchanger,
     _handle_afc,
+    _publish_low_spool,
+    _check_low_spool,
+    LOW_SPOOL_HYSTERESIS_G,
 )
 
 
@@ -32,6 +35,7 @@ def _reset_app_state():
     app_state.cfg = {
         "moonraker_url": "http://moonraker:7125",
         "scanner_topic_prefix": "spoolsense",
+        "low_spool_threshold": 100,
     }
     app_state.state_lock = threading.Lock()
     app_state.active_spool_weights = {}
@@ -39,6 +43,7 @@ def _reset_app_state():
     app_state.active_spool_devices = {}
     app_state.active_spool_diameters = {}
     app_state.active_spool_densities = {}
+    app_state.low_spool_latched = {}
     app_state.mqtt_client = MagicMock()
 
 
@@ -365,6 +370,147 @@ class TestHandleAfc(unittest.TestCase):
         _handle_afc()
 
         app_state.mqtt_client.publish.assert_not_called()
+
+
+class TestPublishLowSpool(unittest.TestCase):
+    """Tests for _publish_low_spool helper."""
+
+    def setUp(self) -> None:
+        _reset_app_state()
+
+    def test_publishes_true_to_correct_topic(self) -> None:
+        _publish_low_spool("scanner1", True)
+
+        app_state.mqtt_client.publish.assert_called_once()
+        call = app_state.mqtt_client.publish.call_args
+        self.assertEqual(call[0][0], "spoolsense/scanner1/cmd/low_spool")
+        self.assertEqual(call[0][1], "true")
+        self.assertEqual(call[1].get("qos"), 1)
+        self.assertTrue(call[1].get("retain"))
+
+    def test_publishes_false_to_correct_topic(self) -> None:
+        _publish_low_spool("mydevice", False)
+
+        app_state.mqtt_client.publish.assert_called_once()
+        call = app_state.mqtt_client.publish.call_args
+        self.assertEqual(call[0][0], "spoolsense/mydevice/cmd/low_spool")
+        self.assertEqual(call[0][1], "false")
+
+    def test_sanitizes_device_id_slashes_and_wildcards(self) -> None:
+        _publish_low_spool("bad/dev+id#foo", True)
+
+        app_state.mqtt_client.publish.assert_called_once()
+        topic = app_state.mqtt_client.publish.call_args[0][0]
+        self.assertEqual(topic, "spoolsense/baddevidfoo/cmd/low_spool")
+
+    def test_noop_when_mqtt_client_is_none(self) -> None:
+        app_state.mqtt_client = None
+        _publish_low_spool("scanner1", True)
+        # No exception — just silently returns
+
+
+class TestCheckLowSpool(unittest.TestCase):
+    """Tests for _check_low_spool edge-triggered state machine."""
+
+    def setUp(self) -> None:
+        _reset_app_state()
+
+    def test_publishes_true_on_transition_below_threshold(self) -> None:
+        app_state.low_spool_latched = {}
+        _check_low_spool("scanner1", 90.0)  # 90 <= 100 threshold
+
+        app_state.mqtt_client.publish.assert_called_once()
+        self.assertEqual(app_state.mqtt_client.publish.call_args[0][1], "true")
+        self.assertTrue(app_state.low_spool_latched.get("scanner1"))
+
+    def test_publishes_false_on_transition_above_threshold_plus_hysteresis(self) -> None:
+        app_state.low_spool_latched = {"scanner1": True}
+        # threshold=100, hysteresis=50, so must exceed 150
+        _check_low_spool("scanner1", 160.0)
+
+        app_state.mqtt_client.publish.assert_called_once()
+        self.assertEqual(app_state.mqtt_client.publish.call_args[0][1], "false")
+        self.assertFalse(app_state.low_spool_latched.get("scanner1"))
+
+    def test_noop_within_hysteresis_band(self) -> None:
+        app_state.low_spool_latched = {"scanner1": True}
+        # threshold=100, hysteresis=50 → clear requires >150; 130 is in the band
+        _check_low_spool("scanner1", 130.0)
+
+        app_state.mqtt_client.publish.assert_not_called()
+        self.assertTrue(app_state.low_spool_latched.get("scanner1"))
+
+    def test_noop_when_already_latched_and_still_low(self) -> None:
+        app_state.low_spool_latched = {"scanner1": True}
+        _check_low_spool("scanner1", 50.0)  # still below threshold
+
+        app_state.mqtt_client.publish.assert_not_called()
+
+    def test_noop_on_empty_device_id(self) -> None:
+        _check_low_spool("", 50.0)
+        app_state.mqtt_client.publish.assert_not_called()
+
+    def test_noop_on_none_device_id(self) -> None:
+        _check_low_spool(None, 50.0)  # type: ignore[arg-type]
+        app_state.mqtt_client.publish.assert_not_called()
+
+    def test_exactly_at_threshold_triggers_latch(self) -> None:
+        _check_low_spool("scanner1", 100.0)  # exactly at threshold (<=)
+
+        app_state.mqtt_client.publish.assert_called_once()
+        self.assertEqual(app_state.mqtt_client.publish.call_args[0][1], "true")
+
+    def test_exactly_at_threshold_plus_hysteresis_does_not_clear(self) -> None:
+        app_state.low_spool_latched = {"scanner1": True}
+        # Must be strictly > threshold + hysteresis to clear; 150.0 is not > 150.0
+        _check_low_spool("scanner1", 150.0)
+
+        app_state.mqtt_client.publish.assert_not_called()
+
+
+class TestHandleAfcLowSpoolIntegration(unittest.TestCase):
+    """Integration-ish: _handle_afc triggers _check_low_spool after deduction."""
+
+    def setUp(self) -> None:
+        _reset_app_state()
+
+    @patch("filament_usage._fetch_afc_lane_weights")
+    def test_low_spool_published_once_after_deduction_below_threshold(
+        self, mock_fetch: MagicMock
+    ) -> None:
+        # Initial weight 800g, deducts to 80g which is below threshold (100g)
+        mock_fetch.return_value = {"lane1": 80.0}
+        app_state.active_spool_weights = {"lane1": 800.0}
+        app_state.active_spool_uids = {"lane1": "uid-aaa"}
+        app_state.active_spool_devices = {"lane1": "scanner1"}
+        app_state.active_spool_formats = {"lane1": "openprinttag"}
+
+        _handle_afc()
+
+        # Collect all publish calls
+        calls = app_state.mqtt_client.publish.call_args_list
+        low_spool_calls = [c for c in calls if "cmd/low_spool" in c[0][0]]
+        self.assertEqual(len(low_spool_calls), 1)
+        self.assertEqual(low_spool_calls[0][0][1], "true")
+        self.assertTrue(app_state.low_spool_latched.get("scanner1"))
+
+    @patch("filament_usage._fetch_afc_lane_weights")
+    def test_low_spool_not_published_when_weight_above_threshold(
+        self, mock_fetch: MagicMock
+    ) -> None:
+        # Deducts to 500g, well above threshold
+        mock_fetch.return_value = {"lane1": 500.0}
+        app_state.active_spool_weights = {"lane1": 800.0}
+        app_state.active_spool_uids = {"lane1": "uid-aaa"}
+        app_state.active_spool_devices = {"lane1": "scanner1"}
+        app_state.active_spool_formats = {"lane1": "openprinttag"}
+
+        _handle_afc()
+
+        calls = app_state.mqtt_client.publish.call_args_list
+        low_spool_calls = [c for c in calls if "cmd/low_spool" in c[0][0]]
+        self.assertEqual(len(low_spool_calls), 0)
+        self.assertFalse(app_state.low_spool_latched.get("scanner1", False))
 
 
 if __name__ == "__main__":

--- a/middleware/tests/test_filament_usage.py
+++ b/middleware/tests/test_filament_usage.py
@@ -43,8 +43,12 @@ def _reset_app_state():
     app_state.active_spool_devices = {}
     app_state.active_spool_diameters = {}
     app_state.active_spool_densities = {}
+    app_state.active_spool_formats = {}
     app_state.low_spool_latched = {}
     app_state.mqtt_client = MagicMock()
+    mock_result = MagicMock()
+    mock_result.rc = 0
+    app_state.mqtt_client.publish.return_value = mock_result
 
 
 class TestFetchLastJobWeights(unittest.TestCase):
@@ -186,6 +190,7 @@ class TestHandleToolchangerPrimary(unittest.TestCase):
         app_state.active_spool_devices["T0"] = "f3d360"
         app_state.active_spool_diameters["T0"] = 1.75
         app_state.active_spool_densities["T0"] = 1.24
+        app_state.active_spool_formats["T0"] = "openprinttag"
 
         _handle_toolchanger()
 
@@ -201,10 +206,12 @@ class TestHandleToolchangerPrimary(unittest.TestCase):
         app_state.active_spool_devices["T0"] = "scanner1"
         app_state.active_spool_diameters["T0"] = 1.75
         app_state.active_spool_densities["T0"] = 1.24
+        app_state.active_spool_formats["T0"] = "openprinttag"
         app_state.active_spool_uids["T2"] = "uid-bbb"
         app_state.active_spool_devices["T2"] = "scanner1"
         app_state.active_spool_diameters["T2"] = 1.75
         app_state.active_spool_densities["T2"] = 1.24
+        app_state.active_spool_formats["T2"] = "openprinttag"
 
         _handle_toolchanger()
 
@@ -221,6 +228,7 @@ class TestHandleToolchangerPrimary(unittest.TestCase):
         app_state.active_spool_devices["T0"] = "f3d360"
         app_state.active_spool_diameters["T0"] = 2.85
         app_state.active_spool_densities["T0"] = 1.27
+        app_state.active_spool_formats["T0"] = "openprinttag"
 
         _handle_toolchanger()
 
@@ -257,6 +265,7 @@ class TestHandleToolchangerFallback(unittest.TestCase):
         mock_fetch_job.return_value = [25.5]
         app_state.active_spool_uids["T0"] = "abc123"
         app_state.active_spool_devices["T0"] = "f3d360"
+        app_state.active_spool_formats["T0"] = "openprinttag"
 
         _handle_toolchanger()
 
@@ -272,8 +281,10 @@ class TestHandleToolchangerFallback(unittest.TestCase):
         mock_fetch_job.return_value = [50.0, 0.0, 30.0, 0.0]
         app_state.active_spool_uids["T0"] = "uid-aaa"
         app_state.active_spool_devices["T0"] = "scanner1"
+        app_state.active_spool_formats["T0"] = "openprinttag"
         app_state.active_spool_uids["T2"] = "uid-bbb"
         app_state.active_spool_devices["T2"] = "scanner1"
+        app_state.active_spool_formats["T2"] = "openprinttag"
 
         _handle_toolchanger()
 
@@ -328,6 +339,7 @@ class TestHandleAfc(unittest.TestCase):
         app_state.active_spool_weights = {"lane1": 800.0, "lane2": 750.0}
         app_state.active_spool_uids = {"lane1": "uid-aaa", "lane2": "uid-bbb"}
         app_state.active_spool_devices = {"lane1": "scanner1", "lane2": "scanner1"}
+        app_state.active_spool_formats = {"lane1": "openprinttag", "lane2": "openprinttag"}
 
         _handle_afc()
 
@@ -343,6 +355,7 @@ class TestHandleAfc(unittest.TestCase):
         app_state.active_spool_weights = {"lane1": 800.0}
         app_state.active_spool_uids = {"lane1": "uid-aaa"}
         app_state.active_spool_devices = {"lane1": "scanner1"}
+        app_state.active_spool_formats = {"lane1": "openprinttag"}
 
         _handle_afc()
 


### PR DESCRIPTION
## Summary
- Restores the middleware-side MQTT publish that drives the scanner's low-spool LED breathing during a print.
- Edge-triggered with 50g hysteresis — publishes retained `true`/`false` to `spoolsense/<device_id>/cmd/low_spool` on threshold transitions only, no flap.
- Also clears latched state at scan time when a fresh spool is loaded on the same device.

## Paths covered
- AFC deduction path in `_handle_afc()` after each lane weight update
- Scan-time path in `_record_spool_tracking()` (handles the spool-swap clear case)

## Not covered
Toolchanger deduction paths — they emit deductions but don't track a per-tool running weight. Filed as follow-up in #72.

## Changes
- `middleware/app_state.py` — new `low_spool_latched: dict[str, bool]` (per-device-id latch)
- `middleware/filament_usage.py` — new `LOW_SPOOL_HYSTERESIS_G`, `_publish_low_spool()`, `_check_low_spool()`; call from `_handle_afc`
- `middleware/mqtt_handler.py` — call `_check_low_spool` at end of `_record_spool_tracking`
- `middleware/tests/test_filament_usage.py` — 14 new tests (publish sanitization, transitions, hysteresis, AFC integration)

Closes #61

## Test plan
- [x] `pytest middleware/tests/test_filament_usage.py` — 28 pass, 7 pre-existing failures (unrelated to this change)
- [x] Full suite baseline unchanged
- [ ] Hardware verification: start a print that will drop below `low_spool_threshold`, confirm scanner LED starts breathing mid-print
- [ ] Hardware verification: swap to a full spool, confirm LED stops breathing on scan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added low-spool detection with hysteresis to prevent repeated alerts
  * Integrated automatic low-spool checks during filament tracking and spool scans
  * Enhanced device-specific spool status monitoring

<!-- end of auto-generated comment: release notes by coderabbit.ai -->