### PR TITLE
Refactor: Decouple klipper helpers from global app_state (#67)

### DIFF
--- a/middleware/afc_status.py
+++ b/middleware/afc_status.py
@@ -85,7 +85,9 @@ def _send_lane_data_delayed(lane_name: str, pending: dict, source: str) -> None:
 
     # Send color/material/weight directly — overwrites any stale values from
     # AFC's Spoolman lookup and works whether or not AFC has Spoolman configured
+    moonraker_url = app_state.cfg.get("moonraker_url", "")
     _send_afc_lane_data(
+        moonraker_url,
         lane_name,
         pending.get("color_hex", ""),
         pending.get("material", ""),

--- a/middleware/afc_status.py
+++ b/middleware/afc_status.py
@@ -86,6 +86,10 @@ def _send_lane_data_delayed(lane_name: str, pending: dict, source: str) -> None:
     # Send color/material/weight directly — overwrites any stale values from
     # AFC's Spoolman lookup and works whether or not AFC has Spoolman configured
     moonraker_url = app_state.cfg.get("moonraker_url", "")
+    if not moonraker_url:
+        logger.debug("AFC %s: skipped lane data for %s — moonraker_url not configured", source, lane_name)
+        return
+
     _send_afc_lane_data(
         moonraker_url,
         lane_name,

--- a/middleware/publishers/klipper.py
+++ b/middleware/publishers/klipper.py
@@ -24,7 +24,6 @@ import re
 
 import requests
 
-import app_state
 from publishers.base import Action, Publisher, SpoolEvent
 
 logger = logging.getLogger(__name__)
@@ -75,6 +74,7 @@ def _send_gcode(moonraker: str, script: str) -> None:
 
 
 def _send_afc_lane_data(
+    moonraker: str,
     toolhead: str,
     color_hex: str,
     material: str,
@@ -87,7 +87,6 @@ def _send_afc_lane_data(
     and weight from tag data so LEDs and lane info work without Spoolman.
     Each command is independent — if one fails, the others still run.
     """
-    moonraker = app_state.cfg.get("moonraker_url", "")
     if not moonraker:
         return
 
@@ -119,6 +118,7 @@ def _send_afc_lane_data(
 
 
 def _send_toolhead_tag_data(
+    moonraker: str,
     target: str,
     color_hex: str,
     material: str,
@@ -130,7 +130,6 @@ def _send_toolhead_tag_data(
     Used when Spoolman is not available — provides the toolhead macro with
     color from tag data so slicer integration still works without Spoolman.
     """
-    moonraker = app_state.cfg.get("moonraker_url", "")
     if not moonraker or not target:
         return
 
@@ -159,11 +158,7 @@ def _publish_toolhead_lane_data(moonraker: str, event: SpoolEvent) -> None:
     AFC writes lane_data for its own lanes internally. For direct toolhead
     assignments (T0, T1, etc.), there is no AFC — so we write to the same
     namespace so Orca Slicer and other slicers see the tool's filament info.
-
-    Gated by publish_lane_data config flag (opt-in).
     """
-    if not app_state.cfg.get("publish_lane_data", False):
-        return
     if not moonraker or not event.target:
         return
 
@@ -305,6 +300,7 @@ class KlipperPublisher(Publisher):
             logger.info(f"[afc_lane] Set spool {event.spool_id} on {event.target} via AFC")
         else:
             _send_afc_lane_data(
+                moonraker,
                 event.target,
                 event.color or "",
                 event.material or "",
@@ -354,6 +350,7 @@ class KlipperPublisher(Publisher):
             logger.info(f"[toolhead] Activated spool {event.spool_id} on {event.target}")
         else:
             _send_toolhead_tag_data(
+                moonraker,
                 event.target,
                 event.color or "",
                 event.material or "",
@@ -364,6 +361,7 @@ class KlipperPublisher(Publisher):
         # and other slicers can auto-populate tool info. AFC handles this
         # internally for its lanes; for direct toolhead assignments we must
         # write it ourselves.
-        _publish_toolhead_lane_data(moonraker, event)
+        if self._config.get("publish_lane_data", False):
+            _publish_toolhead_lane_data(moonraker, event)
 
         return True

--- a/middleware/tests/test_afc_status.py
+++ b/middleware/tests/test_afc_status.py
@@ -99,7 +99,7 @@ class TestSyncLaneState(unittest.TestCase):
             with patch("afc_status._send_afc_lane_data") as mock_send:
                 with patch("afc_status.publish_lock"):
                     _sync_lane_state(data)
-                mock_send.assert_called_once_with("lane1", "FF0000", "PLA", 250.0)
+                mock_send.assert_called_once_with("http://moonraker:7125", "lane1", "FF0000", "PLA", 250.0)
         # pending_spool consumed
         assert app_state.pending_spool is None
 


### PR DESCRIPTION
## Summary
- `_send_afc_lane_data` and `_send_toolhead_tag_data` no longer read `moonraker_url` from the global `app_state.cfg` — they now take it as an explicit parameter, matching the DI pattern already used by `_send_gcode`.
- The `publish_lane_data` flag gate is hoisted from inside `_publish_toolhead_lane_data` up to the caller in `KlipperPublisher` — cleaner flow, no buried config reads.
- Removes the now-unused `import app_state` from `klipper.py`.

## Changes
- `middleware/publishers/klipper.py` — add `moonraker: str` first param to both helpers, move `publish_lane_data` gate to caller, drop `import app_state`
- `middleware/afc_status.py` — update external call to pass `moonraker_url` (caller still reads it from `app_state.cfg` since this module is internal to the state layer)
- `middleware/tests/test_afc_status.py` — update `assert_called_once_with` to include the new first arg

Closes #67

## Test plan
- [x] `pytest middleware/tests/test_klipper_publisher.py` — 35 pass, identical to baseline
- [x] Full suite: 345 pass, 20 pre-existing failures (test_filament_usage.py, test_spoolman_cache.py, test_config.py) — zero new failures
- [x] Ollama (qwen3-coder:30b) second-opinion review — no actionable findings; the one "CRITICAL" flag was a false positive (defensive `if not moonraker: return` guards already exist in every helper)
- [ ] Hardware verification: confirm AFC lane activation and toolhead dispatch still work end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal configuration handling for Moonraker URL and lane data publishing by restructuring how configuration values are passed between internal components.
  * Removed reliance on global state and replaced with explicit parameter passing throughout the publishing module, enhancing code maintainability and module isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->