### PR TITLE
Consolidate six parallel spool-tracking dicts into ActiveSpool

### DIFF
--- a/middleware/app_state.py
+++ b/middleware/app_state.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 import threading
+from dataclasses import dataclass
 
 import paho.mqtt.client as mqtt
 
@@ -73,21 +74,27 @@ pending_spool: dict | None = None
 WRITE_COOLDOWN_SECONDS: int = 10
 tag_write_timestamps: dict[str, float] = {}
 
-# Filament usage tracking — used by UPDATE_TAG to calculate deductions.
-# Records the initial tag weight, UID, scanner device_id, and filament
-# properties per target at scan time. Protected by state_lock.
-active_spool_weights: dict[str, float] = {}
-active_spool_uids: dict[str, str] = {}
-active_spool_devices: dict[str, str] = {}
+# Scan-time tracking for the spool active on each target (toolhead or lane).
+# One record per target — written atomically by _record_spool_tracking() so
+# the fields can never drift apart. Used by UPDATE_TAG deduction math and
+# the lock auto-release UID comparison. Protected by state_lock.
+@dataclass
+class ActiveSpool:
+    uid: str
+    device_id: str = ""              # "" = mobile-scanned, no scanner device
+    weight_g: float | None = None    # remaining at scan; re-baselined after each deduction
+    diameter_mm: float = 1.75
+    density: float = 1.24            # g/cm³
+    tag_format: str = "unknown"      # "openprinttag", "opentag3d", "uid_only", ...
+
+
+active_spool_tracking: dict[str, ActiveSpool] = {}
 
 # Low-spool LED state — tracks whether the low-spool retained MQTT command
 # has been sent to each scanner. Edge-triggered: we only publish on state
 # transitions to avoid flooding the broker. Keyed by device_id (not lane)
 # because the MQTT cmd topic is per-scanner.
 low_spool_latched: dict[str, bool] = {}
-active_spool_diameters: dict[str, float] = {}   # mm, default 1.75
-active_spool_densities: dict[str, float] = {}   # g/cm³, default 1.24
-active_spool_formats: dict[str, str] = {}       # tag format — "openprinttag", "tigertag", etc.
 
 # Pending deductions for mobile-scanned spools (no scanner to receive MQTT).
 # Maps UID → grams pending. Persisted to ~/SpoolSense/deductions.json.

--- a/middleware/filament_usage.py
+++ b/middleware/filament_usage.py
@@ -120,7 +120,8 @@ _WRITABLE_FORMATS = {"openprinttag", "opentag3d"}
 
 def _is_writable_tag(target: str) -> bool:
     """Check if the tag on this target supports weight writes."""
-    fmt = app_state.active_spool_formats.get(target, "unknown")
+    rec = app_state.active_spool_tracking.get(target)
+    fmt = rec.tag_format if rec else "unknown"
     return fmt in _WRITABLE_FORMATS
 
 
@@ -218,23 +219,21 @@ def _handle_afc() -> None:
 
     # Snapshot state under lock
     with app_state.state_lock:
-        initial_weights = dict(app_state.active_spool_weights)
-        uids = dict(app_state.active_spool_uids)
-        devices = dict(app_state.active_spool_devices)
+        tracking = dict(app_state.active_spool_tracking)
 
     for lane, current_weight in lane_weights.items():
-        device_id = devices.get(lane)
-        _check_low_spool(device_id, current_weight)
+        rec = tracking.get(lane)
+        _check_low_spool(rec.device_id if rec else None, current_weight)
 
-        initial = initial_weights.get(lane)
-        if initial is None:
+        if rec is None or rec.weight_g is None:
             continue
 
-        deduction = initial - current_weight
+        deduction = rec.weight_g - current_weight
         if deduction <= 0:
             continue
 
-        uid = uids.get(lane)
+        uid = rec.uid
+        device_id = rec.device_id
         if not uid:
             logger.debug(f"UPDATE_TAG: no UID for {lane}, skipping")
             continue
@@ -249,9 +248,11 @@ def _handle_afc() -> None:
         else:
             _publish_deduction(device_id, uid, deduction)
 
-        # Update initial weight so next UPDATE_TAG only deducts the delta
+        # Re-baseline so the next UPDATE_TAG only deducts the delta
         with app_state.state_lock:
-            app_state.active_spool_weights[lane] = current_weight
+            live = app_state.active_spool_tracking.get(lane)
+            if live is not None:
+                live.weight_g = current_weight
 
 
 def _fetch_tool_filament_used() -> dict[str, float] | None:
@@ -267,7 +268,7 @@ def _fetch_tool_filament_used() -> dict[str, float] | None:
 
     # Build query for all active tools
     with app_state.state_lock:
-        tool_names = list(app_state.active_spool_uids.keys())
+        tool_names = list(app_state.active_spool_tracking.keys())
 
     if not tool_names:
         return None
@@ -317,29 +318,25 @@ def _handle_toolchanger() -> None:
     if tool_usage is not None:
         logger.info("UPDATE_TAG: using per-tool filament_used from toolchanger")
         with app_state.state_lock:
-            uids = dict(app_state.active_spool_uids)
-            devices = dict(app_state.active_spool_devices)
-            diameters = dict(app_state.active_spool_diameters)
-            densities = dict(app_state.active_spool_densities)
+            tracking = dict(app_state.active_spool_tracking)
 
         for tool_name, usage_mm in tool_usage.items():
             if usage_mm <= 0:
                 continue
 
-            uid = uids.get(tool_name)
-            device_id = devices.get(tool_name)
-            if not uid:
+            rec = tracking.get(tool_name)
+            if rec is None or not rec.uid:
                 logger.debug(f"UPDATE_TAG: no active spool on {tool_name}, skipping")
                 continue
+            uid = rec.uid
+            device_id = rec.device_id
 
             # Only send deductions for tags that can store weight updates
             if not _is_writable_tag(tool_name):
                 logger.debug(f"UPDATE_TAG: {tool_name} tag format is not writable, skipping deduction")
                 continue
 
-            diameter = diameters.get(tool_name, 1.75)
-            density = densities.get(tool_name, 1.24)
-            usage_g = _mm_to_grams(usage_mm, diameter, density)
+            usage_g = _mm_to_grams(usage_mm, rec.diameter_mm, rec.density)
 
             # Mobile-scanned spools have no scanner device — store for REST retrieval
             if not device_id:
@@ -357,16 +354,16 @@ def _handle_toolchanger() -> None:
         return
 
     with app_state.state_lock:
-        uids = dict(app_state.active_spool_uids)
-        devices = dict(app_state.active_spool_devices)
+        tracking = dict(app_state.active_spool_tracking)
 
     for index, weight in enumerate(weights):
         if weight <= 0:
             continue
 
         tool_name = f"T{index}"
-        uid = uids.get(tool_name)
-        device_id = devices.get(tool_name)
+        rec = tracking.get(tool_name)
+        uid = rec.uid if rec else None
+        device_id = rec.device_id if rec else None
 
         if not uid:
             logger.debug(f"UPDATE_TAG: no active spool on {tool_name}, skipping")

--- a/middleware/mqtt_handler.py
+++ b/middleware/mqtt_handler.py
@@ -76,12 +76,14 @@ def _record_spool_tracking(
     if not target or not uid or remaining is None:
         return
     with app_state.state_lock:
-        app_state.active_spool_weights[target]   = remaining
-        app_state.active_spool_uids[target]      = uid
-        app_state.active_spool_devices[target]    = device_id or ""
-        app_state.active_spool_diameters[target]  = diameter_mm or 1.75
-        app_state.active_spool_densities[target]  = density or 1.24
-        app_state.active_spool_formats[target]    = tag_format or "unknown"
+        app_state.active_spool_tracking[target] = app_state.ActiveSpool(
+            uid=uid,
+            device_id=device_id or "",
+            weight_g=remaining,
+            diameter_mm=diameter_mm or 1.75,
+            density=density or 1.24,
+            tag_format=tag_format or "unknown",
+        )
 
     # Check low-spool threshold at scan time — if a new spool has plenty of
     # filament, this also clears any latched low-spool state from the same
@@ -317,7 +319,8 @@ def _should_auto_release_lock(target: str, payload: dict) -> bool:
     # _is_printer_idle() — avoids a race window where the active spool
     # could change while we're querying Klipper.
     with app_state.state_lock:
-        active_uid = (app_state.active_spool_uids.get(target) or "").lower()
+        rec = app_state.active_spool_tracking.get(target)
+        active_uid = rec.uid.lower() if rec else ""
 
     if active_uid and incoming_uid == active_uid:
         return False
@@ -348,7 +351,8 @@ def on_message(client: mqtt.Client, userdata: object, msg: mqtt.MQTTMessage) -> 
                 active_uid = ""
                 with app_state.state_lock:
                     if app_state.lane_locks.get(target):
-                        active_uid = (app_state.active_spool_uids.get(target) or "").lower()
+                        rec = app_state.active_spool_tracking.get(target)
+                        active_uid = rec.uid.lower() if rec else ""
                         if not active_uid or active_uid != incoming_uid:
                             app_state.lane_locks[target] = False
                             released = True

--- a/middleware/tests/test_filament_usage.py
+++ b/middleware/tests/test_filament_usage.py
@@ -38,17 +38,21 @@ def _reset_app_state():
         "low_spool_threshold": 100,
     }
     app_state.state_lock = threading.Lock()
-    app_state.active_spool_weights = {}
-    app_state.active_spool_uids = {}
-    app_state.active_spool_devices = {}
-    app_state.active_spool_diameters = {}
-    app_state.active_spool_densities = {}
-    app_state.active_spool_formats = {}
+    app_state.active_spool_tracking = {}
     app_state.low_spool_latched = {}
     app_state.mqtt_client = MagicMock()
     mock_result = MagicMock()
     mock_result.rc = 0
     app_state.mqtt_client.publish.return_value = mock_result
+
+
+def _track(target, uid, device="", weight=None, diameter=1.75, density=1.24,
+           fmt="unknown"):
+    """Install an ActiveSpool tracking record for a target."""
+    app_state.active_spool_tracking[target] = app_state.ActiveSpool(
+        uid=uid, device_id=device, weight_g=weight,
+        diameter_mm=diameter, density=density, tag_format=fmt,
+    )
 
 
 class TestFetchLastJobWeights(unittest.TestCase):
@@ -186,11 +190,7 @@ class TestHandleToolchangerPrimary(unittest.TestCase):
     @patch("filament_usage._fetch_tool_filament_used")
     def test_sends_deduction_from_tool_objects(self, mock_fetch_tool, mock_clear):
         mock_fetch_tool.return_value = {"T0": 5000.0}  # 5000mm
-        app_state.active_spool_uids["T0"] = "abc123"
-        app_state.active_spool_devices["T0"] = "f3d360"
-        app_state.active_spool_diameters["T0"] = 1.75
-        app_state.active_spool_densities["T0"] = 1.24
-        app_state.active_spool_formats["T0"] = "openprinttag"
+        _track("T0", uid="abc123", device="f3d360", fmt="openprinttag")
 
         _handle_toolchanger()
 
@@ -202,16 +202,8 @@ class TestHandleToolchangerPrimary(unittest.TestCase):
     @patch("filament_usage._fetch_tool_filament_used")
     def test_sends_per_tool_deductions_from_tool_objects(self, mock_fetch_tool, mock_clear):
         mock_fetch_tool.return_value = {"T0": 3000.0, "T2": 2000.0}
-        app_state.active_spool_uids["T0"] = "uid-aaa"
-        app_state.active_spool_devices["T0"] = "scanner1"
-        app_state.active_spool_diameters["T0"] = 1.75
-        app_state.active_spool_densities["T0"] = 1.24
-        app_state.active_spool_formats["T0"] = "openprinttag"
-        app_state.active_spool_uids["T2"] = "uid-bbb"
-        app_state.active_spool_devices["T2"] = "scanner1"
-        app_state.active_spool_diameters["T2"] = 1.75
-        app_state.active_spool_densities["T2"] = 1.24
-        app_state.active_spool_formats["T2"] = "openprinttag"
+        _track("T0", uid="uid-aaa", device="scanner1", fmt="openprinttag")
+        _track("T2", uid="uid-bbb", device="scanner1", fmt="openprinttag")
 
         _handle_toolchanger()
 
@@ -224,11 +216,8 @@ class TestHandleToolchangerPrimary(unittest.TestCase):
     @patch("filament_usage._fetch_tool_filament_used")
     def test_uses_tag_diameter_and_density(self, mock_fetch_tool, mock_clear):
         mock_fetch_tool.return_value = {"T0": 1000.0}  # 1000mm
-        app_state.active_spool_uids["T0"] = "abc123"
-        app_state.active_spool_devices["T0"] = "f3d360"
-        app_state.active_spool_diameters["T0"] = 2.85
-        app_state.active_spool_densities["T0"] = 1.27
-        app_state.active_spool_formats["T0"] = "openprinttag"
+        _track("T0", uid="abc123", device="f3d360", diameter=2.85, density=1.27,
+               fmt="openprinttag")
 
         _handle_toolchanger()
 
@@ -243,8 +232,7 @@ class TestHandleToolchangerPrimary(unittest.TestCase):
     @patch("filament_usage._fetch_tool_filament_used")
     def test_skips_tools_with_zero_usage(self, mock_fetch_tool, mock_clear):
         mock_fetch_tool.return_value = {"T0": 0.0, "T1": 0.0}
-        app_state.active_spool_uids["T0"] = "uid-aaa"
-        app_state.active_spool_devices["T0"] = "scanner1"
+        _track("T0", uid="uid-aaa", device="scanner1")
 
         _handle_toolchanger()
 
@@ -263,9 +251,7 @@ class TestHandleToolchangerFallback(unittest.TestCase):
     def test_falls_back_to_slicer_weights(self, mock_fetch_tool, mock_fetch_job, mock_clear):
         mock_fetch_tool.return_value = None  # mod not installed
         mock_fetch_job.return_value = [25.5]
-        app_state.active_spool_uids["T0"] = "abc123"
-        app_state.active_spool_devices["T0"] = "f3d360"
-        app_state.active_spool_formats["T0"] = "openprinttag"
+        _track("T0", uid="abc123", device="f3d360", fmt="openprinttag")
 
         _handle_toolchanger()
 
@@ -279,12 +265,8 @@ class TestHandleToolchangerFallback(unittest.TestCase):
     def test_fallback_per_tool_deductions(self, mock_fetch_tool, mock_fetch_job, mock_clear):
         mock_fetch_tool.return_value = None
         mock_fetch_job.return_value = [50.0, 0.0, 30.0, 0.0]
-        app_state.active_spool_uids["T0"] = "uid-aaa"
-        app_state.active_spool_devices["T0"] = "scanner1"
-        app_state.active_spool_formats["T0"] = "openprinttag"
-        app_state.active_spool_uids["T2"] = "uid-bbb"
-        app_state.active_spool_devices["T2"] = "scanner1"
-        app_state.active_spool_formats["T2"] = "openprinttag"
+        _track("T0", uid="uid-aaa", device="scanner1", fmt="openprinttag")
+        _track("T2", uid="uid-bbb", device="scanner1", fmt="openprinttag")
 
         _handle_toolchanger()
 
@@ -336,10 +318,8 @@ class TestHandleAfc(unittest.TestCase):
     @patch("filament_usage._fetch_afc_lane_weights")
     def test_sends_deduction_from_weight_delta(self, mock_fetch, mock_clear):
         mock_fetch.return_value = {"lane1": 550.0, "lane2": 720.0}
-        app_state.active_spool_weights = {"lane1": 800.0, "lane2": 750.0}
-        app_state.active_spool_uids = {"lane1": "uid-aaa", "lane2": "uid-bbb"}
-        app_state.active_spool_devices = {"lane1": "scanner1", "lane2": "scanner1"}
-        app_state.active_spool_formats = {"lane1": "openprinttag", "lane2": "openprinttag"}
+        _track("lane1", uid="uid-aaa", device="scanner1", weight=800.0, fmt="openprinttag")
+        _track("lane2", uid="uid-bbb", device="scanner1", weight=750.0, fmt="openprinttag")
 
         _handle_afc()
 
@@ -352,22 +332,17 @@ class TestHandleAfc(unittest.TestCase):
     @patch("filament_usage._fetch_afc_lane_weights")
     def test_updates_initial_weight_after_deduction(self, mock_fetch, mock_clear):
         mock_fetch.return_value = {"lane1": 550.0}
-        app_state.active_spool_weights = {"lane1": 800.0}
-        app_state.active_spool_uids = {"lane1": "uid-aaa"}
-        app_state.active_spool_devices = {"lane1": "scanner1"}
-        app_state.active_spool_formats = {"lane1": "openprinttag"}
+        _track("lane1", uid="uid-aaa", device="scanner1", weight=800.0, fmt="openprinttag")
 
         _handle_afc()
 
-        self.assertEqual(app_state.active_spool_weights["lane1"], 550.0)
+        self.assertEqual(app_state.active_spool_tracking["lane1"].weight_g, 550.0)
 
     @patch("filament_usage._clear_pending")
     @patch("filament_usage._fetch_afc_lane_weights")
     def test_skips_lanes_with_no_usage(self, mock_fetch, mock_clear):
         mock_fetch.return_value = {"lane1": 800.0}  # same as initial
-        app_state.active_spool_weights = {"lane1": 800.0}
-        app_state.active_spool_uids = {"lane1": "uid-aaa"}
-        app_state.active_spool_devices = {"lane1": "scanner1"}
+        _track("lane1", uid="uid-aaa", device="scanner1", weight=800.0)
 
         _handle_afc()
 
@@ -377,8 +352,8 @@ class TestHandleAfc(unittest.TestCase):
     @patch("filament_usage._fetch_afc_lane_weights")
     def test_skips_lanes_without_initial_weight(self, mock_fetch, mock_clear):
         mock_fetch.return_value = {"lane1": 550.0}
-        # No initial weight recorded
-        app_state.active_spool_weights = {}
+        # No tracking record for the lane at all
+        app_state.active_spool_tracking = {}
 
         _handle_afc()
 
@@ -493,10 +468,7 @@ class TestHandleAfcLowSpoolIntegration(unittest.TestCase):
     ) -> None:
         # Initial weight 800g, deducts to 80g which is below threshold (100g)
         mock_fetch.return_value = {"lane1": 80.0}
-        app_state.active_spool_weights = {"lane1": 800.0}
-        app_state.active_spool_uids = {"lane1": "uid-aaa"}
-        app_state.active_spool_devices = {"lane1": "scanner1"}
-        app_state.active_spool_formats = {"lane1": "openprinttag"}
+        _track("lane1", uid="uid-aaa", device="scanner1", weight=800.0, fmt="openprinttag")
 
         _handle_afc()
 
@@ -513,10 +485,7 @@ class TestHandleAfcLowSpoolIntegration(unittest.TestCase):
     ) -> None:
         # Deducts to 500g, well above threshold
         mock_fetch.return_value = {"lane1": 500.0}
-        app_state.active_spool_weights = {"lane1": 800.0}
-        app_state.active_spool_uids = {"lane1": "uid-aaa"}
-        app_state.active_spool_devices = {"lane1": "scanner1"}
-        app_state.active_spool_formats = {"lane1": "openprinttag"}
+        _track("lane1", uid="uid-aaa", device="scanner1", weight=800.0, fmt="openprinttag")
 
         _handle_afc()
 

--- a/middleware/tests/test_mqtt_handler.py
+++ b/middleware/tests/test_mqtt_handler.py
@@ -56,7 +56,7 @@ def _reset_app_state(prefix="spoolsense", scanners=None):
     }
     app_state.lane_locks = {}
     app_state.active_spools = {}
-    app_state.active_spool_uids = {}
+    app_state.active_spool_tracking = {}
     app_state.pending_spool = None
     app_state.state_lock = threading.Lock()
 
@@ -225,7 +225,7 @@ class TestShouldAutoReleaseLock(unittest.TestCase):
 
     def setUp(self):
         _reset_app_state()
-        app_state.active_spool_uids["T0"] = "abc123"
+        app_state.active_spool_tracking["T0"] = app_state.ActiveSpool(uid="abc123")
 
     def test_same_uid_does_not_auto_release(self):
         # Same tag scanned twice — no swap intent, lock stays
@@ -254,7 +254,7 @@ class TestShouldAutoReleaseLock(unittest.TestCase):
         # Edge: lock is set but tracking is empty (e.g. lock set without
         # _record_spool_tracking running). Different incoming UID + idle
         # printer should still release.
-        app_state.active_spool_uids = {}
+        app_state.active_spool_tracking = {}
         with patch("mqtt_handler._is_printer_idle", return_value=True):
             assert _should_auto_release_lock("T0", {"uid": "anything"}) is True
 
@@ -268,7 +268,7 @@ class TestOnMessageLockBehavior(unittest.TestCase):
         )
         app_state.DISPATCHER_AVAILABLE = True
         app_state.lane_locks["T0"] = True
-        app_state.active_spool_uids["T0"] = "abc123"
+        app_state.active_spool_tracking["T0"] = app_state.ActiveSpool(uid="abc123")
 
     def _msg(self, uid: str | None) -> MagicMock:
         m = MagicMock()


### PR DESCRIPTION
## Summary

`active_spool_weights`, `_uids`, `_devices`, `_diameters`, `_densities`, and `_formats` were six dicts all keyed by target — written together in `_record_spool_tracking` and read together by the UPDATE_TAG deduction paths. Six parallel dicts is an invitation for drift: one code path updates four of six and the state quietly stops describing one spool.

One dataclass now holds the scan-time record:

```python
@dataclass
class ActiveSpool:
    uid: str
    device_id: str = ""              # "" = mobile-scanned, no scanner device
    weight_g: float | None = None    # remaining at scan; re-baselined after each deduction
    diameter_mm: float = 1.75
    density: float = 1.24
    tag_format: str = "unknown"
```

stored in a single `active_spool_tracking: dict[str, ActiveSpool]`, written atomically under `state_lock`.

## Touched paths

- `mqtt_handler._record_spool_tracking` — builds one record instead of six assignments
- `mqtt_handler` lock auto-release — both UID comparisons read `rec.uid`
- `filament_usage` — AFC deduction, toolchanger per-tool deduction, and slicer-fallback paths all read one snapshot; AFC's post-deduction weight re-baseline mutates `rec.weight_g` under the lock

## Behavior preserved

- Records only created when target + uid + weight are known (same guard)
- Mobile scans keep `device_id=""` semantics for REST-stored deductions
- `_check_low_spool` still fires for lanes without tracking records
- Same defaults (1.75 mm, 1.24 g/cm³, "unknown" format)

## Test plan
- [x] 460 passed / 0 failed; flake8 gate clean
- [x] Zero references to the old dict names remain repo-wide
- [x] Test setups collapse to a `_track()` helper (6 lines → 1 per target); assertions preserved
- [x] Independent review pass found no correctness issues