### PR TITLE
Extract shared Moonraker transport into moonraker_client.py

### DIFF
--- a/middleware/README.md
+++ b/middleware/README.md
@@ -37,6 +37,7 @@ middleware/
 ├── toolhead_status.py         # Toolhead spool eject detection
 ├── filament_usage.py          # UPDATE_TAG macro — filament deduction tracking
 ├── moonraker_ws.py            # Moonraker websocket — real-time AFC and macro events
+├── moonraker_client.py        # Shared Moonraker HTTP helpers — gcode, queries, spool_id, DB items
 ├── klipper_vars.py            # Klipper save_variables sync via Moonraker websocket (toolhead modes)
 │
 ├── spoolman/

--- a/middleware/afc_status.py
+++ b/middleware/afc_status.py
@@ -72,8 +72,8 @@ def _send_lane_data_delayed(lane_name: str, pending: dict, source: str) -> None:
         moonraker_url = app_state.cfg.get("moonraker_url", "")
         if moonraker_url:
             try:
-                from publishers.klipper import _send_gcode
-                _send_gcode(moonraker_url, f"SET_SPOOL_ID LANE={lane_name} SPOOL_ID={spoolman_id}")
+                from moonraker_client import send_gcode
+                send_gcode(moonraker_url, f"SET_SPOOL_ID LANE={lane_name} SPOOL_ID={spoolman_id}")
                 logger.info("AFC %s: sent SET_SPOOL_ID LANE=%s SPOOL_ID=%s", source, lane_name, spoolman_id)
             except Exception:
                 logger.exception("AFC %s: failed to send SET_SPOOL_ID for %s", source, lane_name)

--- a/middleware/filament_usage.py
+++ b/middleware/filament_usage.py
@@ -20,6 +20,7 @@ import requests
 
 import app_state
 from config import has_afc_scanners
+from moonraker_client import query_objects, send_gcode
 
 logger = logging.getLogger(__name__)
 
@@ -107,11 +108,7 @@ def _clear_pending() -> None:
         return
 
     try:
-        requests.post(
-            f"{moonraker}/printer/gcode/script",
-            json={"script": f"SET_GCODE_VARIABLE MACRO={MACRO_NAME} VARIABLE={VARIABLE_NAME} VALUE=0"},
-            timeout=5,
-        ).raise_for_status()
+        send_gcode(moonraker, f"SET_GCODE_VARIABLE MACRO={MACRO_NAME} VARIABLE={VARIABLE_NAME} VALUE=0")
         logger.debug("UPDATE_TAG: cleared pending variable")
     except Exception:
         logger.exception("UPDATE_TAG: failed to clear pending variable")
@@ -277,31 +274,23 @@ def _fetch_tool_filament_used() -> dict[str, float] | None:
 
     # Query tool objects — e.g. ?tool%20T0&tool%20T1
     query_parts = "&".join(f"tool%20{t}" for t in tool_names)
-    try:
-        response = requests.get(
-            f"{moonraker}/printer/objects/query?{query_parts}",
-            timeout=5,
-        )
-        response.raise_for_status()
-        status = response.json().get("result", {}).get("status", {})
+    status = query_objects(moonraker, query_parts, context="UPDATE_TAG")
+    if status is None:
+        return None
 
-        result: dict[str, float] = {}
-        for tool_name in tool_names:
-            tool_data = status.get(f"tool {tool_name}", {})
-            filament = tool_data.get("filament_used")
-            if filament is None:
-                # Tool object doesn't have filament_used — mod not installed
-                return None
+    result: dict[str, float] = {}
+    for tool_name in tool_names:
+        tool_data = status.get(f"tool {tool_name}", {})
+        filament = tool_data.get("filament_used")
+        if filament is None:
+            # Tool object doesn't have filament_used — mod not installed
+            return None
+        try:
             result[tool_name] = float(filament)
+        except (TypeError, ValueError):
+            return None
 
-        return result if result else None
-
-    except requests.ConnectionError:
-        logger.debug("UPDATE_TAG: Moonraker not reachable for tool query")
-        return None
-    except Exception:
-        logger.exception("UPDATE_TAG: failed to fetch tool filament_used")
-        return None
+    return result if result else None
 
 
 def _mm_to_grams(mm: float, diameter_mm: float, density_g_cm3: float) -> float:
@@ -400,21 +389,11 @@ def _fetch_pending() -> int | None:
     if not moonraker:
         return None
 
-    try:
-        response = requests.get(
-            f"{moonraker}/printer/objects/query?gcode_macro%20{MACRO_NAME}",
-            timeout=5,
-        )
-        response.raise_for_status()
-        result = response.json()
-        macro_data = result.get("result", {}).get("status", {}).get(f"gcode_macro {MACRO_NAME}", {})
-        return macro_data.get(VARIABLE_NAME, 0)
-    except requests.ConnectionError:
-        logger.debug("UPDATE_TAG: Moonraker not reachable")
+    status = query_objects(moonraker, f"gcode_macro%20{MACRO_NAME}", context="UPDATE_TAG")
+    if status is None:
         return None
-    except Exception:
-        logger.exception("UPDATE_TAG: unexpected error fetching macro state")
-        return None
+    macro_data = status.get(f"gcode_macro {MACRO_NAME}", {})
+    return macro_data.get(VARIABLE_NAME, 0)
 
 
 class FilamentUsageSync:

--- a/middleware/happy_hare.py
+++ b/middleware/happy_hare.py
@@ -21,10 +21,8 @@ from __future__ import annotations
 import logging
 import threading
 
-import requests
-
 import app_state
-from publishers.klipper import _send_gcode
+from moonraker_client import query_objects, send_gcode
 
 logger = logging.getLogger(__name__)
 
@@ -43,23 +41,10 @@ _logged_mismatch: bool = False
 def _fetch_mmu_status() -> dict | None:
     """GET printer.mmu from Moonraker. Returns the object dict, or None on failure."""
     moonraker_url = app_state.cfg.get("moonraker_url", "")
-    if not moonraker_url:
+    status = query_objects(moonraker_url, "mmu", context="Happy Hare")
+    if status is None:
         return None
-    try:
-        response = requests.get(
-            f"{moonraker_url}/printer/objects/query?mmu",
-            timeout=5,
-        )
-        response.raise_for_status()
-        return (
-            response.json()
-            .get("result", {})
-            .get("status", {})
-            .get("mmu")
-        )
-    except (requests.RequestException, ValueError):
-        logger.exception("Happy Hare: failed to query printer.mmu")
-        return None
+    return status.get("mmu")
 
 
 def _check_mode(mmu_status: dict) -> bool:
@@ -166,7 +151,7 @@ def bind_spool_to_current_gate(spool_id: int) -> bool:
     moonraker_url = app_state.cfg.get("moonraker_url", "")
     if moonraker_url:
         try:
-            _send_gcode(moonraker_url, "MMU_SPOOLMAN SYNC=1")
+            send_gcode(moonraker_url, "MMU_SPOOLMAN SYNC=1")
         except Exception:
             logger.exception("Happy Hare: bind succeeded but MMU_SPOOLMAN SYNC=1 failed; "
                              "Happy Hare will pick up the binding on its next periodic pull")

--- a/middleware/moonraker_client.py
+++ b/middleware/moonraker_client.py
@@ -1,0 +1,178 @@
+"""
+moonraker_client.py — shared Moonraker HTTP transport helpers.
+
+One home for the Moonraker request shapes used across the middleware:
+gcode scripts, printer object queries, the Spoolman active-spool endpoint,
+and database items. Pure functions taking the Moonraker URL explicitly —
+no app_state coupling (same dependency-injection direction as #67).
+
+Modules keep their own semantic layers (sentinels, retries, log flavor);
+this module owns URLs, timeouts, and response envelope unwrapping.
+"""
+from __future__ import annotations
+
+import logging
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT: float = 5.0
+
+# Tri-state sentinel: a fetch that *failed* is not the same as a fetch that
+# returned "no value". Callers compare with `is`.
+FETCH_ERROR = object()
+
+
+def send_gcode(moonraker: str, script: str, timeout: float = DEFAULT_TIMEOUT) -> None:
+    """
+    POST a single gcode script to Moonraker.
+
+    Raises on HTTP error or connection failure. Callers are responsible for
+    catching and handling exceptions.
+    """
+    requests.post(
+        f"{moonraker}/printer/gcode/script",
+        json={"script": script},
+        timeout=timeout,
+    ).raise_for_status()
+
+
+def query_objects(moonraker: str, query: str, timeout: float = DEFAULT_TIMEOUT,
+                  context: str = "moonraker") -> dict | None:
+    """
+    GET /printer/objects/query?<query> and unwrap to the result.status dict.
+
+    `query` is the raw query-string portion (e.g. "mmu", "print_stats",
+    "gcode_macro%20ASSIGN_SPOOL", or multiple objects joined with "&").
+    `context` prefixes log messages so operators can tell which subsystem
+    a failure belongs to.
+
+    Returns the status dict, or None on any failure (logged, never raises).
+    """
+    if not moonraker:
+        return None
+    try:
+        response = requests.get(
+            f"{moonraker}/printer/objects/query?{query}",
+            timeout=timeout,
+        )
+        response.raise_for_status()
+        status = response.json().get("result", {}).get("status", {})
+        return status if isinstance(status, dict) else None
+    except requests.ConnectionError:
+        logger.debug("%s: Moonraker not reachable", context)
+        return None
+    except requests.Timeout:
+        logger.warning("%s: Moonraker request timed out", context)
+        return None
+    except Exception:
+        logger.exception("%s: unexpected error querying %r", context, query)
+        return None
+
+
+def list_objects(moonraker: str, timeout: float = DEFAULT_TIMEOUT) -> list | None:
+    """GET /printer/objects/list. Returns the object name list, or None on failure."""
+    if not moonraker:
+        return None
+    try:
+        response = requests.get(f"{moonraker}/printer/objects/list", timeout=timeout)
+        response.raise_for_status()
+        objects = response.json().get("result", {}).get("objects", [])
+        return objects if isinstance(objects, list) else None
+    except Exception:
+        logger.debug("moonraker: objects/list failed", exc_info=True)
+        return None
+
+
+def get_active_spool_id(moonraker: str, timeout: float = DEFAULT_TIMEOUT):
+    """
+    Fetch the active spool ID from Moonraker's Spoolman integration.
+
+    Returns:
+        int:         the active spool ID
+        None:        no active spool (Moonraker reports null or 0)
+        FETCH_ERROR: fetch failed — Moonraker unreachable, timeout, etc.
+                     Callers must not treat this as "no spool".
+    """
+    if not moonraker:
+        return FETCH_ERROR
+
+    try:
+        response = requests.get(
+            f"{moonraker}/server/spoolman/spool_id",
+            timeout=timeout,
+        )
+        response.raise_for_status()
+        result = response.json()
+
+        # Moonraker wraps in {"result": {"spool_id": N}}
+        if isinstance(result, dict) and "result" in result:
+            result = result["result"]
+
+        spool_id = result.get("spool_id") if isinstance(result, dict) else None
+        # Moonraker returns 0 (not null) when spool is cleared/ejected
+        if spool_id is None or spool_id == 0:
+            return None
+        return int(spool_id)
+
+    except requests.ConnectionError:
+        logger.debug("moonraker: not reachable fetching active spool")
+        return FETCH_ERROR
+    except requests.Timeout:
+        logger.warning("moonraker: active spool request timed out")
+        return FETCH_ERROR
+    except requests.HTTPError as e:
+        if e.response is not None and e.response.status_code == 404:
+            logger.debug("moonraker: Spoolman integration not configured")
+        else:
+            logger.exception("moonraker: HTTP error fetching active spool")
+        return FETCH_ERROR
+    except Exception:
+        logger.exception("moonraker: unexpected error fetching active spool")
+        return FETCH_ERROR
+
+
+def set_active_spool_id(moonraker: str, spool_id: int,
+                        timeout: float = DEFAULT_TIMEOUT) -> None:
+    """
+    POST the active spool ID to Moonraker's Spoolman integration.
+
+    Use spool_id=0 to clear. Raises on HTTP error or connection failure —
+    callers own the failure semantics (rollback, skip, propagate).
+    """
+    requests.post(
+        f"{moonraker}/server/spoolman/spool_id",
+        json={"spool_id": spool_id},
+        timeout=timeout,
+    ).raise_for_status()
+
+
+def set_database_item(moonraker: str, namespace: str, key: str, value: dict,
+                      timeout: float = DEFAULT_TIMEOUT) -> None:
+    """
+    POST a key/value into Moonraker's database (e.g. the lane_data namespace
+    consumed by Orca Slicer). Raises on failure.
+    """
+    requests.post(
+        f"{moonraker}/server/database/item",
+        json={"namespace": namespace, "key": key, "value": value},
+        timeout=timeout,
+    ).raise_for_status()
+
+
+def is_printer_idle(moonraker: str, timeout: float = 2.0) -> bool:
+    """
+    True when Klipper reports print_stats.state == "standby".
+
+    False on any other state or on fetch failure — treat unknown as busy so
+    callers never take print-unsafe actions (e.g. auto-releasing a scanner
+    lock) without positive confirmation the printer is idle.
+    """
+    status = query_objects(moonraker, "print_stats", timeout=timeout,
+                           context="print-state")
+    if status is None:
+        logger.debug("Could not query Klipper print state; treating as busy")
+        return False
+    state = status.get("print_stats", {}).get("state", "")
+    return state == "standby"

--- a/middleware/moonraker_client.py
+++ b/middleware/moonraker_client.py
@@ -80,8 +80,14 @@ def list_objects(moonraker: str, timeout: float = DEFAULT_TIMEOUT) -> list | Non
         response.raise_for_status()
         objects = response.json().get("result", {}).get("objects", [])
         return objects if isinstance(objects, list) else None
+    except requests.ConnectionError:
+        logger.debug("moonraker: not reachable listing objects")
+        return None
+    except requests.Timeout:
+        logger.warning("moonraker: objects/list request timed out")
+        return None
     except Exception:
-        logger.debug("moonraker: objects/list failed", exc_info=True)
+        logger.exception("moonraker: unexpected error listing objects")
         return None
 
 

--- a/middleware/mqtt_handler.py
+++ b/middleware/mqtt_handler.py
@@ -15,12 +15,12 @@ import logging
 from typing import TYPE_CHECKING
 
 import paho.mqtt.client as mqtt
-import requests
 
 import app_state
 from activation import activate_spool, publish_lock, _activate_from_scan
 from publishers.klipper import display_spoolcolor
 from config import has_afc_scanners
+import moonraker_client
 from filament_usage import _check_low_spool
 
 if TYPE_CHECKING:
@@ -295,26 +295,7 @@ def _is_printer_idle() -> bool:
     Returns False on any other state or on fetch failure — treat unknown as
     busy so we never auto-release a lock during a print.
     """
-    moonraker_url = app_state.cfg.get("moonraker_url", "")
-    if not moonraker_url:
-        return False
-    try:
-        response = requests.get(
-            f"{moonraker_url}/printer/objects/query?print_stats",
-            timeout=2,
-        )
-        response.raise_for_status()
-        state = (
-            response.json()
-            .get("result", {})
-            .get("status", {})
-            .get("print_stats", {})
-            .get("state", "")
-        )
-        return state == "standby"
-    except (requests.RequestException, ValueError):
-        logger.debug("Could not query Klipper print state; treating as busy")
-        return False
+    return moonraker_client.is_printer_idle(app_state.cfg.get("moonraker_url", ""))
 
 
 def _should_auto_release_lock(target: str, payload: dict) -> bool:

--- a/middleware/publishers/klipper.py
+++ b/middleware/publishers/klipper.py
@@ -22,11 +22,14 @@ from __future__ import annotations
 import logging
 import re
 
-import requests
-
+from moonraker_client import send_gcode, set_active_spool_id, set_database_item
 from publishers.base import Action, Publisher, SpoolEvent
 
 logger = logging.getLogger(__name__)
+
+# Compatibility alias — send_gcode lived here before moonraker_client.py
+# existed; several modules and forks import it under this name.
+_send_gcode = send_gcode
 
 
 def _validate_color_hex(color_hex: str) -> str | None:
@@ -57,20 +60,6 @@ def display_spoolcolor(color_hex: str) -> str | None:
     if safe == "000000":
         return _LED_BLACK_SUBSTITUTE
     return safe
-
-
-def _send_gcode(moonraker: str, script: str) -> None:
-    """
-    POST a single gcode script to Moonraker.
-
-    Raises on HTTP error or connection failure. Callers are responsible for
-    catching and handling exceptions.
-    """
-    requests.post(
-        f"{moonraker}/printer/gcode/script",
-        json={"script": script},
-        timeout=5,
-    ).raise_for_status()
 
 
 def _send_afc_lane_data(
@@ -187,11 +176,7 @@ def _publish_toolhead_lane_data(moonraker: str, event: SpoolEvent) -> None:
     }
 
     try:
-        requests.post(
-            f"{moonraker}/server/database/item",
-            json={"namespace": "lane_data", "key": event.target, "value": value},
-            timeout=5,
-        ).raise_for_status()
+        set_database_item(moonraker, "lane_data", event.target, value)
         logger.info(f"[toolhead] Published lane_data for {event.target}: {material} {color}")
     except Exception:
         logger.exception(f"[toolhead] Failed to publish lane_data for {event.target}")
@@ -298,11 +283,7 @@ class KlipperPublisher(Publisher):
             return False
 
         if not event.tag_only and event.spool_id is not None:
-            requests.post(
-                f"{moonraker}/printer/gcode/script",
-                json={"script": f"SET_SPOOL_ID LANE={event.target} SPOOL_ID={event.spool_id}"},
-                timeout=5,
-            ).raise_for_status()
+            send_gcode(moonraker, f"SET_SPOOL_ID LANE={event.target} SPOOL_ID={event.spool_id}")
             logger.info(f"[afc_lane] Set spool {event.spool_id} on {event.target} via AFC")
         else:
             _send_afc_lane_data(
@@ -327,17 +308,12 @@ class KlipperPublisher(Publisher):
             return False
 
         if not event.tag_only and event.spool_id is not None:
-            requests.post(
-                f"{moonraker}/server/spoolman/spool_id",
-                json={"spool_id": event.spool_id},
-                timeout=5,
-            ).raise_for_status()
+            set_active_spool_id(moonraker, event.spool_id)
             try:
-                requests.post(
-                    f"{moonraker}/printer/gcode/script",
-                    json={"script": f"SAVE_VARIABLE VARIABLE={event.target.lower()}_spool_id VALUE={event.spool_id}"},
-                    timeout=5,
-                ).raise_for_status()
+                send_gcode(
+                    moonraker,
+                    f"SAVE_VARIABLE VARIABLE={event.target.lower()}_spool_id VALUE={event.spool_id}",
+                )
             except Exception:
                 # Rollback: revert Spoolman to prevent orphaned spool_id (#15)
                 logger.error(
@@ -345,11 +321,7 @@ class KlipperPublisher(Publisher):
                     event.spool_id, event.target,
                 )
                 try:
-                    requests.post(
-                        f"{moonraker}/server/spoolman/spool_id",
-                        json={"spool_id": 0},
-                        timeout=5,
-                    ).raise_for_status()
+                    set_active_spool_id(moonraker, 0)
                 except Exception:
                     logger.exception("[toolhead] Rollback also failed — Spoolman may have stale spool_id")
                 raise

--- a/middleware/publishers/klipper.py
+++ b/middleware/publishers/klipper.py
@@ -316,7 +316,7 @@ class KlipperPublisher(Publisher):
                 )
             except Exception:
                 # Rollback: revert Spoolman to prevent orphaned spool_id (#15)
-                logger.error(
+                logger.exception(
                     "[toolhead] SAVE_VARIABLE failed for spool %s on %s — rolling back Spoolman",
                     event.spool_id, event.target,
                 )

--- a/middleware/rest_api.py
+++ b/middleware/rest_api.py
@@ -24,8 +24,8 @@ from pydantic import BaseModel
 import app_state
 from adapters.dispatcher import detect_and_parse
 from activation import _activate_from_scan
+from moonraker_client import send_gcode
 from mqtt_handler import _record_spool_tracking, _get_scanner_target
-from publishers.klipper import _send_gcode
 from config import CONFIG_PATH
 
 logger = logging.getLogger(__name__)
@@ -266,7 +266,7 @@ def assign_tool(req: AssignToolRequest) -> ApiResponse:
         return ApiResponse(success=False, message="Moonraker URL not configured")
 
     try:
-        _send_gcode(moonraker, f"ASSIGN_SPOOL TOOL={toolhead}")
+        send_gcode(moonraker, f"ASSIGN_SPOOL TOOL={toolhead}")
         logger.info(f"[mobile] Sent ASSIGN_SPOOL TOOL={toolhead}")
     except Exception as e:
         logger.exception("Failed to send ASSIGN_SPOOL gcode")

--- a/middleware/spoolsense.py
+++ b/middleware/spoolsense.py
@@ -186,19 +186,15 @@ def _discover_afc_lanes() -> list[str]:
     if not moonraker_url:
         return []
 
-    try:
-        import requests as req
-        resp = req.get(f"{moonraker_url}/printer/objects/list", timeout=5)
-        if not resp.ok:
-            return []
-        objects = resp.json().get("result", {}).get("objects", [])
-        lanes = [o.replace("AFC_stepper ", "") for o in objects if o.startswith("AFC_stepper ")]
-        if lanes:
-            logger.info(f"Discovered AFC lanes: {lanes}")
-        return lanes
-    except Exception:
+    from moonraker_client import list_objects
+    objects = list_objects(moonraker_url)
+    if objects is None:
         logger.warning("Could not discover AFC lanes from Moonraker")
         return []
+    lanes = [o.replace("AFC_stepper ", "") for o in objects if o.startswith("AFC_stepper ")]
+    if lanes:
+        logger.info(f"Discovered AFC lanes: {lanes}")
+    return lanes
 
 
 def _setup_websocket(lane_names: list[str]) -> bool:

--- a/middleware/tests/test_happy_hare.py
+++ b/middleware/tests/test_happy_hare.py
@@ -60,8 +60,8 @@ class TestBindHappyPath(unittest.TestCase):
         _reset()
 
     def test_bind_patches_spoolman_with_gate_and_printer_name(self):
-        with patch("happy_hare.requests.get", return_value=_mock_response(_mmu_status())), \
-             patch("happy_hare._send_gcode"):
+        with patch("moonraker_client.requests.get", return_value=_mock_response(_mmu_status())), \
+             patch("happy_hare.send_gcode"):
             result = bind_spool_to_current_gate(spool_id=42)
         assert result is True
         app_state.spoolman_client.update_spool_extras.assert_called_once_with(
@@ -69,16 +69,16 @@ class TestBindHappyPath(unittest.TestCase):
         )
 
     def test_bind_fires_mmu_spoolman_sync(self):
-        with patch("happy_hare.requests.get", return_value=_mock_response(_mmu_status())), \
-             patch("happy_hare._send_gcode") as mock_gcode:
+        with patch("moonraker_client.requests.get", return_value=_mock_response(_mmu_status())), \
+             patch("happy_hare.send_gcode") as mock_gcode:
             bind_spool_to_current_gate(spool_id=42)
         mock_gcode.assert_called_once_with("http://moonraker:7125", "MMU_SPOOLMAN SYNC=1")
 
     def test_bind_sync_failure_does_not_fail_overall_bind(self):
         # The PATCH already landed; a missing sync just means Happy Hare
         # picks it up on the next periodic pull. Still report success.
-        with patch("happy_hare.requests.get", return_value=_mock_response(_mmu_status())), \
-             patch("happy_hare._send_gcode", side_effect=Exception("boom")):
+        with patch("moonraker_client.requests.get", return_value=_mock_response(_mmu_status())), \
+             patch("happy_hare.send_gcode", side_effect=Exception("boom")):
             result = bind_spool_to_current_gate(spool_id=42)
         assert result is True
 
@@ -100,34 +100,34 @@ class TestBindGuards(unittest.TestCase):
 
     def test_skipped_when_printer_name_empty(self):
         _reset(printer_name="")
-        with patch("happy_hare.requests.get", return_value=_mock_response(_mmu_status())):
+        with patch("moonraker_client.requests.get", return_value=_mock_response(_mmu_status())):
             result = bind_spool_to_current_gate(spool_id=42)
         assert result is False
         self._assert_no_patch_called()
 
     def test_skipped_when_moonraker_unreachable(self):
         import requests
-        with patch("happy_hare.requests.get", side_effect=requests.ConnectionError("refused")):
+        with patch("moonraker_client.requests.get", side_effect=requests.ConnectionError("refused")):
             result = bind_spool_to_current_gate(spool_id=42)
         assert result is False
         self._assert_no_patch_called()
 
     def test_refused_when_spoolman_support_is_push(self):
-        with patch("happy_hare.requests.get",
+        with patch("moonraker_client.requests.get",
                    return_value=_mock_response(_mmu_status(spoolman_support="push"))):
             result = bind_spool_to_current_gate(spool_id=42)
         assert result is False
         self._assert_no_patch_called()
 
     def test_refused_when_spoolman_support_is_readonly(self):
-        with patch("happy_hare.requests.get",
+        with patch("moonraker_client.requests.get",
                    return_value=_mock_response(_mmu_status(spoolman_support="readonly"))):
             result = bind_spool_to_current_gate(spool_id=42)
         assert result is False
         self._assert_no_patch_called()
 
     def test_skipped_when_mmu_disabled(self):
-        with patch("happy_hare.requests.get",
+        with patch("moonraker_client.requests.get",
                    return_value=_mock_response(_mmu_status(enabled=False))):
             result = bind_spool_to_current_gate(spool_id=42)
         assert result is False
@@ -135,14 +135,14 @@ class TestBindGuards(unittest.TestCase):
 
     def test_skipped_when_no_gate_selected(self):
         # Happy Hare reports gate=-1 (or any non-int) when no gate is selected
-        with patch("happy_hare.requests.get",
+        with patch("moonraker_client.requests.get",
                    return_value=_mock_response(_mmu_status(gate=-1))):
             result = bind_spool_to_current_gate(spool_id=42)
         assert result is False
         self._assert_no_patch_called()
 
     def test_skipped_when_gate_out_of_range(self):
-        with patch("happy_hare.requests.get",
+        with patch("moonraker_client.requests.get",
                    return_value=_mock_response(_mmu_status(gate=10, num_gates=8))):
             result = bind_spool_to_current_gate(spool_id=42)
         assert result is False
@@ -150,14 +150,14 @@ class TestBindGuards(unittest.TestCase):
 
     def test_skipped_when_spoolman_client_missing(self):
         app_state.spoolman_client = None
-        with patch("happy_hare.requests.get", return_value=_mock_response(_mmu_status())):
+        with patch("moonraker_client.requests.get", return_value=_mock_response(_mmu_status())):
             result = bind_spool_to_current_gate(spool_id=42)
         assert result is False
 
     def test_returns_false_when_spoolman_patch_fails(self):
         app_state.spoolman_client.update_spool_extras = MagicMock(return_value=False)
-        with patch("happy_hare.requests.get", return_value=_mock_response(_mmu_status())), \
-             patch("happy_hare._send_gcode"):
+        with patch("moonraker_client.requests.get", return_value=_mock_response(_mmu_status())), \
+             patch("happy_hare.send_gcode"):
             result = bind_spool_to_current_gate(spool_id=42)
         assert result is False
 
@@ -172,7 +172,7 @@ class TestModeCheckCaching(unittest.TestCase):
     def test_mismatch_logs_exactly_once(self):
         # Two calls while mode is wrong — error logged on the first, suppressed
         # on the second. (Spamming logs every scan would be noisy.)
-        with patch("happy_hare.requests.get",
+        with patch("moonraker_client.requests.get",
                    return_value=_mock_response(_mmu_status(spoolman_support="push"))):
             with self.assertLogs("happy_hare", level="ERROR") as captured:
                 # Need at least one ERROR for assertLogs to pass; we'll count after.
@@ -183,9 +183,9 @@ class TestModeCheckCaching(unittest.TestCase):
 
     def test_pull_mode_cached_after_first_success(self):
         # First call confirms pull → cached. Second call should not re-query Moonraker.
-        with patch("happy_hare.requests.get",
+        with patch("moonraker_client.requests.get",
                    return_value=_mock_response(_mmu_status())) as mock_get, \
-             patch("happy_hare._send_gcode"):
+             patch("happy_hare.send_gcode"):
             assert bind_spool_to_current_gate(spool_id=1) is True
             first_call_count = mock_get.call_count
             assert bind_spool_to_current_gate(spool_id=2) is True
@@ -198,15 +198,15 @@ class TestModeCheckCaching(unittest.TestCase):
         # If Happy Hare's mode is wrong, we must not cache it permanently —
         # the user could fix mmu_parameters.cfg and we should recover without
         # restarting the middleware.
-        with patch("happy_hare.requests.get",
+        with patch("moonraker_client.requests.get",
                    return_value=_mock_response(_mmu_status(spoolman_support="push"))):
             bind_spool_to_current_gate(spool_id=1)
         assert happy_hare._cached_pull_mode is False
 
         # User flips Happy Hare to pull mode. Next bind should succeed.
-        with patch("happy_hare.requests.get",
+        with patch("moonraker_client.requests.get",
                    return_value=_mock_response(_mmu_status(spoolman_support="pull"))), \
-             patch("happy_hare._send_gcode"):
+             patch("happy_hare.send_gcode"):
             assert bind_spool_to_current_gate(spool_id=1) is True
         assert happy_hare._cached_pull_mode is True
 
@@ -216,7 +216,7 @@ class TestModeCheckCaching(unittest.TestCase):
         # next call retries.
         bad_status = _mmu_status()
         del bad_status["spoolman_support"]
-        with patch("happy_hare.requests.get",
+        with patch("moonraker_client.requests.get",
                    return_value=_mock_response(bad_status)):
             assert bind_spool_to_current_gate(spool_id=1) is False
         assert happy_hare._cached_pull_mode is False

--- a/middleware/tests/test_moonraker_client.py
+++ b/middleware/tests/test_moonraker_client.py
@@ -1,0 +1,193 @@
+"""Tests for moonraker_client.py — shared Moonraker HTTP transport helpers."""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+import requests
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import moonraker_client  # noqa: E402
+from moonraker_client import (  # noqa: E402
+    FETCH_ERROR,
+    get_active_spool_id,
+    is_printer_idle,
+    list_objects,
+    query_objects,
+    send_gcode,
+    set_active_spool_id,
+    set_database_item,
+)
+
+BASE = "http://moonraker:7125"
+
+
+def _ok_json(payload):
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json = MagicMock(return_value=payload)
+    return resp
+
+
+class TestSendGcode(unittest.TestCase):
+
+    @patch("moonraker_client.requests.post")
+    def test_posts_script_to_gcode_endpoint(self, mock_post):
+        mock_post.return_value = _ok_json({})
+        send_gcode(BASE, "M117 hello")
+        args, kwargs = mock_post.call_args
+        self.assertEqual(args[0], f"{BASE}/printer/gcode/script")
+        self.assertEqual(kwargs["json"], {"script": "M117 hello"})
+
+    @patch("moonraker_client.requests.post")
+    def test_raises_on_http_error(self, mock_post):
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock(side_effect=requests.HTTPError("500"))
+        mock_post.return_value = resp
+        with self.assertRaises(requests.HTTPError):
+            send_gcode(BASE, "M117 boom")
+
+
+class TestQueryObjects(unittest.TestCase):
+
+    @patch("moonraker_client.requests.get")
+    def test_unwraps_result_status(self, mock_get):
+        mock_get.return_value = _ok_json(
+            {"result": {"status": {"print_stats": {"state": "standby"}}}}
+        )
+        status = query_objects(BASE, "print_stats")
+        self.assertEqual(status, {"print_stats": {"state": "standby"}})
+        self.assertIn("/printer/objects/query?print_stats", mock_get.call_args[0][0])
+
+    @patch("moonraker_client.requests.get")
+    def test_returns_none_on_connection_error(self, mock_get):
+        mock_get.side_effect = requests.ConnectionError("refused")
+        self.assertIsNone(query_objects(BASE, "mmu"))
+
+    @patch("moonraker_client.requests.get")
+    def test_returns_none_on_timeout(self, mock_get):
+        mock_get.side_effect = requests.Timeout()
+        self.assertIsNone(query_objects(BASE, "mmu"))
+
+    @patch("moonraker_client.requests.get")
+    def test_returns_none_on_non_dict_status(self, mock_get):
+        mock_get.return_value = _ok_json({"result": {"status": "garbage"}})
+        self.assertIsNone(query_objects(BASE, "mmu"))
+
+    def test_returns_none_when_no_url(self):
+        self.assertIsNone(query_objects("", "mmu"))
+
+
+class TestListObjects(unittest.TestCase):
+
+    @patch("moonraker_client.requests.get")
+    def test_returns_object_list(self, mock_get):
+        mock_get.return_value = _ok_json(
+            {"result": {"objects": ["toolhead", "save_variables"]}}
+        )
+        self.assertEqual(list_objects(BASE), ["toolhead", "save_variables"])
+
+    @patch("moonraker_client.requests.get")
+    def test_returns_none_on_failure(self, mock_get):
+        mock_get.side_effect = requests.ConnectionError("refused")
+        self.assertIsNone(list_objects(BASE))
+
+    def test_returns_none_when_no_url(self):
+        self.assertIsNone(list_objects(""))
+
+
+class TestGetActiveSpoolId(unittest.TestCase):
+
+    @patch("moonraker_client.requests.get")
+    def test_returns_spool_id(self, mock_get):
+        mock_get.return_value = _ok_json({"result": {"spool_id": 42}})
+        self.assertEqual(get_active_spool_id(BASE), 42)
+
+    @patch("moonraker_client.requests.get")
+    def test_zero_means_no_spool(self, mock_get):
+        mock_get.return_value = _ok_json({"result": {"spool_id": 0}})
+        self.assertIsNone(get_active_spool_id(BASE))
+
+    @patch("moonraker_client.requests.get")
+    def test_null_means_no_spool(self, mock_get):
+        mock_get.return_value = _ok_json({"result": {"spool_id": None}})
+        self.assertIsNone(get_active_spool_id(BASE))
+
+    @patch("moonraker_client.requests.get")
+    def test_connection_error_is_fetch_error_not_none(self, mock_get):
+        # The tri-state matters: a failed fetch must never read as "ejected"
+        mock_get.side_effect = requests.ConnectionError("refused")
+        self.assertIs(get_active_spool_id(BASE), FETCH_ERROR)
+
+    @patch("moonraker_client.requests.get")
+    def test_404_is_fetch_error(self, mock_get):
+        resp = MagicMock()
+        resp.status_code = 404
+        mock_get.side_effect = requests.HTTPError(response=resp)
+        self.assertIs(get_active_spool_id(BASE), FETCH_ERROR)
+
+    def test_no_url_is_fetch_error(self):
+        self.assertIs(get_active_spool_id(""), FETCH_ERROR)
+
+
+class TestSetActiveSpoolId(unittest.TestCase):
+
+    @patch("moonraker_client.requests.post")
+    def test_posts_spool_id(self, mock_post):
+        mock_post.return_value = _ok_json({})
+        set_active_spool_id(BASE, 42)
+        args, kwargs = mock_post.call_args
+        self.assertEqual(args[0], f"{BASE}/server/spoolman/spool_id")
+        self.assertEqual(kwargs["json"], {"spool_id": 42})
+
+    @patch("moonraker_client.requests.post")
+    def test_raises_on_failure(self, mock_post):
+        mock_post.side_effect = requests.ConnectionError("refused")
+        with self.assertRaises(requests.ConnectionError):
+            set_active_spool_id(BASE, 42)
+
+
+class TestSetDatabaseItem(unittest.TestCase):
+
+    @patch("moonraker_client.requests.post")
+    def test_posts_namespaced_item(self, mock_post):
+        mock_post.return_value = _ok_json({})
+        set_database_item(BASE, "lane_data", "T0", {"color": "#FF0000"})
+        args, kwargs = mock_post.call_args
+        self.assertEqual(args[0], f"{BASE}/server/database/item")
+        self.assertEqual(kwargs["json"], {
+            "namespace": "lane_data", "key": "T0", "value": {"color": "#FF0000"},
+        })
+
+
+class TestIsPrinterIdle(unittest.TestCase):
+
+    @patch("moonraker_client.requests.get")
+    def test_standby_is_idle(self, mock_get):
+        mock_get.return_value = _ok_json(
+            {"result": {"status": {"print_stats": {"state": "standby"}}}}
+        )
+        self.assertTrue(is_printer_idle(BASE))
+
+    @patch("moonraker_client.requests.get")
+    def test_printing_is_busy(self, mock_get):
+        mock_get.return_value = _ok_json(
+            {"result": {"status": {"print_stats": {"state": "printing"}}}}
+        )
+        self.assertFalse(is_printer_idle(BASE))
+
+    @patch("moonraker_client.requests.get")
+    def test_fetch_failure_is_busy(self, mock_get):
+        # Unknown state must never allow print-unsafe actions
+        mock_get.side_effect = requests.ConnectionError("refused")
+        self.assertFalse(is_printer_idle(BASE))
+
+    def test_no_url_is_busy(self):
+        self.assertFalse(is_printer_idle(""))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/middleware/tests/test_mqtt_handler.py
+++ b/middleware/tests/test_mqtt_handler.py
@@ -196,23 +196,23 @@ class TestIsPrinterIdle(unittest.TestCase):
         return resp
 
     def test_returns_true_when_standby(self):
-        with patch("mqtt_handler.requests.get") as mock_get:
+        with patch("moonraker_client.requests.get") as mock_get:
             mock_get.return_value = self._resp("standby")
             assert _is_printer_idle() is True
 
     def test_returns_false_when_printing(self):
-        with patch("mqtt_handler.requests.get") as mock_get:
+        with patch("moonraker_client.requests.get") as mock_get:
             mock_get.return_value = self._resp("printing")
             assert _is_printer_idle() is False
 
     def test_returns_false_when_paused(self):
-        with patch("mqtt_handler.requests.get") as mock_get:
+        with patch("moonraker_client.requests.get") as mock_get:
             mock_get.return_value = self._resp("paused")
             assert _is_printer_idle() is False
 
     def test_returns_false_on_network_error(self):
         import requests
-        with patch("mqtt_handler.requests.get", side_effect=requests.ConnectionError("boom")):
+        with patch("moonraker_client.requests.get", side_effect=requests.ConnectionError("boom")):
             assert _is_printer_idle() is False
 
     def test_returns_false_when_no_moonraker_url(self):

--- a/middleware/tests/test_rest_api.py
+++ b/middleware/tests/test_rest_api.py
@@ -227,7 +227,7 @@ class TestAssignTool(unittest.TestCase):
         self.assertFalse(resp.json()["success"])
 
     def test_valid_assign_sends_gcode_and_returns_success(self):
-        with patch("rest_api._send_gcode") as mock_gcode:
+        with patch("rest_api.send_gcode") as mock_gcode:
             resp = self._post("T0")
         self.assertEqual(resp.status_code, 200)
         self.assertTrue(resp.json()["success"])
@@ -239,14 +239,14 @@ class TestAssignTool(unittest.TestCase):
 
     def test_toolhead_uppercased(self):
         # Mobile clients may send lowercase toolhead names
-        with patch("rest_api._send_gcode") as mock_gcode:
+        with patch("rest_api.send_gcode") as mock_gcode:
             resp = self._post("t0")
         self.assertEqual(resp.status_code, 200)
         call_args = mock_gcode.call_args[0]
         self.assertIn("T0", call_args[1])
 
     def test_invalid_toolhead_returns_failure(self):
-        with patch("rest_api._send_gcode"):
+        with patch("rest_api.send_gcode"):
             resp = self._post("T9")
         self.assertEqual(resp.status_code, 200)
         self.assertFalse(resp.json()["success"])
@@ -257,12 +257,12 @@ class TestAssignTool(unittest.TestCase):
         self.assertEqual(resp.status_code, 409)
 
     def test_moonraker_error_returns_502(self):
-        with patch("rest_api._send_gcode", side_effect=Exception("connection refused")):
+        with patch("rest_api.send_gcode", side_effect=Exception("connection refused")):
             resp = self._post("T0")
         self.assertEqual(resp.status_code, 502)
 
     def test_response_includes_spool_id(self):
-        with patch("rest_api._send_gcode"):
+        with patch("rest_api.send_gcode"):
             resp = self._post("T0")
         self.assertEqual(resp.json()["spool_id"], 42)
 

--- a/middleware/toolchanger_status.py
+++ b/middleware/toolchanger_status.py
@@ -32,10 +32,11 @@ import logging
 import re
 import threading
 
-import requests
-
 import app_state
-from publishers.klipper import _send_gcode, _validate_color_hex, display_spoolcolor
+from moonraker_client import (
+    query_objects, send_gcode, set_active_spool_id, set_database_item,
+)
+from publishers.klipper import _validate_color_hex, display_spoolcolor
 
 logger = logging.getLogger(__name__)
 
@@ -56,11 +57,7 @@ def _activate_spoolman(moonraker: str, macro: str, tool_number_str: str, spoolma
     orphaned assignments that disappear after reboot (#15)."""
     # Step 1: tell Moonraker which spool is active
     try:
-        requests.post(
-            f"{moonraker}/server/spoolman/spool_id",
-            json={"spool_id": spoolman_id},
-            timeout=5,
-        ).raise_for_status()
+        set_active_spool_id(moonraker, spoolman_id)
         logger.info(f"[toolhead_stage] SET_ACTIVE_SPOOL {spoolman_id} on {macro}")
     except Exception:
         logger.exception(f"[toolhead_stage] Failed to set active spool on {macro} — skipping persist")
@@ -69,7 +66,7 @@ def _activate_spoolman(moonraker: str, macro: str, tool_number_str: str, spoolma
     # Step 2: set the gcode variable so macros can read it
     gcode_var_set = False
     try:
-        _send_gcode(moonraker, f"SET_GCODE_VARIABLE MACRO={macro} VARIABLE=spool_id VALUE={spoolman_id}")
+        send_gcode(moonraker, f"SET_GCODE_VARIABLE MACRO={macro} VARIABLE=spool_id VALUE={spoolman_id}")
         gcode_var_set = True
         logger.info(f"[toolhead_stage] SET_GCODE_VARIABLE {macro} spool_id={spoolman_id}")
     except Exception:
@@ -77,7 +74,7 @@ def _activate_spoolman(moonraker: str, macro: str, tool_number_str: str, spoolma
 
     # Step 3: persist to disk so it survives reboot
     try:
-        _send_gcode(moonraker, f"SAVE_VARIABLE VARIABLE=t{tool_number_str}_spool_id VALUE={spoolman_id}")
+        send_gcode(moonraker, f"SAVE_VARIABLE VARIABLE=t{tool_number_str}_spool_id VALUE={spoolman_id}")
         logger.info(f"[toolhead_stage] SAVE_VARIABLE t{tool_number_str}_spool_id={spoolman_id}")
         return True
     except Exception:
@@ -85,12 +82,12 @@ def _activate_spoolman(moonraker: str, macro: str, tool_number_str: str, spoolma
 
     # Rollback: undo steps 1 and 2 to avoid partial state
     try:
-        requests.post(f"{moonraker}/server/spoolman/spool_id", json={"spool_id": 0}, timeout=5).raise_for_status()
+        set_active_spool_id(moonraker, 0)
     except Exception:
         logger.exception(f"[toolhead_stage] Spoolman rollback failed for {macro}")
     if gcode_var_set:
         try:
-            _send_gcode(moonraker, f"SET_GCODE_VARIABLE MACRO={macro} VARIABLE=spool_id VALUE=0")
+            send_gcode(moonraker, f"SET_GCODE_VARIABLE MACRO={macro} VARIABLE=spool_id VALUE=0")
         except Exception:
             logger.exception(f"[toolhead_stage] Gcode variable rollback failed for {macro}")
     return False
@@ -121,11 +118,7 @@ def _publish_tool_lane_data(moonraker: str, macro: str, tool_number_str: str,
         "lane": tool_number_str,
     }
     try:
-        requests.post(
-            f"{moonraker}/server/database/item",
-            json={"namespace": "lane_data", "key": macro, "value": lane_value},
-            timeout=5,
-        ).raise_for_status()
+        set_database_item(moonraker, "lane_data", macro, lane_value)
         logger.info(f"[toolhead_stage] Published lane_data for {macro}: {safe_material} {safe_color}")
     except Exception:
         logger.exception(f"[toolhead_stage] Failed to publish lane_data for {macro}")
@@ -155,7 +148,7 @@ def _assign_spool_to_tool(tool_name: str, pending: dict) -> None:
     spool_color = display_spoolcolor(color_hex)
     if spool_color is not None:
         try:
-            _send_gcode(moonraker, f"SET_GCODE_VARIABLE MACRO={macro} VARIABLE=color VALUE=\"'{spool_color}'\"")
+            send_gcode(moonraker, f"SET_GCODE_VARIABLE MACRO={macro} VARIABLE=color VALUE=\"'{spool_color}'\"")
             logger.info(f"[toolhead_stage] SET_GCODE_VARIABLE {macro} color='{spool_color}'")
         except Exception:
             logger.exception(f"[toolhead_stage] Failed to set color on {macro}")
@@ -186,24 +179,11 @@ def _fetch_pending_tool() -> str | None:
     if not moonraker:
         return None
 
-    try:
-        response = requests.get(
-            f"{moonraker}/printer/objects/query?gcode_macro%20{MACRO_NAME}",
-            timeout=5,
-        )
-        response.raise_for_status()
-        result = response.json()
-        macro_data = result.get("result", {}).get("status", {}).get(f"gcode_macro {MACRO_NAME}", {})
-        return macro_data.get(VARIABLE_NAME, "")
-    except requests.ConnectionError:
-        logger.debug("Macro assign: Moonraker not reachable")
+    status = query_objects(moonraker, f"gcode_macro%20{MACRO_NAME}", context="Macro assign")
+    if status is None:
         return None
-    except requests.Timeout:
-        logger.warning("Macro assign: Moonraker request timed out")
-        return None
-    except Exception:
-        logger.exception("Macro assign: unexpected error")
-        return None
+    macro_data = status.get(f"gcode_macro {MACRO_NAME}", {})
+    return macro_data.get(VARIABLE_NAME, "")
 
 
 def _clear_pending_tool() -> None:
@@ -213,7 +193,7 @@ def _clear_pending_tool() -> None:
         return
 
     try:
-        _send_gcode(
+        send_gcode(
             moonraker,
             f'SET_GCODE_VARIABLE MACRO={MACRO_NAME} VARIABLE={VARIABLE_NAME} VALUE="\'\'\"',
         )

--- a/middleware/toolhead_status.py
+++ b/middleware/toolhead_status.py
@@ -18,9 +18,8 @@ import logging
 import threading
 import time
 
-import requests
-
 import app_state
+import moonraker_client
 from activation import publish_lock
 
 logger = logging.getLogger(__name__)
@@ -30,7 +29,9 @@ RETRY_BASE: float = 2.0
 RETRY_MAX: float = 30.0
 
 
-_FETCH_ERROR = object()  # sentinel: fetch failed (distinct from spool_id=None meaning "no spool")
+# Canonical sentinel lives in moonraker_client; re-exported here because
+# this module's tests and callers compare against it by identity.
+_FETCH_ERROR = moonraker_client.FETCH_ERROR
 
 
 def _fetch_active_spool_id() -> int | None | object:
@@ -42,43 +43,7 @@ def _fetch_active_spool_id() -> int | None | object:
         None: no active spool (ejected)
         _FETCH_ERROR: fetch failed (Moonraker unreachable, timeout, etc.)
     """
-    moonraker_url = app_state.cfg.get("moonraker_url", "")
-    if not moonraker_url:
-        return _FETCH_ERROR
-
-    try:
-        response = requests.get(
-            f"{moonraker_url}/server/spoolman/spool_id",
-            timeout=5,
-        )
-        response.raise_for_status()
-        result = response.json()
-
-        # Moonraker wraps in {"result": {"spool_id": N}}
-        if isinstance(result, dict) and "result" in result:
-            result = result["result"]
-
-        spool_id = result.get("spool_id") if isinstance(result, dict) else None
-        # Moonraker returns 0 (not null) when spool is cleared/ejected
-        if spool_id is None or spool_id == 0:
-            return None
-        return int(spool_id)
-
-    except requests.ConnectionError:
-        logger.debug("Toolhead status: Moonraker not reachable")
-        return _FETCH_ERROR
-    except requests.Timeout:
-        logger.warning("Toolhead status: Moonraker request timed out")
-        return _FETCH_ERROR
-    except requests.HTTPError as e:
-        if e.response is not None and e.response.status_code == 404:
-            logger.debug("Toolhead status: Spoolman integration not configured in Moonraker")
-        else:
-            logger.exception("Toolhead status: HTTP error")
-        return _FETCH_ERROR
-    except Exception:
-        logger.exception("Toolhead status: unexpected error")
-        return _FETCH_ERROR
+    return moonraker_client.get_active_spool_id(app_state.cfg.get("moonraker_url", ""))
 
 
 class ToolheadStatusSync:


### PR DESCRIPTION
## Summary

Moonraker HTTP calls were scattered across nine modules, each with its own `requests` boilerplate, timeout choice, and error handling. This PR gives the transport one home: `middleware/moonraker_client.py` — pure functions taking the Moonraker URL explicitly (same dependency-injection direction as #67, zero `app_state` coupling).

## The client

| Function | Replaces raw calls in |
|---|---|
| `send_gcode` | publishers/klipper (moved out; `_send_gcode` compat alias kept for forks), toolchanger_status, afc_status, filament_usage, happy_hare, rest_api |
| `query_objects` (unwraps `result.status` once, takes a `context` label so operators can still tell which subsystem logged a failure) | mqtt_handler, happy_hare, toolchanger_status, filament_usage ×2 |
| `get_active_spool_id` (tri-state — carries the `FETCH_ERROR` sentinel from toolhead_status so a failed fetch can never read as "ejected") | toolhead_status |
| `set_active_spool_id` (raises; callers own rollback/skip semantics) | publishers/klipper ×3, toolchanger_status ×2 |
| `set_database_item` | publishers/klipper, toolchanger_status (lane_data writes) |
| `list_objects` | spoolsense startup lane discovery |
| `is_printer_idle` | mqtt_handler (wrapper kept; future integrations use the client directly) |

**Deliberately not migrated:** AFC status polling (`/printer/afc/status`) and Moonraker job history — endpoint shapes unique to one module each.

**Behavior preserved:** wrappers keep `mqtt_handler._is_printer_idle()` and `toolhead_status._fetch_active_spool_id()` as-is for their callers; failure semantics (raise vs None vs sentinel) match the originals per call site.

## Test plan
- [x] 23 new tests for the client (request shapes, envelope unwrapping, tri-state sentinel, raise-vs-None contracts)
- [x] Existing tests unchanged except mechanical patch-target updates (27 targets re-pointed, zero assertion changes)
- [x] 460 passed / 0 failed on Python 3.9; flake8 gate clean
- [x] Independent review passes completed; no correctness issues found

Pre-existing dead imports noted but intentionally untouched (`rest_api.py`: `sys`, `StaticFiles`; `toolhead_status.py`: `time`) — they were unused before this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Moonraker/Printer integration across spool, tool, and lane workflows.
  * Added shared support for querying printer status and sending gcode more reliably.

* **Bug Fixes**
  * Made printer idle detection more consistent for auto-release behavior.
  * Improved spool assignment, pending-state updates, and lane discovery handling when Moonraker is unavailable.
  * Reduced failure cases during spool activation and rollback flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->