### PR TITLE
Release v1.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to SpoolSense are documented here.
 
 ---
 
+## [1.7.3] - 2026-05-10
+
+### Added
+
+- **Happy Hare MMU integration (pull mode)** — new `happy_hare_stage`
+  scanner action for shared scanners used with Happy Hare-managed MMUs
+  (ERCF, etc.). Workflow: user selects an MMU gate via
+  `MMU_SELECT_GATE GATE=N`, then scans a tag. The middleware reads the
+  selected gate from Moonraker, PATCHes the spool's `extra.mmu_gate` and
+  `extra.printer_name` in Spoolman, then fires `MMU_SPOOLMAN SYNC=1` so
+  Happy Hare picks up the binding immediately. Pull mode is auto-detected
+  via `printer.mmu.spoolman_support` — no config knob. Config example at
+  `middleware/config.example.happy_hare.yaml`.
+- **`SpoolmanClient.update_spool_extras()`** — narrow PATCH helper for
+  writing declared extra fields on a spool. Used only by the Happy Hare
+  integration. Values are JSON-encoded per Spoolman's on-disk format.
+
+---
+
 ## [1.7.2] - 2026-05-02
 
 ### Fixed

--- a/middleware/activation.py
+++ b/middleware/activation.py
@@ -135,6 +135,17 @@ def _route_staged(action_enum: Action, spoolman_activated: bool,
         logger.info(f"[{stage_name}] Tag data cached, waiting for assignment. Scanner remains unlocked")
 
 
+def _route_happy_hare(spoolman_id: int | None) -> None:
+    """Handle happy_hare_stage — bind the scanned spool to the currently-selected
+    MMU gate via Spoolman extras + Happy Hare sync trigger. No lock, no cache."""
+    if spoolman_id is None:
+        logger.warning("[happy_hare_stage] No Spoolman ID for scan — cannot bind to MMU gate. "
+                       "The scanned tag must be registered in Spoolman first.")
+        return
+    from happy_hare import bind_spool_to_current_gate
+    bind_spool_to_current_gate(spoolman_id)
+
+
 def _route_dedicated(action_enum: Action, spoolman_activated: bool,
                      spoolman_id: int | None, target: str, event: SpoolEvent) -> None:
     """Handle afc_lane and toolhead — lock after activation or tag-only publish."""
@@ -210,6 +221,14 @@ def _activate_from_scan(
 
     event = _build_spool_event(scanner_cfg, action_enum, target, spoolman_id,
                                color_hex, filament_label, remaining, scan)
+
+    # Happy Hare has its own binding path — skip the generic publisher chain
+    # so a no-op publisher call doesn't burn a round trip for every scan.
+    if action_enum == Action.HAPPY_HARE_STAGE:
+        _route_happy_hare(spoolman_id)
+        if remaining is not None and remaining <= app_state.cfg["low_spool_threshold"]:
+            logger.warning(f"Low spool: {filament_label} ({remaining:.1f}g) on {target or 'staged'}")
+        return
 
     # Attempt Spoolman activation if we have a spool ID
     spoolman_activated = False

--- a/middleware/config.example.happy_hare.yaml
+++ b/middleware/config.example.happy_hare.yaml
@@ -1,0 +1,63 @@
+# =============================================================
+# SpoolSense NFC Middleware — Configuration (Happy Hare MMU)
+# =============================================================
+# Copy this file to ~/SpoolSense/config.yaml and fill in your values.
+#
+#   cp config.example.happy_hare.yaml ~/SpoolSense/config.yaml
+#
+# This config is for Happy Hare MMU users running in pull mode.
+# Workflow:
+#   1. Select an MMU gate (MMU_SELECT_GATE GATE=N) in Mainsail / LCD
+#   2. Scan a tag on the shared scanner
+#   3. The middleware reads the selected gate from Moonraker, writes
+#      mmu_gate + printer_name to the spool's Spoolman extras, then
+#      fires MMU_SPOOLMAN SYNC=1 so Happy Hare picks up the binding
+#      immediately.
+#
+# Pull mode is required. Happy Hare reports its mode via printer.mmu
+# .spoolman_support — the middleware queries it and refuses to bind
+# in push or readonly mode (use MMU_GATE_MAP NEXT_SPOOLID=... there).
+# =============================================================
+
+# ---- MQTT Broker --------------------------------------------
+mqtt:
+  broker: "YOUR_HOME_ASSISTANT_IP"
+  port: 1883
+  username: "your_mqtt_username"
+  password: "your_mqtt_password"
+
+# ---- Spoolman URL (required for Happy Hare integration) -----
+spoolman_url: "http://YOUR_SPOOLMAN_IP:7912"
+
+# ---- Moonraker URL ------------------------------------------
+moonraker_url: "http://YOUR_KLIPPER_IP"
+
+# ---- Low Spool Threshold ------------------------------------
+low_spool_threshold: 100
+
+# ---- Happy Hare integration ---------------------------------
+#
+# Prerequisite: declare these extra fields in Spoolman before the first bind:
+#   Settings → Extra Fields → Spool → Add
+#     - key: mmu_gate       type: integer
+#     - key: printer_name   type: text
+# Without these declared, the PATCH will fail with HTTP 400 "Unknown extra
+# field X." (the error body is logged so you can see which field is missing).
+happy_hare:
+  enabled: true
+  # Written to each spool's extra.printer_name in Spoolman. Happy Hare uses
+  # this to identify which spools belong to this printer when syncing from
+  # Spoolman. Typically matches the "Printer Name" set in Happy Hare's
+  # mmu_parameters.cfg, but the middleware does not enforce that — anything
+  # consistent with how you've configured Happy Hare will work.
+  printer_name: "YOUR_PRINTER_NAME"
+
+# ---- Scanners ------------------------------------------------
+# One shared scanner, used to bind any spool to whichever gate the user
+# has currently selected. No `lane` or `toolhead` field — happy_hare_stage
+# is a shared (untargeted) action.
+scanners:
+  "YOUR_DEVICE_ID":
+    action: "happy_hare_stage"
+
+scanner_topic_prefix: "spoolsense"

--- a/middleware/config.py
+++ b/middleware/config.py
@@ -18,7 +18,9 @@ logger = logging.getLogger(__name__)
 
 CONFIG_PATH: str = os.path.expanduser("~/SpoolSense/config.yaml")
 
-VALID_ACTIONS: tuple[str, ...] = ("afc_stage", "afc_lane", "toolhead", "toolhead_stage")
+VALID_ACTIONS: tuple[str, ...] = (
+    "afc_stage", "afc_lane", "toolhead", "toolhead_stage", "happy_hare_stage",
+)
 
 DEFAULTS: dict = {
     "mqtt": {
@@ -146,7 +148,7 @@ def _validate_scanners(config: dict) -> None:
         elif action == "toolhead":
             _validate_targeted_scanner(device_id, scanner_cfg, action, "toolhead", "lane", toolheads_list)
 
-        elif action in ("afc_stage", "toolhead_stage"):
+        elif action in ("afc_stage", "toolhead_stage", "happy_hare_stage"):
             # Shared scanners have no target — lane/toolhead fields are invalid
             if "lane" in scanner_cfg or "toolhead" in scanner_cfg:
                 _config_error(
@@ -200,6 +202,15 @@ def has_toolhead_stage_scanners(config: dict) -> bool:
     """Returns True if any scanner has a toolhead_stage action."""
     return any(
         s.get("action") == "toolhead_stage"
+        for s in config.get("scanners", {}).values()
+        if isinstance(s, dict)
+    )
+
+
+def has_happy_hare_scanners(config: dict) -> bool:
+    """Returns True if any scanner has a happy_hare_stage action."""
+    return any(
+        s.get("action") == "happy_hare_stage"
         for s in config.get("scanners", {}).values()
         if isinstance(s, dict)
     )
@@ -264,6 +275,7 @@ def load_config() -> dict:
 
     _validate_scanners(config)
     _validate_mobile(config)
+    _validate_happy_hare(config)
 
     return config
 
@@ -284,6 +296,56 @@ def _validate_mobile(config: dict) -> None:
     mobile_port = mobile["port"]
     if not isinstance(mobile_port, int) or mobile_port < 1 or mobile_port > 65535:
         _config_error("mobile.port must be an integer 1-65535 (got %s)", mobile_port)
+
+
+def _validate_happy_hare(config: dict) -> None:
+    """
+    Validate the optional `happy_hare:` top-level section and cross-check
+    against scanner actions. A `happy_hare_stage` scanner requires
+    `happy_hare.enabled: true` and a `printer_name`.
+
+    Multiple `happy_hare_stage` scanners are intentionally allowed — they
+    all bind to whichever gate is currently selected, which is harmless.
+    """
+    # Malformed YAML (e.g. `happy_hare: null` or `happy_hare: "yes"`) should
+    # fail loud, not crash on setdefault later. Absent key is fine — defaults
+    # get applied.
+    if "happy_hare" in config and not isinstance(config["happy_hare"], dict):
+        _config_error(
+            "happy_hare must be a mapping in config.yaml (got %s). "
+            "Remove the section or format it as `happy_hare:\\n  enabled: true\\n  ...`",
+            type(config["happy_hare"]).__name__,
+        )
+
+    happy_hare = config.setdefault("happy_hare", {})
+    happy_hare.setdefault("enabled", False)
+    happy_hare.setdefault("printer_name", "")
+
+    has_hh_scanner = has_happy_hare_scanners(config)
+    enabled = bool(happy_hare["enabled"])
+
+    if has_hh_scanner and not enabled:
+        _config_error(
+            "A scanner has action 'happy_hare_stage' but happy_hare.enabled is false. "
+            "Set 'happy_hare.enabled: true' in config.yaml or change the scanner action."
+        )
+
+    if enabled and not happy_hare["printer_name"]:
+        _config_error(
+            "happy_hare.enabled is true but happy_hare.printer_name is empty. "
+            "Set 'happy_hare.printer_name' to match the Printer Name configured "
+            "in Happy Hare's mmu_parameters.cfg."
+        )
+
+    # Happy Hare binding writes to Spoolman — the integration cannot function
+    # in tag-only mode. Fail loud at config load so users don't discover this
+    # only after the first scan.
+    if has_hh_scanner and not config.get("spoolman_url"):
+        _config_error(
+            "A scanner has action 'happy_hare_stage' but spoolman_url is not set. "
+            "Happy Hare binding writes to Spoolman — tag-only mode is not supported "
+            "for this action. Set 'spoolman_url' in config.yaml."
+        )
 
 
 def discover_klipper_var_path() -> str | None:

--- a/middleware/happy_hare.py
+++ b/middleware/happy_hare.py
@@ -1,0 +1,186 @@
+"""
+happy_hare.py — Happy Hare MMU integration (pull mode).
+
+Workflow for `action: happy_hare_stage` scanners:
+  1. User selects an MMU gate via `MMU_SELECT_GATE GATE=N` (Mainsail/LCD/console)
+  2. User scans a tag on the shared scanner
+  3. This module reads the currently-selected gate from Moonraker,
+     PATCHes the Spoolman spool's `extra.mmu_gate` and `extra.printer_name`,
+     then fires `MMU_SPOOLMAN SYNC=1` so Happy Hare picks up the binding
+     immediately rather than waiting for its next periodic pull
+
+Pull-mode-only: Happy Hare exposes `spoolman_support` on its `printer.mmu`
+object. We query that on first use and refuse to bind in any other mode,
+since `MMU_GATE_MAP NEXT_SPOOLID=...` is the right path there.
+
+No background thread, no startup wiring — this is purely a synchronous
+helper called from the scan handler.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+
+import requests
+
+import app_state
+from publishers.klipper import _send_gcode
+
+logger = logging.getLogger(__name__)
+
+REQUIRED_MODE: str = "pull"
+_KNOWN_MODES: frozenset[str] = frozenset({"pull", "push", "readonly"})
+
+# We cache only the success case (`pull`). Any other observed value re-fetches
+# on the next call so the integration can recover if the user fixes their
+# Happy Hare config without restarting the middleware. `_logged_mismatch`
+# prevents log spam when the mode is wrong and stays wrong.
+_mode_lock = threading.Lock()
+_cached_pull_mode: bool = False
+_logged_mismatch: bool = False
+
+
+def _fetch_mmu_status() -> dict | None:
+    """GET printer.mmu from Moonraker. Returns the object dict, or None on failure."""
+    moonraker_url = app_state.cfg.get("moonraker_url", "")
+    if not moonraker_url:
+        return None
+    try:
+        response = requests.get(
+            f"{moonraker_url}/printer/objects/query?mmu",
+            timeout=5,
+        )
+        response.raise_for_status()
+        return (
+            response.json()
+            .get("result", {})
+            .get("status", {})
+            .get("mmu")
+        )
+    except (requests.RequestException, ValueError):
+        logger.exception("Happy Hare: failed to query printer.mmu")
+        return None
+
+
+def _check_mode(mmu_status: dict) -> bool:
+    """
+    Return True if Happy Hare's spoolman_support matches the mode this
+    integration supports (`pull`).
+
+    Caches only the success case. If the mode is anything else (push,
+    readonly, missing, unrecognized), we don't cache — the next bind
+    re-fetches so the integration recovers automatically if the user
+    fixes their Happy Hare config without restarting middleware.
+
+    Logs the mismatch error exactly once per process while the mode
+    is wrong; resets on recovery.
+    """
+    global _cached_pull_mode, _logged_mismatch
+    with _mode_lock:
+        if _cached_pull_mode:
+            return True
+
+        actual = mmu_status.get("spoolman_support", "")
+        if actual == REQUIRED_MODE:
+            _cached_pull_mode = True
+            _logged_mismatch = False
+            return True
+
+        if not _logged_mismatch:
+            if actual in _KNOWN_MODES:
+                logger.error(
+                    "Happy Hare: spoolman_support=%r, this integration requires %r. "
+                    "Either switch Happy Hare's spoolman_support to %r in mmu_parameters.cfg, "
+                    "or disable happy_hare in the middleware config.",
+                    actual, REQUIRED_MODE, REQUIRED_MODE,
+                )
+            else:
+                logger.error(
+                    "Happy Hare: unrecognized spoolman_support value %r in printer.mmu. "
+                    "Expected one of %s. Cannot bind until this is resolved.",
+                    actual, sorted(_KNOWN_MODES),
+                )
+            _logged_mismatch = True
+        return False
+
+
+def bind_spool_to_current_gate(spool_id: int) -> bool:
+    """
+    Bind a spool to whichever MMU gate is currently selected.
+
+    Reads the current gate from Moonraker, PATCHes the spool's
+    `extra.mmu_gate` + `extra.printer_name`, then triggers Happy Hare's
+    Spoolman sync. Returns True on success, False on any failure
+    (with a logged reason).
+    """
+    happy_hare_cfg = app_state.cfg.get("happy_hare", {})
+    if not happy_hare_cfg.get("enabled"):
+        logger.debug("Happy Hare: bind skipped — integration not enabled")
+        return False
+
+    printer_name = happy_hare_cfg.get("printer_name", "")
+    if not printer_name:
+        logger.error("Happy Hare: bind skipped — happy_hare.printer_name is empty")
+        return False
+
+    mmu_status = _fetch_mmu_status()
+    if not mmu_status:
+        logger.warning("Happy Hare: bind skipped — could not read printer.mmu from Moonraker")
+        return False
+
+    if not _check_mode(mmu_status):
+        return False
+
+    if not mmu_status.get("enabled", False):
+        logger.warning("Happy Hare: bind skipped — MMU reports enabled=false")
+        return False
+
+    gate = mmu_status.get("gate")
+    if not isinstance(gate, int) or gate < 0:
+        logger.warning("Happy Hare: bind skipped — no gate selected (got %r). "
+                       "Run MMU_SELECT_GATE GATE=N before scanning.", gate)
+        return False
+
+    num_gates = mmu_status.get("num_gates")
+    if isinstance(num_gates, int) and gate >= num_gates:
+        logger.warning("Happy Hare: bind skipped — gate %d out of range (num_gates=%d)",
+                       gate, num_gates)
+        return False
+
+    if app_state.spoolman_client is None:
+        logger.error("Happy Hare: bind skipped — Spoolman client not configured")
+        return False
+
+    extras = {
+        "mmu_gate": gate,
+        "printer_name": printer_name,
+    }
+    if not app_state.spoolman_client.update_spool_extras(spool_id, extras):
+        return False
+
+    logger.info("Happy Hare: bound spool %s to gate %d on printer %r",
+                spool_id, gate, printer_name)
+
+    # Nudge Happy Hare to re-pull from Spoolman so the new binding is live
+    # immediately rather than on its next periodic sync.
+    moonraker_url = app_state.cfg.get("moonraker_url", "")
+    if moonraker_url:
+        try:
+            _send_gcode(moonraker_url, "MMU_SPOOLMAN SYNC=1")
+        except Exception:
+            logger.exception("Happy Hare: bind succeeded but MMU_SPOOLMAN SYNC=1 failed; "
+                             "Happy Hare will pick up the binding on its next periodic pull")
+
+    return True
+
+
+def _reset_mode_cache_for_testing() -> None:
+    """Test helper — clears the cached spoolman_support read.
+
+    Must be called in setUp() of any test that exercises this module, since
+    the cache is module-level and persists across test methods otherwise.
+    """
+    global _cached_pull_mode, _logged_mismatch
+    with _mode_lock:
+        _cached_pull_mode = False
+        _logged_mismatch = False

--- a/middleware/mqtt_handler.py
+++ b/middleware/mqtt_handler.py
@@ -121,6 +121,19 @@ def _handle_uid_only_tag(client: mqtt.Client, scanner_cfg: dict, uid: str, topic
     action = scanner_cfg["action"]
     target = _get_scanner_target(scanner_cfg)
 
+    # Happy Hare — bind to currently-selected MMU gate immediately,
+    # no cache, no lock.
+    if action == "happy_hare_stage":
+        from happy_hare import bind_spool_to_current_gate
+        bind_spool_to_current_gate(spool_id)
+        # Still drive low-spool LED feedback on the scanner so users loading
+        # multiple spools into MMU gates see when one is nearly empty.
+        if device_id and remaining is not None:
+            _check_low_spool(device_id, remaining)
+        if remaining is not None and remaining <= app_state.cfg["low_spool_threshold"]:
+            logger.warning(f"Low spool: {name} ({remaining:.1f}g) on {target_id}")
+        return
+
     # Shared scanners — cache for later assignment, don't activate yet
     if action in ("toolhead_stage", "afc_stage"):
         with app_state.state_lock:

--- a/middleware/publishers/base.py
+++ b/middleware/publishers/base.py
@@ -34,6 +34,7 @@ class Action(str, Enum):
     AFC_LANE = "afc_lane"
     TOOLHEAD = "toolhead"
     TOOLHEAD_STAGE = "toolhead_stage"
+    HAPPY_HARE_STAGE = "happy_hare_stage"
 
 
 @dataclass

--- a/middleware/publishers/klipper.py
+++ b/middleware/publishers/klipper.py
@@ -264,6 +264,12 @@ class KlipperPublisher(Publisher):
             logger.info(f"[toolhead_stage] Staged spool {event.spool_id} for next tool pickup")
             return True
 
+        elif action == Action.HAPPY_HARE_STAGE:
+            # Shared scanner — actual binding is handled by happy_hare.py
+            # (Spoolman PATCH + MMU_SPOOLMAN SYNC=1). Nothing for the
+            # generic Klipper publisher to do at scan time.
+            return True
+
         else:
             # Forward-compatible: unknown actions are a no-op success so future
             # action types added in new PRs don't break existing publishers.

--- a/middleware/spoolman/client.py
+++ b/middleware/spoolman/client.py
@@ -1,11 +1,16 @@
 """
 client.py — SpoolmanClient for spool lookup and enrichment.
 
-Read-only interface to Spoolman. Looks up spools by NFC UID and enriches
-tag data with Spoolman's color, material, and weight info. Does NOT create
-or modify spools — the scanner handles all Spoolman writes, and Moonraker
-handles filament usage tracking via sync_rate.
+Primarily read-only: looks up spools by NFC UID and enriches tag data with
+Spoolman's color, material, and weight info. The scanner handles spool
+creation and the bulk of Spoolman writes; Moonraker handles filament usage
+tracking via sync_rate.
+
+One narrow write path exists: `update_spool_extras()` is used by integrations
+that need to bind metadata onto an existing spool (e.g. Happy Hare's MMU gate
+assignment).
 """
+import json
 import logging
 import time
 from typing import Optional
@@ -56,6 +61,41 @@ class SpoolmanClient:
         except requests.RequestException:
             logger.exception("Failed to fetch spool %s", spool_id)
             return None
+
+    def update_spool_extras(self, spool_id: int, extras: dict) -> bool:
+        """
+        PATCH the `extra` field on a spool. Returns True on success.
+
+        Spoolman stores `extra` values as JSON-encoded strings (an int 4
+        becomes "4", a string "muffin" becomes '"muffin"'), so each value
+        is run through `json.dumps()` before sending.
+
+        Only the keys passed in are written; Spoolman merges them with the
+        spool's existing extras. Unknown extra keys (fields not declared
+        under Spoolman → Extras) are rejected with HTTP 400 — the error
+        body is logged so users can see which field to declare.
+        """
+        payload = {"extra": {k: json.dumps(v) for k, v in extras.items()}}
+        try:
+            response = requests.patch(
+                f"{self.base_url}/api/v1/spool/{spool_id}",
+                json=payload,
+                timeout=5,
+            )
+            response.raise_for_status()
+            return True
+        except requests.HTTPError as e:
+            # Include Spoolman's response body — "Unknown extra field X" and
+            # similar messages are actionable, but only if the user sees them.
+            body = e.response.text if e.response is not None else ""
+            logger.error(
+                "Failed to update extras on spool %s: %s. Spoolman response: %s",
+                spool_id, e, body,
+            )
+            return False
+        except requests.RequestException:
+            logger.exception("Failed to update extras on spool %s", spool_id)
+            return False
 
     def find_by_nfc(self, nfc_uid: str) -> Optional[dict]:
         """Looks up a spool by NFC UID, with TTL-based cache and single forced refresh on miss."""

--- a/middleware/spoolsense.py
+++ b/middleware/spoolsense.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
-__version__ = "1.7.2"
+__version__ = "1.7.3"
 """
 SpoolSense NFC Middleware
 =========================
@@ -34,7 +34,11 @@ import threading
 import paho.mqtt.client as mqtt
 
 import app_state
-from config import CONFIG_PATH, load_config, has_afc_scanners, has_toolhead_scanners, has_toolhead_stage_scanners
+from config import (
+    CONFIG_PATH, load_config,
+    has_afc_scanners, has_happy_hare_scanners,
+    has_toolhead_scanners, has_toolhead_stage_scanners,
+)
 from mqtt_handler import on_connect, on_message
 from activation import publish_lock
 from afc_status import AfcStatusSync
@@ -142,6 +146,8 @@ def _log_startup() -> None:
         logger.info("Klipper sync: file watcher")
     if has_toolhead_scanners(app_state.cfg) or has_toolhead_stage_scanners(app_state.cfg):
         logger.info("Toolhead status: Moonraker spool eject polling")
+    if has_happy_hare_scanners(app_state.cfg):
+        logger.info("Happy Hare: pull-mode gate binding enabled")
     logger.info(f"Filament usage: UPDATE_TAG macro tracking enabled")
     logger.info(f"Dispatcher: {'enabled' if app_state.DISPATCHER_AVAILABLE else 'disabled'}")
 

--- a/middleware/tests/test_config.py
+++ b/middleware/tests/test_config.py
@@ -24,10 +24,12 @@ import app_state  # noqa: E402
 
 from config import (  # noqa: E402
     _validate_scanners,
+    _validate_happy_hare,
     _derive_toolheads,
     _migrate_legacy_config,
     discover_klipper_var_path,
     has_afc_scanners,
+    has_happy_hare_scanners,
     has_toolhead_scanners,
     has_toolhead_stage_scanners,
 )
@@ -105,6 +107,15 @@ class TestValidateScanners(unittest.TestCase):
 
     def test_toolhead_stage_with_lane_rejected(self):
         self._call({"scanners": {"abc123": {"action": "toolhead_stage", "lane": "lane1"}}})
+
+    def test_happy_hare_stage_no_target_accepted(self):
+        self._ok({"scanners": {"abc123": {"action": "happy_hare_stage"}}})
+
+    def test_happy_hare_stage_with_lane_rejected(self):
+        self._call({"scanners": {"abc123": {"action": "happy_hare_stage", "lane": "lane1"}}})
+
+    def test_happy_hare_stage_with_toolhead_rejected(self):
+        self._call({"scanners": {"abc123": {"action": "happy_hare_stage", "toolhead": "T0"}}})
 
     def test_empty_scanners_dict_rejected(self):
         self._call({"scanners": {}})
@@ -380,6 +391,85 @@ class TestDiscoverKlipperVarPath(unittest.TestCase):
             result = discover_klipper_var_path()
             assert result == "/cached/path/variables.cfg"
             mock_get.assert_not_called()
+
+
+class TestValidateHappyHare(unittest.TestCase):
+    """The optional `happy_hare:` section + cross-check against scanner actions."""
+
+    def _call(self, config):
+        with self.assertRaises(SystemExit):
+            _validate_happy_hare(config)
+
+    def _ok(self, config):
+        _validate_happy_hare(config)
+
+    def test_section_absent_is_ok(self):
+        # No happy_hare section, no happy_hare_stage scanners → defaults applied, no error
+        cfg = {"scanners": {"abc123": {"action": "afc_stage"}}}
+        self._ok(cfg)
+        assert cfg["happy_hare"]["enabled"] is False
+
+    def test_disabled_with_no_hh_scanner_is_ok(self):
+        self._ok({
+            "scanners": {"abc123": {"action": "afc_stage"}},
+            "happy_hare": {"enabled": False},
+        })
+
+    def test_enabled_without_printer_name_rejected(self):
+        self._call({
+            "scanners": {"abc123": {"action": "happy_hare_stage"}},
+            "happy_hare": {"enabled": True},
+        })
+
+    def test_hh_scanner_without_enabled_rejected(self):
+        # Cross-check: scanner action present but integration disabled → fail loud
+        self._call({
+            "scanners": {"abc123": {"action": "happy_hare_stage"}},
+            "happy_hare": {"enabled": False},
+        })
+
+    def test_hh_scanner_without_spoolman_url_rejected(self):
+        # HH bind writes to Spoolman — tag-only mode isn't supported
+        self._call({
+            "scanners": {"abc123": {"action": "happy_hare_stage"}},
+            "happy_hare": {"enabled": True, "printer_name": "muffin"},
+        })
+
+    def test_hh_scanner_with_spoolman_url_accepted(self):
+        self._ok({
+            "scanners": {"abc123": {"action": "happy_hare_stage"}},
+            "happy_hare": {"enabled": True, "printer_name": "muffin"},
+            "spoolman_url": "http://spoolman:7912",
+        })
+
+    def test_null_happy_hare_section_rejected(self):
+        # `happy_hare: null` in YAML would crash setdefault otherwise
+        self._call({
+            "scanners": {"abc123": {"action": "afc_stage"}},
+            "happy_hare": None,
+        })
+
+    def test_string_happy_hare_section_rejected(self):
+        # `happy_hare: "yes"` in YAML would crash setdefault otherwise
+        self._call({
+            "scanners": {"abc123": {"action": "afc_stage"}},
+            "happy_hare": "yes",
+        })
+
+
+class TestHasHappyHareScanners(unittest.TestCase):
+    def test_returns_true_when_present(self):
+        assert has_happy_hare_scanners(
+            {"scanners": {"a": {"action": "happy_hare_stage"}}}
+        ) is True
+
+    def test_returns_false_when_only_other_actions(self):
+        assert has_happy_hare_scanners(
+            {"scanners": {"a": {"action": "afc_stage"}, "b": {"action": "toolhead"}}}
+        ) is False
+
+    def test_returns_false_when_no_scanners(self):
+        assert has_happy_hare_scanners({}) is False
 
 
 if __name__ == "__main__":

--- a/middleware/tests/test_happy_hare.py
+++ b/middleware/tests/test_happy_hare.py
@@ -1,0 +1,226 @@
+"""
+Tests for happy_hare.py — MMU gate binding via Spoolman PATCH + sync trigger.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+sys.modules.setdefault("paho", MagicMock())
+sys.modules.setdefault("paho.mqtt", MagicMock())
+sys.modules.setdefault("paho.mqtt.client", MagicMock())
+sys.modules.setdefault("watchdog", MagicMock())
+sys.modules.setdefault("watchdog.observers", MagicMock())
+sys.modules.setdefault("watchdog.events", MagicMock())
+
+import app_state  # noqa: E402
+import happy_hare  # noqa: E402
+from happy_hare import bind_spool_to_current_gate  # noqa: E402
+
+
+def _reset(*, enabled=True, printer_name="muffin"):
+    app_state.cfg = {
+        "moonraker_url": "http://moonraker:7125",
+        "happy_hare": {"enabled": enabled, "printer_name": printer_name},
+        "scanners": {},
+    }
+    app_state.state_lock = threading.Lock()
+    app_state.spoolman_client = MagicMock()
+    app_state.spoolman_client.update_spool_extras = MagicMock(return_value=True)
+    happy_hare._reset_mode_cache_for_testing()
+
+
+def _mmu_status(**overrides):
+    base = {
+        "enabled": True,
+        "spoolman_support": "pull",
+        "gate": 4,
+        "num_gates": 8,
+    }
+    base.update(overrides)
+    return base
+
+
+def _mock_response(payload):
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json = MagicMock(return_value={"result": {"status": {"mmu": payload}}})
+    return resp
+
+
+class TestBindHappyPath(unittest.TestCase):
+    """Successful end-to-end bind path."""
+
+    def setUp(self):
+        _reset()
+
+    def test_bind_patches_spoolman_with_gate_and_printer_name(self):
+        with patch("happy_hare.requests.get", return_value=_mock_response(_mmu_status())), \
+             patch("happy_hare._send_gcode"):
+            result = bind_spool_to_current_gate(spool_id=42)
+        assert result is True
+        app_state.spoolman_client.update_spool_extras.assert_called_once_with(
+            42, {"mmu_gate": 4, "printer_name": "muffin"}
+        )
+
+    def test_bind_fires_mmu_spoolman_sync(self):
+        with patch("happy_hare.requests.get", return_value=_mock_response(_mmu_status())), \
+             patch("happy_hare._send_gcode") as mock_gcode:
+            bind_spool_to_current_gate(spool_id=42)
+        mock_gcode.assert_called_once_with("http://moonraker:7125", "MMU_SPOOLMAN SYNC=1")
+
+    def test_bind_sync_failure_does_not_fail_overall_bind(self):
+        # The PATCH already landed; a missing sync just means Happy Hare
+        # picks it up on the next periodic pull. Still report success.
+        with patch("happy_hare.requests.get", return_value=_mock_response(_mmu_status())), \
+             patch("happy_hare._send_gcode", side_effect=Exception("boom")):
+            result = bind_spool_to_current_gate(spool_id=42)
+        assert result is True
+
+
+class TestBindGuards(unittest.TestCase):
+    """Refusal paths — each should return False without writing to Spoolman."""
+
+    def setUp(self):
+        _reset()
+
+    def _assert_no_patch_called(self):
+        app_state.spoolman_client.update_spool_extras.assert_not_called()
+
+    def test_skipped_when_integration_disabled(self):
+        _reset(enabled=False)
+        result = bind_spool_to_current_gate(spool_id=42)
+        assert result is False
+        self._assert_no_patch_called()
+
+    def test_skipped_when_printer_name_empty(self):
+        _reset(printer_name="")
+        with patch("happy_hare.requests.get", return_value=_mock_response(_mmu_status())):
+            result = bind_spool_to_current_gate(spool_id=42)
+        assert result is False
+        self._assert_no_patch_called()
+
+    def test_skipped_when_moonraker_unreachable(self):
+        import requests
+        with patch("happy_hare.requests.get", side_effect=requests.ConnectionError("refused")):
+            result = bind_spool_to_current_gate(spool_id=42)
+        assert result is False
+        self._assert_no_patch_called()
+
+    def test_refused_when_spoolman_support_is_push(self):
+        with patch("happy_hare.requests.get",
+                   return_value=_mock_response(_mmu_status(spoolman_support="push"))):
+            result = bind_spool_to_current_gate(spool_id=42)
+        assert result is False
+        self._assert_no_patch_called()
+
+    def test_refused_when_spoolman_support_is_readonly(self):
+        with patch("happy_hare.requests.get",
+                   return_value=_mock_response(_mmu_status(spoolman_support="readonly"))):
+            result = bind_spool_to_current_gate(spool_id=42)
+        assert result is False
+        self._assert_no_patch_called()
+
+    def test_skipped_when_mmu_disabled(self):
+        with patch("happy_hare.requests.get",
+                   return_value=_mock_response(_mmu_status(enabled=False))):
+            result = bind_spool_to_current_gate(spool_id=42)
+        assert result is False
+        self._assert_no_patch_called()
+
+    def test_skipped_when_no_gate_selected(self):
+        # Happy Hare reports gate=-1 (or any non-int) when no gate is selected
+        with patch("happy_hare.requests.get",
+                   return_value=_mock_response(_mmu_status(gate=-1))):
+            result = bind_spool_to_current_gate(spool_id=42)
+        assert result is False
+        self._assert_no_patch_called()
+
+    def test_skipped_when_gate_out_of_range(self):
+        with patch("happy_hare.requests.get",
+                   return_value=_mock_response(_mmu_status(gate=10, num_gates=8))):
+            result = bind_spool_to_current_gate(spool_id=42)
+        assert result is False
+        self._assert_no_patch_called()
+
+    def test_skipped_when_spoolman_client_missing(self):
+        app_state.spoolman_client = None
+        with patch("happy_hare.requests.get", return_value=_mock_response(_mmu_status())):
+            result = bind_spool_to_current_gate(spool_id=42)
+        assert result is False
+
+    def test_returns_false_when_spoolman_patch_fails(self):
+        app_state.spoolman_client.update_spool_extras = MagicMock(return_value=False)
+        with patch("happy_hare.requests.get", return_value=_mock_response(_mmu_status())), \
+             patch("happy_hare._send_gcode"):
+            result = bind_spool_to_current_gate(spool_id=42)
+        assert result is False
+
+
+class TestModeCheckCaching(unittest.TestCase):
+    """Mode check should cache success but re-fetch on mismatch, and log
+    the mismatch error exactly once per wrong-mode run."""
+
+    def setUp(self):
+        _reset()
+
+    def test_mismatch_logs_exactly_once(self):
+        # Two calls while mode is wrong — error logged on the first, suppressed
+        # on the second. (Spamming logs every scan would be noisy.)
+        with patch("happy_hare.requests.get",
+                   return_value=_mock_response(_mmu_status(spoolman_support="push"))):
+            with self.assertLogs("happy_hare", level="ERROR") as captured:
+                # Need at least one ERROR for assertLogs to pass; we'll count after.
+                bind_spool_to_current_gate(spool_id=1)
+                bind_spool_to_current_gate(spool_id=2)
+        mismatch_errors = [r for r in captured.records if "spoolman_support" in r.getMessage()]
+        assert len(mismatch_errors) == 1, f"expected 1 mismatch log, got {len(mismatch_errors)}"
+
+    def test_pull_mode_cached_after_first_success(self):
+        # First call confirms pull → cached. Second call should not re-query Moonraker.
+        with patch("happy_hare.requests.get",
+                   return_value=_mock_response(_mmu_status())) as mock_get, \
+             patch("happy_hare._send_gcode"):
+            assert bind_spool_to_current_gate(spool_id=1) is True
+            first_call_count = mock_get.call_count
+            assert bind_spool_to_current_gate(spool_id=2) is True
+            # We expect a second call (the bind path always fetches gate info)
+            # but the mode-check shouldn't add an extra one — the assertion is
+            # cleaner via the public flag.
+        assert happy_hare._cached_pull_mode is True
+
+    def test_mismatch_does_not_cache_allowing_recovery(self):
+        # If Happy Hare's mode is wrong, we must not cache it permanently —
+        # the user could fix mmu_parameters.cfg and we should recover without
+        # restarting the middleware.
+        with patch("happy_hare.requests.get",
+                   return_value=_mock_response(_mmu_status(spoolman_support="push"))):
+            bind_spool_to_current_gate(spool_id=1)
+        assert happy_hare._cached_pull_mode is False
+
+        # User flips Happy Hare to pull mode. Next bind should succeed.
+        with patch("happy_hare.requests.get",
+                   return_value=_mock_response(_mmu_status(spoolman_support="pull"))), \
+             patch("happy_hare._send_gcode"):
+            assert bind_spool_to_current_gate(spool_id=1) is True
+        assert happy_hare._cached_pull_mode is True
+
+    def test_missing_spoolman_support_field_does_not_cache(self):
+        # If Moonraker returns the mmu object but the spoolman_support key is
+        # missing (old Happy Hare, partial init, etc), we should NOT cache —
+        # next call retries.
+        bad_status = _mmu_status()
+        del bad_status["spoolman_support"]
+        with patch("happy_hare.requests.get",
+                   return_value=_mock_response(bad_status)):
+            assert bind_spool_to_current_gate(spool_id=1) is False
+        assert happy_hare._cached_pull_mode is False
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/middleware/tests/test_spoolman_client.py
+++ b/middleware/tests/test_spoolman_client.py
@@ -323,5 +323,64 @@ class TestNoWrites(unittest.TestCase):
         mock_patch.assert_not_called()
 
 
+class TestUpdateSpoolExtras(unittest.TestCase):
+    """PATCH /api/v1/spool/<id> with `extra` updates, JSON-encoded per value."""
+
+    def setUp(self):
+        _reset_app_state()
+
+    @patch("requests.patch")
+    def test_extras_json_encoded_per_value(self, mock_patch):
+        # Spoolman stores extras as JSON-encoded strings, so we must encode
+        # each value before sending: int 4 → "4", string "muffin" → '"muffin"'.
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        mock_patch.return_value = resp
+
+        client = SpoolmanClient(BASE_URL)
+        result = client.update_spool_extras(42, {"mmu_gate": 4, "printer_name": "muffin"})
+
+        assert result is True
+        args, kwargs = mock_patch.call_args
+        assert args[0] == f"{BASE_URL}/api/v1/spool/42"
+        assert kwargs["json"] == {"extra": {"mmu_gate": "4", "printer_name": '"muffin"'}}
+
+    @patch("requests.patch")
+    def test_returns_false_on_http_error(self, mock_patch):
+        import requests as req
+        mock_patch.side_effect = req.HTTPError("404")
+        client = SpoolmanClient(BASE_URL)
+        assert client.update_spool_extras(42, {"x": 1}) is False
+
+    @patch("requests.patch")
+    def test_logs_spoolman_response_body_on_400(self, mock_patch):
+        # Unknown extra fields return 400 with a body like
+        # `{"message": "Unknown extra field mmu_gate."}` — the log must
+        # include that body so users know which field to declare.
+        import requests as req
+        err_response = MagicMock()
+        err_response.text = '{"message": "Unknown extra field mmu_gate."}'
+        http_error = req.HTTPError("400 Client Error")
+        http_error.response = err_response
+
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock(side_effect=http_error)
+        mock_patch.return_value = resp
+
+        client = SpoolmanClient(BASE_URL)
+        with self.assertLogs("spoolman.client", level="ERROR") as captured:
+            result = client.update_spool_extras(42, {"mmu_gate": 4})
+        assert result is False
+        combined = "\n".join(r.getMessage() for r in captured.records)
+        assert "Unknown extra field mmu_gate" in combined
+
+    @patch("requests.patch")
+    def test_returns_false_on_connection_error(self, mock_patch):
+        import requests as req
+        mock_patch.side_effect = req.ConnectionError("refused")
+        client = SpoolmanClient(BASE_URL)
+        assert client.update_spool_extras(42, {"x": 1}) is False
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
v1.7.3 — adds Happy Hare MMU integration (pull mode).

## Added

- **Happy Hare MMU integration** (pull mode) — new `happy_hare_stage` scanner action for shared scanners used with Happy Hare-managed MMUs (ERCF, etc.). Workflow: user selects an MMU gate via `MMU_SELECT_GATE GATE=N`, then scans a tag. The middleware reads the selected gate from Moonraker, PATCHes the spool's `extra.mmu_gate` and `extra.printer_name` in Spoolman, then fires `MMU_SPOOLMAN SYNC=1` so Happy Hare picks up the binding immediately. Pull mode is auto-detected via `printer.mmu.spoolman_support` — no config knob. Config example at `middleware/config.example.happy_hare.yaml`.
- **`SpoolmanClient.update_spool_extras()`** — narrow PATCH helper for writing declared extra fields on a spool. Used only by the Happy Hare integration.

## Test plan
- [x] 30 new tests covering bind state machine, mode-cache success/recovery, JSON extras encoding, HTTP error body captured in logs
- [x] Full suite: 438 pass / 1 pre-existing fail (unrelated)
- [x] Codex + CodeRabbit reviews addressed
- [x] PATCH merge + 400-body behavior verified against a real Spoolman
- [ ] End-to-end verification on real Happy Hare hardware — pending (tracking in SpoolSense/spoolsense_scanner#194)