### PR TITLE
chore: add installer-impact checkbox to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,3 +11,4 @@ Steps to verify these changes work.
 - [ ] Tested with live scanner hardware
 - [ ] Config examples updated if config format changed
 - [ ] Works with Spoolman enabled and disabled
+- [ ] Installer impact assessed — new config keys, setup types/actions, Spoolman extra fields, or install steps need a matching spoolsense-installer issue


### PR DESCRIPTION
Adds one checklist line so PRs that introduce new config keys, setup types/actions, Spoolman extra fields, or install steps get a matching spoolsense-installer issue at merge time instead of being discovered months later (Happy Hare shipped in v1.7.3 with no install path until the installer catch-up). Tracking pattern: SpoolSense/spoolsense-installer#38.