### PR TITLE
Publish middleware service health to MQTT

### DIFF
--- a/middleware/README.md
+++ b/middleware/README.md
@@ -38,6 +38,7 @@ middleware/
 ├── filament_usage.py          # UPDATE_TAG macro — filament deduction tracking
 ├── moonraker_ws.py            # Moonraker websocket — real-time AFC and macro events
 ├── moonraker_client.py        # Shared Moonraker HTTP helpers — gcode, queries, spool_id, DB items
+├── health.py                  # Service health → retained MQTT status topic (edge-triggered)
 ├── klipper_vars.py            # Klipper save_variables sync via Moonraker websocket (toolhead modes)
 │
 ├── spoolman/

--- a/middleware/app_state.py
+++ b/middleware/app_state.py
@@ -96,6 +96,16 @@ active_spool_tracking: dict[str, ActiveSpool] = {}
 # because the MQTT cmd topic is per-scanner.
 low_spool_latched: dict[str, bool] = {}
 
+# Per-service health for the MQTT status topic (#41). "unknown" until the
+# first check; updated via health.set_health() which publishes retained
+# snapshots on transitions. Protected by state_lock.
+service_health: dict[str, str] = {
+    "mqtt": "unknown",
+    "moonraker": "unknown",
+    "spoolman": "unknown",
+    "klipper": "unknown",
+}
+
 # Pending deductions for mobile-scanned spools (no scanner to receive MQTT).
 # Maps UID → grams pending. Persisted to ~/SpoolSense/deductions.json.
 # Protected by state_lock.

--- a/middleware/health.py
+++ b/middleware/health.py
@@ -1,0 +1,88 @@
+"""
+health.py — middleware service health published to MQTT (#41).
+
+Tracks per-service connectivity (mqtt, moonraker, spoolman, klipper) and
+publishes a retained JSON snapshot to `spoolsense/middleware/status` on
+state transitions only — same edge-triggered philosophy as the low-spool
+LED (#61). Retained + QoS 1 means scanners and dashboards get the current
+state immediately on subscribe without polling.
+
+Callers report state from wherever they already learn it (poll loops,
+websocket callbacks, cache refreshes):
+
+    from health import set_health
+    set_health("moonraker", "unreachable")
+
+Values per #41: "connected" / "unreachable" for services,
+"ready" / "disconnected" for klipper. "unknown" before the first check.
+"""
+from __future__ import annotations
+
+import json
+import logging
+
+import app_state
+
+logger = logging.getLogger(__name__)
+
+STATUS_TOPIC = "spoolsense/middleware/status"
+
+_SERVICES = ("mqtt", "moonraker", "spoolman", "klipper")
+
+# Last snapshot actually published — compared under state_lock so identical
+# transitions from concurrent reporters publish once.
+_last_published: dict | None = None
+
+
+def set_health(service: str, status: str) -> None:
+    """
+    Record a service's health and publish the full snapshot if anything
+    changed since the last publish. Safe from any thread; never raises.
+    """
+    global _last_published
+
+    if service not in _SERVICES:
+        logger.warning("health: unknown service %r ignored", service)
+        return
+
+    with app_state.state_lock:
+        current = app_state.service_health.get(service)
+        if current == status:
+            return
+        app_state.service_health[service] = status
+        snapshot = dict(app_state.service_health)
+        if snapshot == _last_published:
+            return
+        _last_published = snapshot
+
+    _publish(snapshot)
+
+
+def publish_current() -> None:
+    """
+    Publish the current snapshot unconditionally (used after MQTT reconnect
+    so the retained topic reflects this session's state).
+    """
+    global _last_published
+    with app_state.state_lock:
+        snapshot = dict(app_state.service_health)
+        _last_published = snapshot
+    _publish(snapshot)
+
+
+def _publish(snapshot: dict) -> None:
+    """Publish the snapshot to the retained status topic. Never raises."""
+    client = app_state.mqtt_client
+    if client is None:
+        return
+    try:
+        client.publish(STATUS_TOPIC, json.dumps(snapshot), qos=1, retain=True)
+        logger.info("health: %s", snapshot)
+    except Exception:
+        logger.exception("health: failed to publish status")
+
+
+def _reset_for_testing() -> None:
+    """Test helper — clears the last-published snapshot."""
+    global _last_published
+    _last_published = None

--- a/middleware/moonraker_ws.py
+++ b/middleware/moonraker_ws.py
@@ -33,6 +33,17 @@ RETRY_BASE: float = 2.0
 RETRY_MAX: float = 30.0
 
 
+def _report_health(service: str, status: str) -> None:
+    """Best-effort health reporting (#41) — must never break websocket setup.
+
+    Imported lazily so this module stays importable without app_state."""
+    try:
+        from health import set_health
+        set_health(service, status)
+    except Exception:
+        logger.debug("health reporting unavailable", exc_info=True)
+
+
 class MoonrakerWebsocket:
     """
     Single websocket connection to Moonraker for real-time printer object updates.
@@ -130,6 +141,7 @@ class MoonrakerWebsocket:
         """Connected — discover AFC lanes via printer.objects.list, then subscribe."""
         logger.info("MoonrakerWebsocket: connected")
         self._consecutive_failures = 0
+        _report_health("moonraker", "connected")
         self._discover_lanes(ws)
 
     def _discover_lanes(self, ws) -> None:
@@ -191,6 +203,10 @@ class MoonrakerWebsocket:
         # Subscription response — contains full initial state
         if msg_id is not None and msg_id == self._subscribe_id:
             status = data.get("result", {}).get("status", {})
+            # Successful subscription implies Klipper is up — Moonraker
+            # rejects object subscriptions while klippy is down. Covers
+            # normal startup, where notify_klippy_ready never fires.
+            _report_health("klipper", "ready")
             self._dispatch_status(status)
             logger.info("MoonrakerWebsocket: initial state received")
             return
@@ -205,13 +221,17 @@ class MoonrakerWebsocket:
         # Klipper restarted — re-discover lanes and re-subscribe for fresh state
         elif method == "notify_klippy_ready":
             logger.info("MoonrakerWebsocket: Klipper ready — re-discovering AFC lanes")
+            _report_health("klipper", "ready")
             self._discover_lanes(ws)
 
         elif method == "notify_klippy_disconnected":
             logger.warning("MoonrakerWebsocket: Klipper disconnected — waiting for reconnect")
+            _report_health("klipper", "disconnected")
 
     def _on_close(self, ws, close_status_code, close_msg) -> None:
         logger.info(f"MoonrakerWebsocket: connection closed ({close_status_code})")
+        if not self._stop_event.is_set():
+            _report_health("moonraker", "unreachable")
 
     def _on_error(self, ws, error) -> None:
         if not self._stop_event.is_set():

--- a/middleware/mqtt_handler.py
+++ b/middleware/mqtt_handler.py
@@ -279,6 +279,13 @@ def on_connect(client: mqtt.Client, userdata: object, flags: dict, rc: int) -> N
     logger.info(f"Subscribed to {len(scanners)} scanner(s): {', '.join(scanners.keys())}")
 
     client.publish("spoolsense/middleware/online", "true", qos=1, retain=True)
+
+    # Health status (#41) — mark MQTT up and refresh the retained snapshot
+    # so subscribers see this session's state after a reconnect.
+    from health import set_health, publish_current
+    set_health("mqtt", "connected")
+    publish_current()
+
     if app_state.spoolman_client:
         app_state.spoolman_client.refresh()
 

--- a/middleware/spoolman/client.py
+++ b/middleware/spoolman/client.py
@@ -45,8 +45,13 @@ class SpoolmanClient:
             self.cache = new_cache
             self._last_refresh = time.time()
             logger.info(f"Spoolman cache refreshed: {len(self.cache)} spools indexed.")
+            # Imported lazily: this client stays free of app_state coupling (#41)
+            from health import set_health
+            set_health("spoolman", "connected")
         except Exception as e:
             logger.error(f"Failed to fetch Spoolman cache: {e}")
+            from health import set_health
+            set_health("spoolman", "unreachable")
 
     def refresh(self) -> None:
         """Public wrapper around _fetch_all_spools for explicit cache priming."""

--- a/middleware/tests/test_health.py
+++ b/middleware/tests/test_health.py
@@ -1,0 +1,151 @@
+"""Tests for health.py — edge-triggered service health on a retained MQTT topic (#41)."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import threading
+import unittest
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+sys.modules.setdefault("paho", MagicMock())
+sys.modules.setdefault("paho.mqtt", MagicMock())
+sys.modules.setdefault("paho.mqtt.client", MagicMock())
+
+import app_state  # noqa: E402
+import health  # noqa: E402
+from health import STATUS_TOPIC, publish_current, set_health  # noqa: E402
+
+
+def _reset(mqtt_client=True):
+    app_state.state_lock = threading.Lock()
+    app_state.service_health = {
+        "mqtt": "unknown",
+        "moonraker": "unknown",
+        "spoolman": "unknown",
+        "klipper": "unknown",
+    }
+    app_state.mqtt_client = MagicMock() if mqtt_client else None
+    health._reset_for_testing()
+
+
+def _published_payloads():
+    return [
+        json.loads(call.args[1])
+        for call in app_state.mqtt_client.publish.call_args_list
+        if call.args[0] == STATUS_TOPIC
+    ]
+
+
+class TestSetHealth(unittest.TestCase):
+
+    def setUp(self):
+        _reset()
+
+    def test_transition_publishes_full_snapshot(self):
+        set_health("moonraker", "connected")
+        payloads = _published_payloads()
+        self.assertEqual(len(payloads), 1)
+        self.assertEqual(payloads[0], {
+            "mqtt": "unknown",
+            "moonraker": "connected",
+            "spoolman": "unknown",
+            "klipper": "unknown",
+        })
+
+    def test_publishes_retained_qos1(self):
+        set_health("moonraker", "connected")
+        kwargs = app_state.mqtt_client.publish.call_args.kwargs
+        self.assertTrue(kwargs["retain"])
+        self.assertEqual(kwargs["qos"], 1)
+
+    def test_no_change_no_publish(self):
+        # Poll loops report the same state every cycle — only the first
+        # transition may publish
+        set_health("moonraker", "connected")
+        set_health("moonraker", "connected")
+        set_health("moonraker", "connected")
+        self.assertEqual(len(_published_payloads()), 1)
+
+    def test_flap_publishes_each_transition(self):
+        set_health("moonraker", "connected")
+        set_health("moonraker", "unreachable")
+        set_health("moonraker", "connected")
+        self.assertEqual(len(_published_payloads()), 3)
+
+    def test_multiple_services_each_publish(self):
+        set_health("moonraker", "connected")
+        set_health("klipper", "ready")
+        set_health("spoolman", "unreachable")
+        payloads = _published_payloads()
+        self.assertEqual(len(payloads), 3)
+        self.assertEqual(payloads[-1], {
+            "mqtt": "unknown",
+            "moonraker": "connected",
+            "spoolman": "unreachable",
+            "klipper": "ready",
+        })
+
+    def test_unknown_service_ignored(self):
+        set_health("nonsense", "connected")
+        self.assertEqual(len(_published_payloads()), 0)
+        self.assertNotIn("nonsense", app_state.service_health)
+
+    def test_no_mqtt_client_no_crash(self):
+        _reset(mqtt_client=False)
+        set_health("moonraker", "connected")  # must not raise
+        self.assertEqual(app_state.service_health["moonraker"], "connected")
+
+    def test_publish_failure_does_not_raise(self):
+        app_state.mqtt_client.publish.side_effect = Exception("broker gone")
+        set_health("moonraker", "connected")  # must not raise
+        self.assertEqual(app_state.service_health["moonraker"], "connected")
+
+
+class TestPublishCurrent(unittest.TestCase):
+
+    def setUp(self):
+        _reset()
+
+    def test_publishes_unconditionally(self):
+        publish_current()
+        publish_current()
+        self.assertEqual(len(_published_payloads()), 2)
+
+    def test_set_health_after_publish_current_dedups(self):
+        # publish_current records the snapshot; a redundant set_health
+        # must not double-publish
+        set_health("mqtt", "connected")
+        publish_current()
+        set_health("mqtt", "connected")
+        self.assertEqual(len(_published_payloads()), 2)
+
+
+class TestMoonrakerWsWiring(unittest.TestCase):
+    """Klippy lifecycle events must drive the klipper health state."""
+
+    def setUp(self):
+        _reset(mqtt_client=False)
+        from moonraker_ws import MoonrakerWebsocket
+        self.ws = MoonrakerWebsocket("ws://localhost:7125/websocket")
+
+    def test_klippy_ready_sets_health(self):
+        self.ws._on_message(MagicMock(), json.dumps({"method": "notify_klippy_ready"}))
+        self.assertEqual(app_state.service_health["klipper"], "ready")
+
+    def test_klippy_disconnected_sets_health(self):
+        self.ws._on_message(MagicMock(), json.dumps({"method": "notify_klippy_disconnected"}))
+        self.assertEqual(app_state.service_health["klipper"], "disconnected")
+
+    def test_subscribe_response_sets_klipper_ready(self):
+        # Normal startup: notify_klippy_ready never fires, but a successful
+        # subscription is positive evidence Klipper is up.
+        self.ws._subscribe_id = 5
+        self.ws._on_message(MagicMock(), json.dumps({"id": 5, "result": {"status": {}}}))
+        self.assertEqual(app_state.service_health["klipper"], "ready")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/middleware/toolhead_status.py
+++ b/middleware/toolhead_status.py
@@ -111,7 +111,10 @@ class ToolheadStatusSync:
                 consecutive_failures = 0
                 wait = POLL_INTERVAL
             else:
-                # Fetch failed — do NOT treat as eject, just backoff and retry
+                # Fetch failed — do NOT treat as eject, just backoff and retry.
+                # No health report here: _FETCH_ERROR includes 404 from
+                # no-Spoolman setups, which is not a Moonraker outage — the
+                # websocket open/close is the moonraker health source (#41).
                 consecutive_failures += 1
                 wait = min(RETRY_BASE * (2 ** (consecutive_failures - 1)), RETRY_MAX)
                 if consecutive_failures == 1:


### PR DESCRIPTION
Closes #41.

## Summary

Implements the design agreed in #41: per-service health (`mqtt`, `moonraker`, `spoolman`, `klipper`) published to `spoolsense/middleware/status` — **retained, QoS 1, transitions only**. Retained means scanners and dashboards get current state immediately on subscribe; edge-triggering keeps broker traffic near zero (same pattern as the low-spool LED, #61).

```json
{"mqtt": "connected", "moonraker": "connected", "spoolman": "connected", "klipper": "ready"}
```

Values per #41: `connected` / `unreachable`, `ready` / `disconnected` for klipper, plus `unknown` before the first check.

## Where reporters live

- **mqtt** — `on_connect` marks it up and refreshes the retained snapshot for the new session
- **moonraker** — websocket open/close only. The HTTP pollers deliberately don't report: `FETCH_ERROR` can't distinguish a 404 on a no-Spoolman setup from a real outage, and a false "unreachable" on dashboards is worse than no signal
- **klipper** — `notify_klippy_ready`/`notify_klippy_disconnected`, **plus** a successful object subscription reports `ready` (Moonraker rejects subscriptions while klippy is down) — covering normal startup, where the ready notification never fires
- **spoolman** — cache refresh success/failure in `SpoolmanClient`

Health reporting is best-effort everywhere — `_report_health()` in the websocket can never break subscription setup, and `set_health()` never raises.

## Out of scope

Scanner-side TFT/LCD display of this topic (scanner repo). The web panel can adopt the same source later.

## Test plan
- [x] 13 new tests: transition publish, dedup, flap behavior, retained+QoS flags, unknown-service guard, no-client/no-crash, publish-failure/no-crash, klippy lifecycle wiring, subscribe-response evidence
- [x] 473 passed / 0 failed; flake8 gate clean
- [x] Independent review pass: three findings (critical-path import, startup klipper state, poller 404 conflation) — all addressed