### PR TITLE
Release v1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to SpoolSense are documented here.
 
 ---
 
+## [1.7.2] - 2026-05-02
+
+### Fixed
+
+- **Klipper var path discovery never worked** — `discover_klipper_var_path()`
+  was hitting a non-existent Moonraker endpoint (`/printer/configfile/settings`)
+  and silently returning None. Toolhead-mode users have lost the Klipper
+  variables file watcher since the middleware was first written. Now uses
+  `/printer/objects/query?configfile=settings` and walks the nested response
+  shape correctly. (#77)
+- **Tilde-prefixed save_variables filename** — when Klipper reports
+  `~/printer_data/config/variables.cfg` (literal `~`), the path-resolution
+  logic produced a broken concatenated path. Now expands `~` before checking
+  absoluteness. (#77)
+- **Toolhead lock state machine** had three gaps preventing re-scan after a
+  spool swap (#76):
+  - Single-toolhead users: a Mainsail/Spoolman manual spool change
+    (non-null → non-null spool_id transition) now clears the lock and updates
+    tracked state. Multi-toolhead behavior unchanged.
+  - Scan-driven auto-release: when an incoming scan has a different UID from
+    the active spool AND Klipper is idle, the lock releases and the new scan
+    is processed normally. During a print, the lock holds.
+  - Lock log message now points users to recovery actions (Mainsail eject or
+    REST unlock).
+
+### Added
+
+- **`POST /api/unlock/{target}` REST endpoint** — explicit unlock for HA
+  automations and power users. Validates against configured scanner targets
+  to prevent `lane_locks` poisoning. Idempotent. (#76)
+
+### Thanks
+
+Big thanks to **PlasticSnake** (Discord) / **@shallqs** (GitHub) for the clean
+reproduction in #76 that drove the lock-path redesign.
+
+---
+
 ## [1.7.1] - 2026-05-02
 
 ### Fixed

--- a/middleware/config.py
+++ b/middleware/config.py
@@ -299,21 +299,34 @@ def discover_klipper_var_path() -> str | None:
     try:
         logger.info("Discovering Klipper save_variables path...")
         response = requests.get(
-            f"{app_state.cfg['moonraker_url']}/printer/configfile/settings", timeout=5
+            f"{app_state.cfg['moonraker_url']}/printer/objects/query?configfile=settings",
+            timeout=5,
         )
         response.raise_for_status()
-        settings = response.json().get("result", {}).get("settings", {})
-        filename = settings.get("save_variables", {}).get("filename")
+        # Defensive walk through the nested response — guard each level with
+        # isinstance(dict) so an unexpected Moonraker response shape returns
+        # None cleanly instead of raising AttributeError. (CodeRabbit #79)
+        cur: object = response.json()
+        for key in ("result", "status", "configfile", "settings", "save_variables", "filename"):
+            if not isinstance(cur, dict):
+                cur = None
+                break
+            cur = cur.get(key)
+        filename = cur if isinstance(cur, str) else None
 
         if not filename:
             logger.warning("No [save_variables] in Klipper config. Klipper sync disabled.")
             return None
 
+        # Klipper may report the path as `~/...` (literal tilde), absolute, or
+        # bare-relative. Expand `~` first so the absolute-path branch is taken
+        # when applicable; otherwise fall back to the default config dir.
+        filename = os.path.expanduser(filename)
         if not filename.startswith("/"):
             filename = os.path.join(os.path.expanduser("~/printer_data/config"), filename)
 
         logger.info(f"Discovered Klipper variables file: {filename}")
         return filename
-    except Exception as e:
-        logger.error(f"Failed to discover Klipper variables path: {e}")
+    except (requests.RequestException, ValueError):
+        logger.exception("Failed to discover Klipper variables path")
         return None

--- a/middleware/mqtt_handler.py
+++ b/middleware/mqtt_handler.py
@@ -15,6 +15,7 @@ import logging
 from typing import TYPE_CHECKING
 
 import paho.mqtt.client as mqtt
+import requests
 
 import app_state
 from activation import activate_spool, publish_lock, _activate_from_scan
@@ -282,6 +283,61 @@ def on_connect(client: mqtt.Client, userdata: object, flags: dict, rc: int) -> N
         resync_lock_state()
 
 
+def _is_printer_idle() -> bool:
+    """
+    Returns True when Klipper reports `print_stats.state == "standby"`.
+    Returns False on any other state or on fetch failure — treat unknown as
+    busy so we never auto-release a lock during a print.
+    """
+    moonraker_url = app_state.cfg.get("moonraker_url", "")
+    if not moonraker_url:
+        return False
+    try:
+        response = requests.get(
+            f"{moonraker_url}/printer/objects/query?print_stats",
+            timeout=2,
+        )
+        response.raise_for_status()
+        state = (
+            response.json()
+            .get("result", {})
+            .get("status", {})
+            .get("print_stats", {})
+            .get("state", "")
+        )
+        return state == "standby"
+    except (requests.RequestException, ValueError):
+        logger.debug("Could not query Klipper print state; treating as busy")
+        return False
+
+
+def _should_auto_release_lock(target: str, payload: dict) -> bool:
+    """
+    Decide whether a locked target should auto-release for an incoming scan.
+
+    Auto-release happens when:
+      - Incoming UID is known and differs from the currently-active UID
+      - Klipper is idle (print_stats.state == "standby")
+
+    Same-UID re-scans are ignored without auto-release. UID-less payloads
+    (e.g. tag-removed events) leave the lock in place.
+    """
+    incoming_uid = (payload.get("uid") or "").lower()
+    if not incoming_uid:
+        return False
+
+    # Snapshot active UID under state_lock before the network I/O in
+    # _is_printer_idle() — avoids a race window where the active spool
+    # could change while we're querying Klipper.
+    with app_state.state_lock:
+        active_uid = (app_state.active_spool_uids.get(target) or "").lower()
+
+    if active_uid and incoming_uid == active_uid:
+        return False
+
+    return _is_printer_idle()
+
+
 def on_message(client: mqtt.Client, userdata: object, msg: mqtt.MQTTMessage) -> None:
     """Fires on every MQTT message. Resolves scanner, checks lock, routes to handler."""
     try:
@@ -296,8 +352,36 @@ def on_message(client: mqtt.Client, userdata: object, msg: mqtt.MQTTMessage) -> 
         # Shared scanners (afc_stage/toolhead_stage) have no target to lock
         target = _get_scanner_target(scanner_cfg)
         if target and app_state.lane_locks.get(target):
-            logger.info(f"Ignoring scan on {target} (locked)")
-            return
+            if _should_auto_release_lock(target, payload):
+                # _should_auto_release_lock did network I/O (~2s); re-verify
+                # under state_lock to close the TOCTOU window before writing.
+                # (CodeRabbit #79)
+                incoming_uid = (payload.get("uid") or "").lower()
+                released = False
+                active_uid = ""
+                with app_state.state_lock:
+                    if app_state.lane_locks.get(target):
+                        active_uid = (app_state.active_spool_uids.get(target) or "").lower()
+                        if not active_uid or active_uid != incoming_uid:
+                            app_state.lane_locks[target] = False
+                            released = True
+                if released:
+                    logger.info(
+                        f"Lock auto-release on {target}: idle printer, swap "
+                        f"{active_uid or '?'} → {incoming_uid}"
+                    )
+                    # Fall through to normal scan processing
+                else:
+                    logger.debug(
+                        f"Lock auto-release aborted on {target}: state changed mid-check"
+                    )
+                    return
+            else:
+                logger.info(
+                    f"Ignoring scan on {target} (locked). To unlock: eject the spool "
+                    f"in Mainsail, or POST /api/unlock/{target} on the middleware REST API."
+                )
+                return
 
         if not app_state.DISPATCHER_AVAILABLE:
             logger.warning("Rich-tag dispatcher not available — cannot process scanner payload")

--- a/middleware/rest_api.py
+++ b/middleware/rest_api.py
@@ -110,6 +110,56 @@ def get_status() -> dict[str, Any]:
     }
 
 
+def _configured_targets() -> set[str]:
+    """All `lane`/`toolhead` values present in scanner config — what the lock
+    gate keys off. Used to validate unlock requests so callers can't poison
+    `lane_locks` with arbitrary keys."""
+    targets: set[str] = set()
+    for s in app_state.cfg.get("scanners", {}).values():
+        if isinstance(s, dict):
+            t = s.get("lane") or s.get("toolhead")
+            if t:
+                targets.add(t)
+    return targets
+
+
+@app.post("/api/unlock/{target}", response_model=ApiResponse)
+def unlock_target(target: str) -> ApiResponse:
+    """
+    Explicit unlock for a locked toolhead or AFC lane (#76).
+
+    Use cases:
+      - HA automation that wants to drop the lock on a button press
+      - User stuck in the lock-out scenario where idle-detection didn't fire
+      - Power users scripting against the middleware
+
+    Idempotent: unlocking an already-unlocked target returns success.
+    """
+    if target not in _configured_targets():
+        raise HTTPException(
+            status_code=404,
+            detail=f"Unknown target '{target}'. Configured targets: "
+                   f"{sorted(_configured_targets())}",
+        )
+
+    with app_state.state_lock:
+        was_locked = bool(app_state.lane_locks.get(target))
+        app_state.lane_locks[target] = False
+
+    if was_locked:
+        logger.info(f"REST API: explicit unlock for {target}")
+        return ApiResponse(
+            success=True,
+            message=f"Unlocked {target}",
+            toolhead=target,
+        )
+    return ApiResponse(
+        success=True,
+        message=f"{target} was already unlocked",
+        toolhead=target,
+    )
+
+
 @app.post("/api/mobile-scan", response_model=ApiResponse)
 def mobile_scan(req: MobileScanRequest) -> ApiResponse:
     mobile_cfg = app_state.cfg.get("mobile", {})

--- a/middleware/spoolsense.py
+++ b/middleware/spoolsense.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
-__version__ = "1.7.1"
+__version__ = "1.7.2"
 """
 SpoolSense NFC Middleware
 =========================

--- a/middleware/tests/test_config.py
+++ b/middleware/tests/test_config.py
@@ -16,10 +16,17 @@ sys.modules.setdefault("watchdog", MagicMock())
 sys.modules.setdefault("watchdog.observers", MagicMock())
 sys.modules.setdefault("watchdog.events", MagicMock())
 
+from unittest.mock import patch  # noqa: E402
+
+import requests  # noqa: E402
+
+import app_state  # noqa: E402
+
 from config import (  # noqa: E402
     _validate_scanners,
     _derive_toolheads,
     _migrate_legacy_config,
+    discover_klipper_var_path,
     has_afc_scanners,
     has_toolhead_scanners,
     has_toolhead_stage_scanners,
@@ -279,6 +286,100 @@ class TestHasScannerFunctions(unittest.TestCase):
         assert has_afc_scanners(config) is True
         assert has_toolhead_scanners(config) is True
         assert has_toolhead_stage_scanners(config) is True
+
+
+class TestDiscoverKlipperVarPath(unittest.TestCase):
+    """Verifies discover_klipper_var_path() hits the correct Moonraker endpoint
+    and parses the response shape correctly (#77)."""
+
+    def setUp(self):
+        app_state.cfg = {"moonraker_url": "http://moonraker:7125"}
+
+    def _moonraker_response(self, filename: str | None) -> MagicMock:
+        save_variables = {"filename": filename} if filename is not None else {}
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json = MagicMock(return_value={
+            "result": {
+                "status": {
+                    "configfile": {
+                        "settings": {
+                            "save_variables": save_variables,
+                        }
+                    }
+                }
+            }
+        })
+        return resp
+
+    def test_uses_correct_moonraker_endpoint(self):
+        with patch("config.requests.get") as mock_get:
+            mock_get.return_value = self._moonraker_response("/home/pi/printer_data/config/variables.cfg")
+            discover_klipper_var_path()
+            args, kwargs = mock_get.call_args
+            assert "printer/objects/query?configfile=settings" in args[0], args[0]
+
+    def test_parses_absolute_filename(self):
+        with patch("config.requests.get") as mock_get:
+            mock_get.return_value = self._moonraker_response("/home/pi/printer_data/config/variables.cfg")
+            result = discover_klipper_var_path()
+            assert result == "/home/pi/printer_data/config/variables.cfg"
+
+    def test_relative_filename_resolved_to_default_config_dir(self):
+        with patch("config.requests.get") as mock_get:
+            mock_get.return_value = self._moonraker_response("variables.cfg")
+            result = discover_klipper_var_path()
+            assert result.endswith("/printer_data/config/variables.cfg")
+
+    def test_tilde_filename_expanded_to_home(self):
+        # Klipper's configfile.settings can report paths with a literal `~`.
+        # Without expansion, os.path.join with the default config dir produces
+        # a broken concatenated path (verified against a real toolchanger
+        # printer reporting `~/printer_data/config/...`).
+        with patch("config.requests.get") as mock_get:
+            mock_get.return_value = self._moonraker_response("~/printer_data/config/variables.cfg")
+            result = discover_klipper_var_path()
+            assert result == os.path.expanduser("~/printer_data/config/variables.cfg")
+            assert "~" not in result
+            assert result.startswith("/")
+
+    def test_missing_save_variables_returns_none(self):
+        with patch("config.requests.get") as mock_get:
+            mock_get.return_value = self._moonraker_response(None)
+            assert discover_klipper_var_path() is None
+
+    def test_network_failure_returns_none(self):
+        with patch("config.requests.get", side_effect=requests.ConnectionError("connection refused")):
+            assert discover_klipper_var_path() is None
+
+    def test_http_error_returns_none(self):
+        with patch("config.requests.get") as mock_get:
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock(side_effect=requests.HTTPError("404"))
+            mock_get.return_value = resp
+            assert discover_klipper_var_path() is None
+
+    def test_invalid_json_returns_none(self):
+        with patch("config.requests.get") as mock_get:
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            resp.json = MagicMock(side_effect=ValueError("not json"))
+            mock_get.return_value = resp
+            assert discover_klipper_var_path() is None
+
+    def test_unexpected_exception_propagates(self):
+        # Programming errors (KeyError, AttributeError) should NOT be silently
+        # swallowed — they indicate bugs we want to surface, not hide.
+        with patch("config.requests.get", side_effect=KeyError("config")):
+            with self.assertRaises(KeyError):
+                discover_klipper_var_path()
+
+    def test_returns_cached_path_without_querying_moonraker(self):
+        app_state.cfg["klipper_var_path"] = "/cached/path/variables.cfg"
+        with patch("config.requests.get") as mock_get:
+            result = discover_klipper_var_path()
+            assert result == "/cached/path/variables.cfg"
+            mock_get.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/middleware/tests/test_mqtt_handler.py
+++ b/middleware/tests/test_mqtt_handler.py
@@ -39,9 +39,12 @@ app_state.DISPATCHER_AVAILABLE = False
 
 from mqtt_handler import (  # noqa: E402
     _extract_scanner_device_id,
+    _is_printer_idle,
     _resolve_scanner_from_topic,
     _get_scanner_target,
+    _should_auto_release_lock,
     on_connect,
+    on_message,
 )
 
 
@@ -54,6 +57,7 @@ def _reset_app_state(prefix="spoolsense", scanners=None):
     }
     app_state.lane_locks = {}
     app_state.active_spools = {}
+    app_state.active_spool_uids = {}
     app_state.pending_spool = None
     app_state.state_lock = threading.Lock()
 
@@ -174,6 +178,163 @@ class TestOnConnect(unittest.TestCase):
         with patch("mqtt_handler.discover_klipper_var_path", return_value="/tmp/x.cfg"):
             on_connect(client, None, {}, 0)
         client.subscribe.assert_called_once_with("spoolsense/f08538/tag/state")
+
+
+class TestIsPrinterIdle(unittest.TestCase):
+    """Verifies the Klipper print-state probe used as a safety guard before
+    auto-releasing a toolhead lock. Idle = standby; everything else (including
+    fetch failure) is treated as busy."""
+
+    def setUp(self):
+        _reset_app_state()
+
+    def _resp(self, state: str) -> MagicMock:
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json = MagicMock(return_value={
+            "result": {"status": {"print_stats": {"state": state}}}
+        })
+        return resp
+
+    def test_returns_true_when_standby(self):
+        with patch("mqtt_handler.requests.get") as mock_get:
+            mock_get.return_value = self._resp("standby")
+            assert _is_printer_idle() is True
+
+    def test_returns_false_when_printing(self):
+        with patch("mqtt_handler.requests.get") as mock_get:
+            mock_get.return_value = self._resp("printing")
+            assert _is_printer_idle() is False
+
+    def test_returns_false_when_paused(self):
+        with patch("mqtt_handler.requests.get") as mock_get:
+            mock_get.return_value = self._resp("paused")
+            assert _is_printer_idle() is False
+
+    def test_returns_false_on_network_error(self):
+        import requests
+        with patch("mqtt_handler.requests.get", side_effect=requests.ConnectionError("boom")):
+            assert _is_printer_idle() is False
+
+    def test_returns_false_when_no_moonraker_url(self):
+        app_state.cfg["moonraker_url"] = ""
+        assert _is_printer_idle() is False
+
+
+class TestShouldAutoReleaseLock(unittest.TestCase):
+    """Decision logic for whether a locked target releases on an incoming scan."""
+
+    def setUp(self):
+        _reset_app_state()
+        app_state.active_spool_uids["T0"] = "abc123"
+
+    def test_same_uid_does_not_auto_release(self):
+        # Same tag scanned twice — no swap intent, lock stays
+        with patch("mqtt_handler._is_printer_idle", return_value=True):
+            assert _should_auto_release_lock("T0", {"uid": "abc123"}) is False
+
+    def test_same_uid_case_insensitive(self):
+        with patch("mqtt_handler._is_printer_idle", return_value=True):
+            assert _should_auto_release_lock("T0", {"uid": "ABC123"}) is False
+
+    def test_no_uid_does_not_auto_release(self):
+        # Tag-removed event or empty payload — leave lock alone
+        with patch("mqtt_handler._is_printer_idle", return_value=True):
+            assert _should_auto_release_lock("T0", {"uid": None}) is False
+            assert _should_auto_release_lock("T0", {}) is False
+
+    def test_different_uid_idle_releases(self):
+        with patch("mqtt_handler._is_printer_idle", return_value=True):
+            assert _should_auto_release_lock("T0", {"uid": "DIFFER"}) is True
+
+    def test_different_uid_busy_holds_lock(self):
+        with patch("mqtt_handler._is_printer_idle", return_value=False):
+            assert _should_auto_release_lock("T0", {"uid": "DIFFER"}) is False
+
+    def test_different_uid_idle_releases_when_no_active_uid_tracked(self):
+        # Edge: lock is set but tracking is empty (e.g. lock set without
+        # _record_spool_tracking running). Different incoming UID + idle
+        # printer should still release.
+        app_state.active_spool_uids = {}
+        with patch("mqtt_handler._is_printer_idle", return_value=True):
+            assert _should_auto_release_lock("T0", {"uid": "anything"}) is True
+
+
+class TestOnMessageLockBehavior(unittest.TestCase):
+    """End-to-end on_message lock-gate behavior covering #76 repros."""
+
+    def setUp(self):
+        _reset_app_state(
+            scanners={"f08538": {"action": "toolhead", "toolhead": "T0"}},
+        )
+        app_state.DISPATCHER_AVAILABLE = True
+        app_state.lane_locks["T0"] = True
+        app_state.active_spool_uids["T0"] = "abc123"
+
+    def _msg(self, uid: str | None) -> MagicMock:
+        m = MagicMock()
+        body = {"uid": uid} if uid is not None else {}
+        m.payload = MagicMock()
+        m.payload.decode = MagicMock(return_value=__import__("json").dumps(body))
+        m.topic = "spoolsense/f08538/tag/state"
+        return m
+
+    def test_locked_same_uid_is_dropped(self):
+        # Same tag rescanned — no auto-release, no further processing
+        with patch("mqtt_handler._is_printer_idle", return_value=True), \
+             patch("mqtt_handler._handle_rich_tag") as mock_handle:
+            on_message(MagicMock(), None, self._msg("abc123"))
+            mock_handle.assert_not_called()
+        assert app_state.lane_locks["T0"] is True
+
+    def test_locked_different_uid_idle_auto_releases_and_processes(self):
+        # The #76 repro: scan A is locked, scan B is different UID, printer idle.
+        # Should release the lock and fall through to _handle_rich_tag.
+        with patch("mqtt_handler._is_printer_idle", return_value=True), \
+             patch("mqtt_handler._handle_rich_tag") as mock_handle:
+            on_message(MagicMock(), None, self._msg("DIFFER"))
+            mock_handle.assert_called_once()
+        assert app_state.lane_locks["T0"] is False
+
+    def test_locked_different_uid_printing_holds_lock(self):
+        # Stray scan during a print — lock holds, scan dropped.
+        with patch("mqtt_handler._is_printer_idle", return_value=False), \
+             patch("mqtt_handler._handle_rich_tag") as mock_handle:
+            on_message(MagicMock(), None, self._msg("DIFFER"))
+            mock_handle.assert_not_called()
+        assert app_state.lane_locks["T0"] is True
+
+    def test_unlocked_scan_processes_normally(self):
+        # Baseline: no lock means we always process.
+        app_state.lane_locks["T0"] = False
+        with patch("mqtt_handler._handle_rich_tag") as mock_handle:
+            on_message(MagicMock(), None, self._msg("anything"))
+            mock_handle.assert_called_once()
+
+    def test_locked_blank_tag_idle_releases_and_handler_called(self):
+        # Edge: incoming scan has a different UID but is a blank tag. The
+        # auto-release logic only knows the UID at this stage — it can't tell
+        # the tag is unusable. Expected: lock released, _handle_rich_tag is
+        # invoked (where it would log the blank tag and return without
+        # re-locking). End state is unlocked-with-no-active-spool, which is
+        # acceptable: the user clearly removed the original tag.
+        import json
+        blank_payload = {
+            "uid": "BLANK01",
+            "present": True,
+            "tag_data_valid": False,
+            "blank": True,
+        }
+        msg = MagicMock()
+        msg.payload = MagicMock()
+        msg.payload.decode = MagicMock(return_value=json.dumps(blank_payload))
+        msg.topic = "spoolsense/f08538/tag/state"
+
+        with patch("mqtt_handler._is_printer_idle", return_value=True), \
+             patch("mqtt_handler._handle_rich_tag") as mock_handle:
+            on_message(MagicMock(), None, msg)
+            mock_handle.assert_called_once()
+        assert app_state.lane_locks["T0"] is False
 
 
 if __name__ == "__main__":

--- a/middleware/tests/test_rest_api.py
+++ b/middleware/tests/test_rest_api.py
@@ -267,5 +267,53 @@ class TestAssignTool(unittest.TestCase):
         self.assertEqual(resp.json()["spool_id"], 42)
 
 
+class TestUnlockTarget(unittest.TestCase):
+    """POST /api/unlock/{target} — explicit unlock for #76."""
+
+    def setUp(self):
+        _reset_app_state()
+        # Mix of toolhead + AFC scanners so we cover both target kinds
+        app_state.cfg["scanners"] = {
+            "ecb338": {"action": "afc_lane", "lane": "lane1"},
+            "f08538": {"action": "toolhead", "toolhead": "T0"},
+        }
+
+    def test_unlocks_locked_target(self):
+        app_state.lane_locks["T0"] = True
+        resp = client.post("/api/unlock/T0")
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertTrue(body["success"])
+        self.assertEqual(body["toolhead"], "T0")
+        self.assertFalse(app_state.lane_locks["T0"])
+
+    def test_idempotent_when_already_unlocked(self):
+        app_state.lane_locks["T0"] = False
+        resp = client.post("/api/unlock/T0")
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.json()["success"])
+        self.assertIn("already unlocked", resp.json()["message"])
+
+    def test_works_for_afc_lane_target(self):
+        app_state.lane_locks["lane1"] = True
+        resp = client.post("/api/unlock/lane1")
+        self.assertEqual(resp.status_code, 200)
+        self.assertFalse(app_state.lane_locks["lane1"])
+
+    def test_unknown_target_returns_404(self):
+        # Targets not present in the scanner config are rejected — prevents
+        # callers from poisoning lane_locks with arbitrary keys
+        resp = client.post("/api/unlock/T99")
+        self.assertEqual(resp.status_code, 404)
+        self.assertIn("Unknown target", resp.json()["detail"])
+
+    def test_does_not_touch_other_targets(self):
+        app_state.lane_locks["T0"] = True
+        app_state.lane_locks["lane1"] = True
+        client.post("/api/unlock/T0")
+        self.assertFalse(app_state.lane_locks["T0"])
+        self.assertTrue(app_state.lane_locks["lane1"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/middleware/tests/test_toolhead_status.py
+++ b/middleware/tests/test_toolhead_status.py
@@ -170,15 +170,55 @@ class TestCheckTransition(unittest.TestCase):
         self.assertEqual(sync._last_spool_id, 12)
 
     @patch("toolhead_status.publish_lock")
-    def test_global_spool_change_does_not_clear_locks(self, mock_publish_lock: MagicMock) -> None:
-        # Spool changed from one ID to another (e.g., different tool activated in Mainsail).
-        # This is NOT an eject — do not touch any locks.
+    def test_global_spool_change_multi_toolhead_does_not_clear_locks(self, mock_publish_lock: MagicMock) -> None:
+        # Multi-toolhead config: spool changed from one ID to another (e.g., a
+        # different tool activated in Mainsail). Ambiguous — could be a different
+        # tool getting assigned. Do not touch any locks.
+        app_state.cfg["scanners"] = {
+            "scanner_t0": {"action": "toolhead", "toolhead": "T0"},
+            "scanner_t1": {"action": "toolhead", "toolhead": "T1"},
+        }
         app_state.active_spools["T0"] = 3
+        app_state.lane_locks["T0"] = True
         sync = self._make_sync(last_spool_id=3)
 
         sync._check_transition(9)
 
         mock_publish_lock.assert_not_called()
+
+    @patch("toolhead_status.publish_lock")
+    def test_global_spool_change_single_toolhead_clears_lock(self, mock_publish_lock: MagicMock) -> None:
+        # Single-toolhead config: spool swap (e.g., Mainsail UI change) is
+        # authoritative — there's only one slot, so clear the lock and update
+        # active_spools so the next scan can go through (#76).
+        app_state.cfg["scanners"] = {
+            "scanner_t0": {"action": "toolhead", "toolhead": "T0"},
+        }
+        app_state.active_spools["T0"] = 3
+        app_state.lane_locks["T0"] = True
+        sync = self._make_sync(last_spool_id=3)
+
+        sync._check_transition(9)
+
+        mock_publish_lock.assert_called_once_with("T0", "clear")
+        self.assertEqual(app_state.active_spools["T0"], 9)
+
+    @patch("toolhead_status.publish_lock")
+    def test_global_spool_change_single_toolhead_no_lock_to_clear(self, mock_publish_lock: MagicMock) -> None:
+        # Single-toolhead, but the toolhead isn't locked — transition does not
+        # try to clear a lock that isn't there, BUT it still updates tracked
+        # active_spools so consecutive Mainsail swaps stay consistent.
+        app_state.cfg["scanners"] = {
+            "scanner_t0": {"action": "toolhead", "toolhead": "T0"},
+        }
+        app_state.active_spools["T0"] = 3
+        app_state.lane_locks["T0"] = False
+        sync = self._make_sync(last_spool_id=3)
+
+        sync._check_transition(9)
+
+        mock_publish_lock.assert_not_called()
+        self.assertEqual(app_state.active_spools["T0"], 9)
 
     @patch("toolhead_status.publish_lock")
     def test_eject_with_no_matching_toolhead_clears_lane_locks(self, mock_publish_lock: MagicMock) -> None:

--- a/middleware/toolhead_status.py
+++ b/middleware/toolhead_status.py
@@ -193,9 +193,52 @@ class ToolheadStatusSync:
             logger.info(f"Toolhead status: active spool changed to #{current_spool_id}")
 
         elif prev != current_spool_id and prev is not None and current_spool_id is not None:
-            # Global spool_id changed from one spool to another. In multi-toolhead
-            # setups this happens when a different tool is assigned — does NOT mean
-            # the previous tool's spool was ejected. Do not clear any locks.
-            logger.debug(
-                f"Toolhead status: global spool changed #{prev} → #{current_spool_id} (no lock change)"
-            )
+            # Global spool_id changed from one spool to another. On multi-toolhead
+            # setups this is ambiguous (could be a different tool getting assigned),
+            # so we don't touch locks. On single-toolhead there's only one slot —
+            # the swap is authoritative, so clear the lock so the user's next scan
+            # gets through (#76).
+            if _is_single_toolhead_setup():
+                target = _single_toolhead_target()
+                if target:
+                    with app_state.state_lock:
+                        was_locked = bool(app_state.lane_locks.get(target))
+                        if was_locked:
+                            publish_lock(target, "clear")
+                        # Track the new spool_id regardless of lock state so
+                        # consecutive Mainsail swaps stay consistent.
+                        app_state.active_spools[target] = current_spool_id
+                    if was_locked:
+                        logger.info(
+                            f"Toolhead status: single-toolhead spool swap #{prev} → "
+                            f"#{current_spool_id}, clearing lock on {target}"
+                        )
+                    else:
+                        logger.debug(
+                            f"Toolhead status: single-toolhead spool swap #{prev} → "
+                            f"#{current_spool_id} (no lock to clear)"
+                        )
+            else:
+                logger.debug(
+                    f"Toolhead status: global spool changed #{prev} → #{current_spool_id} (no lock change)"
+                )
+
+
+def _toolhead_targets() -> set[str]:
+    """Distinct toolhead targets (T0, T1, ...) from `toolhead`-action scanners."""
+    return {
+        s["toolhead"]
+        for s in app_state.cfg.get("scanners", {}).values()
+        if isinstance(s, dict) and s.get("action") == "toolhead" and s.get("toolhead")
+    }
+
+
+def _is_single_toolhead_setup() -> bool:
+    """True if the config has exactly one toolhead-action target."""
+    return len(_toolhead_targets()) == 1
+
+
+def _single_toolhead_target() -> str | None:
+    """Returns the single toolhead target if there is exactly one, else None."""
+    targets = _toolhead_targets()
+    return next(iter(targets)) if len(targets) == 1 else None


### PR DESCRIPTION
v1.7.2 — bugfix release for Klipper variable file discovery and toolhead unlock paths.

## Fixed
- Klipper var path discovery hit a non-existent Moonraker endpoint and silently failed for toolhead users (#77)
- Tilde-prefixed save_variables filename produced a broken concatenated path (#77)
- Toolhead lock state machine had three gaps that prevented re-scanning after a spool swap (#76):
  - Single-toolhead Mainsail/Spoolman swap now clears the lock
  - Scan-driven auto-release with print-state guard (idle → swap, printing → hold)
  - Improved lock log message points users to recovery actions

## Added
- `POST /api/unlock/{target}` REST endpoint for HA automations and power users (#76)

## Test plan
- [x] 33 new tests, full suite passes (130 / 1 pre-existing fail)
- [x] Senior code review + CodeRabbit findings addressed
- [x] Live deploy on a real printer — clean startup, REST endpoint works as designed

Closes #77.
Lock-path fixes in #76 — issue stays open pending real-hardware verification by the original reporter.