### PR TITLE
Fix red test, add CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [master, dev]
+  pull_request:
+    branches: [master, dev]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # 3.9 = Raspberry Pi OS (Bullseye) floor; 3.12 = current
+        python-version: ["3.9", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: middleware/requirements-dev.txt
+
+      - name: Install dependencies
+        run: pip install -r middleware/requirements-dev.txt
+
+      - name: Lint (syntax errors and undefined names only)
+        run: flake8 middleware/ --count --select=E9,F63,F7,F82 --show-source --exclude=middleware/docs
+
+      - name: Test
+        run: pytest middleware/tests/ -q

--- a/middleware/config.py
+++ b/middleware/config.py
@@ -119,6 +119,19 @@ def _validate_targeted_scanner(device_id: str, scanner_cfg: dict, action: str,
         )
 
 
+def _apply_scanner_defaults(config: dict) -> None:
+    """
+    Apply per-scanner defaults before derivation and validation.
+
+    Runs in load_config() ahead of _derive_toolheads() and
+    _validate_scanners() — single-toolhead users shouldn't need to
+    specify `toolhead: "T0"` explicitly (#44).
+    """
+    for scanner_cfg in config.get("scanners", {}).values():
+        if isinstance(scanner_cfg, dict) and scanner_cfg.get("action") == "toolhead":
+            scanner_cfg.setdefault("toolhead", "T0")
+
+
 def _validate_scanners(config: dict) -> None:
     """Validates the scanners config entries. Exits on any invalid config."""
     scanners = config.get("scanners", {})
@@ -267,9 +280,7 @@ def load_config() -> dict:
     config = _migrate_legacy_config(config)
 
     # Apply scanner defaults before derivation and validation
-    for scanner_cfg in config.get("scanners", {}).values():
-        if isinstance(scanner_cfg, dict) and scanner_cfg.get("action") == "toolhead":
-            scanner_cfg.setdefault("toolhead", "T0")  # single-toolhead users don't need to specify
+    _apply_scanner_defaults(config)
 
     # Derive toolheads from scanner entries if not explicitly provided
     if not config.get("toolheads"):

--- a/middleware/requirements-dev.txt
+++ b/middleware/requirements-dev.txt
@@ -1,0 +1,5 @@
+# Development / CI dependencies — not needed on the printer host
+-r requirements.txt
+pytest>=8.0
+httpx>=0.27          # fastapi TestClient transport (test_rest_api.py)
+flake8>=7.0

--- a/middleware/tag_sync/policy.py
+++ b/middleware/tag_sync/policy.py
@@ -10,8 +10,11 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import dataclass
-from typing import Any, Dict, Literal, Optional
+from typing import Any, Dict, Literal, Optional, TYPE_CHECKING
 import app_state
+
+if TYPE_CHECKING:
+    from state.models import ScanEvent, SpoolInfo
 
 logger = logging.getLogger(__name__)
 
@@ -51,8 +54,8 @@ def should_write_remaining(
 
 
 def build_write_plan(
-    scan: "ScanEvent",
-    spool_info: "SpoolInfo | None",
+    scan: ScanEvent,
+    spool_info: SpoolInfo | None,
     device_id: str | None,
 ) -> TagWritePlan | None:
     """

--- a/middleware/tests/test_config.py
+++ b/middleware/tests/test_config.py
@@ -21,6 +21,7 @@ from unittest.mock import patch  # noqa: E402
 import app_state  # noqa: E402
 
 from config import (  # noqa: E402
+    _apply_scanner_defaults,
     _validate_scanners,
     _validate_happy_hare,
     _derive_toolheads,
@@ -51,10 +52,23 @@ class TestValidateScanners(unittest.TestCase):
         self._ok({"scanners": {"abc123": {"action": "toolhead", "toolhead": "T0"}}})
 
     def test_toolhead_defaults_to_t0(self):
-        # Single-toolhead users shouldn't need to specify toolhead: "T0" (#44)
+        # Single-toolhead users shouldn't need to specify toolhead: "T0" (#44).
+        # Defaulting runs in load_config() via _apply_scanner_defaults() before
+        # validation — mirror that order here.
         config = {"scanners": {"abc123": {"action": "toolhead"}}}
+        _apply_scanner_defaults(config)
         self._ok(config)
         self.assertEqual(config["scanners"]["abc123"]["toolhead"], "T0")
+
+    def test_explicit_toolhead_not_overwritten_by_default(self):
+        config = {"scanners": {"abc123": {"action": "toolhead", "toolhead": "T3"}}}
+        _apply_scanner_defaults(config)
+        self.assertEqual(config["scanners"]["abc123"]["toolhead"], "T3")
+
+    def test_defaults_do_not_touch_other_actions(self):
+        config = {"scanners": {"abc123": {"action": "afc_stage"}}}
+        _apply_scanner_defaults(config)
+        self.assertNotIn("toolhead", config["scanners"]["abc123"])
 
     def test_valid_toolhead_stage(self):
         self._ok({"scanners": {"abc123": {"action": "toolhead_stage"}}})


### PR DESCRIPTION
## Summary

The test suite is fully green for the first time (437 passed, 0 failed), and CI now gates every PR so it stays that way.

### Red test fix
`test_toolhead_defaults_to_t0` has been failing since the T0 defaulting moved into `load_config()` (2853521) — the test called `_validate_scanners()` directly and never saw the default applied. Production behavior was always correct; the test just exercised a stale path. The defaulting is now extracted into `_apply_scanner_defaults()` so `load_config()` and the test hit the same code. Two new tests pin the edges: explicit `toolhead:` values are never overwritten, other actions are untouched.

### Real lint findings
`tag_sync/policy.py` had two F821s — quoted `"ScanEvent"` / `"SpoolInfo | None"` annotations referencing names that were never imported. Fixed with a `TYPE_CHECKING` import, matching the pattern used elsewhere in the codebase.

### CI
`.github/workflows/ci.yml`:
- pytest + flake8 on PRs and pushes to `dev`/`master`
- flake8 scoped to syntax errors and undefined names only (`E9,F63,F7,F82`) — a real gate without boiling the style ocean
- Python matrix: **3.9** (Raspberry Pi OS floor) and **3.12**
- Dev dependencies split into `middleware/requirements-dev.txt` (pytest, httpx for the FastAPI TestClient, flake8)

3.9 compatibility verified with a full import sweep of all 23 middleware modules under 3.9.6 before adding the matrix leg.

## Test plan
- [x] 437 passed / 0 failed locally on Python 3.9.6
- [x] flake8 error-gate clean
- [x] All 23 modules import under 3.9
- [ ] CI runs green on this PR (the workflow's first execution is this PR itself)