### PR TITLE
Fix: Missing sync_from_klipper_vars import in mqtt_handler on_connect

### DIFF
--- a/middleware/mqtt_handler.py
+++ b/middleware/mqtt_handler.py
@@ -269,11 +269,11 @@ def on_connect(client: mqtt.Client, userdata: object, flags: dict, rc: int) -> N
     # Sync klipper variables for toolhead scanners (AFC uses afc_status.py instead)
     if has_toolhead_scanners(app_state.cfg):
         app_state.cfg["klipper_var_path"] = discover_klipper_var_path()
+        from var_watcher import start_klipper_watcher, sync_from_klipper_vars
         sync_from_klipper_vars()
         if app_state.watcher:
             app_state.watcher.stop()
             app_state.watcher.join(timeout=2)
-        from var_watcher import start_klipper_watcher
         app_state.watcher = start_klipper_watcher()
 
     # Re-publish AFC lock state so scanners know current state after reconnect

--- a/middleware/tests/test_mqtt_handler.py
+++ b/middleware/tests/test_mqtt_handler.py
@@ -41,6 +41,7 @@ from mqtt_handler import (  # noqa: E402
     _extract_scanner_device_id,
     _resolve_scanner_from_topic,
     _get_scanner_target,
+    on_connect,
 )
 
 
@@ -156,6 +157,23 @@ class TestGetScannerTarget(unittest.TestCase):
         scanner_cfg = {"action": "afc_lane", "lane": "lane2", "toolhead": "T0"}
         # lane is checked first via `or`
         assert _get_scanner_target(scanner_cfg) == "lane2"
+
+
+class TestOnConnect(unittest.TestCase):
+
+    def setUp(self):
+        _reset_app_state(
+            scanners={"f08538": {"action": "toolhead", "toolhead": "T0"}},
+        )
+        app_state.DISPATCHER_AVAILABLE = True
+        app_state.spoolman_client = None
+        app_state.watcher = None
+
+    def test_on_connect_toolhead_action_does_not_raise(self):
+        client = MagicMock()
+        with patch("mqtt_handler.discover_klipper_var_path", return_value="/tmp/x.cfg"):
+            on_connect(client, None, {}, 0)
+        client.subscribe.assert_called_once_with("spoolsense/f08538/tag/state")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `on_connect()` calls `sync_from_klipper_vars()` in the toolhead-scanner branch, but the import was dropped during a refactor in 8728b6e
- Every toolhead-mode install crashes with `NameError` on MQTT connect
- Moves the inline `var_watcher` import up one block and adds `sync_from_klipper_vars` alongside `start_klipper_watcher`
- Adds `TestOnConnect` regression test that reproduces the `NameError` when the import is omitted

## Test plan
- [x] Regression test added to `middleware/tests/test_mqtt_handler.py`
- [x] Verified test fails with the original code (reproduces NameError)
- [x] Verified test passes with the fix
- [x] Verified by user (@shallqs) on real toolhead-mode hardware — middleware no longer crashes on connect

Closes the crash referenced in #76 (the lock-state issue surfaced in #76 is unrelated and tracked there).