### PR TITLE
Add MQTT event publisher — SpoolEvents on spoolsense/events/#

### DIFF
--- a/middleware/README.md
+++ b/middleware/README.md
@@ -29,7 +29,8 @@ middleware/
 │
 ├── publishers/
 │   ├── base.py                # SpoolEvent dataclass, Publisher ABC, Action enum
-│   └── klipper.py             # KlipperPublisher — gcode commands, Moonraker REST
+│   ├── klipper.py             # KlipperPublisher — gcode commands, Moonraker REST
+│   └── mqtt_events.py         # MqttEventPublisher — SpoolEvents → spoolsense/events/#
 ├── publisher_manager.py       # Fan-out dispatcher — primary + secondary publishers
 │
 ├── afc_status.py              # AFC lane state sync via Moonraker (websocket/polling)

--- a/middleware/activation.py
+++ b/middleware/activation.py
@@ -125,7 +125,7 @@ def _try_spoolman_activation(event: SpoolEvent, spoolman_id: int, target: str | 
 
 def _route_staged(action_enum: Action, spoolman_activated: bool,
                   color_hex: str, filament_label: str, remaining: float | None,
-                  spoolman_id: int | None) -> None:
+                  spoolman_id: int | None, event: SpoolEvent) -> None:
     """Handle afc_stage and toolhead_stage — cache tag data, don't lock."""
     _cache_pending_spool(color_hex, filament_label, remaining, spoolman_id)
     stage_name = "afc_stage" if action_enum == Action.AFC_STAGE else "toolhead_stage"
@@ -133,9 +133,21 @@ def _route_staged(action_enum: Action, spoolman_activated: bool,
         logger.info(f"[{stage_name}] Spool staged with Spoolman ID, scanner remains unlocked")
     else:
         logger.info(f"[{stage_name}] Tag data cached, waiting for assignment. Scanner remains unlocked")
+    if spoolman_id is None:
+        # Tag-only staged scans never reach the publisher chain — the event
+        # stream still gets them via the observer path (#93)
+        notify_observers(event)
 
 
-def _route_happy_hare(spoolman_id: int | None) -> None:
+def notify_observers(event: SpoolEvent) -> None:
+    """Fan an event out to secondary (observer) publishers only — never the
+    primary, so no printer commands fire. No-op when the manager isn't wired."""
+    manager = app_state.publisher_manager
+    if manager is not None:
+        manager.notify(event)
+
+
+def _route_happy_hare(spoolman_id: int | None, event: SpoolEvent) -> None:
     """Handle happy_hare_stage — bind the scanned spool to the currently-selected
     MMU gate via Spoolman extras + Happy Hare sync trigger. No lock, no cache."""
     if spoolman_id is None:
@@ -143,7 +155,8 @@ def _route_happy_hare(spoolman_id: int | None) -> None:
                        "The scanned tag must be registered in Spoolman first.")
         return
     from happy_hare import bind_spool_to_current_gate
-    bind_spool_to_current_gate(spoolman_id)
+    if bind_spool_to_current_gate(spoolman_id):
+        notify_observers(event)
 
 
 def _route_dedicated(action_enum: Action, spoolman_activated: bool,
@@ -162,10 +175,14 @@ def _route_dedicated(action_enum: Action, spoolman_activated: bool,
 
 # ── UID-only activation path ────────────────────────────────────────────────
 
-def activate_spool(spool_id: int, action: str, target: str | None = None) -> bool:
+def activate_spool(spool_id: int, action: str, target: str | None = None,
+                   color: str | None = None, material: str | None = None,
+                   weight: float | None = None,
+                   scanner_id: str = "legacy") -> bool:
     """
     UID-only fallback path — called when tag has no embedded data but maps to a Spoolman spool.
-    Builds a minimal SpoolEvent and routes through publisher_manager.
+    Builds a SpoolEvent (with whatever Spoolman-resolved metadata the caller
+    has) and routes through publisher_manager.
     Returns True if the primary publisher succeeded.
     """
     # Targeted actions need a target (lane or toolhead name)
@@ -183,10 +200,10 @@ def activate_spool(spool_id: int, action: str, target: str | None = None) -> boo
         spool_id=spool_id,
         action=action_enum,
         target=target or "",
-        color=None, material=None, weight=None,
+        color=color, material=material, weight=weight,
         nozzle_temp_min=None, nozzle_temp_max=None,
         bed_temp_min=None, bed_temp_max=None,
-        scanner_id="legacy",
+        scanner_id=scanner_id,
         tag_only=False,
     )
     return _publish_event(event)
@@ -225,7 +242,7 @@ def _activate_from_scan(
     # Happy Hare has its own binding path — skip the generic publisher chain
     # so a no-op publisher call doesn't burn a round trip for every scan.
     if action_enum == Action.HAPPY_HARE_STAGE:
-        _route_happy_hare(spoolman_id)
+        _route_happy_hare(spoolman_id, event)
         if remaining is not None and remaining <= app_state.cfg["low_spool_threshold"]:
             logger.warning(f"Low spool: {filament_label} ({remaining:.1f}g) on {target or 'staged'}")
         return
@@ -243,7 +260,8 @@ def _activate_from_scan(
 
     # Route by action type
     if action_enum in (Action.AFC_STAGE, Action.TOOLHEAD_STAGE):
-        _route_staged(action_enum, spoolman_activated, color_hex, filament_label, remaining, spoolman_id)
+        _route_staged(action_enum, spoolman_activated, color_hex, filament_label,
+                      remaining, spoolman_id, event)
     elif action_enum in (Action.AFC_LANE, Action.TOOLHEAD):
         _route_dedicated(action_enum, spoolman_activated, spoolman_id, target, event)
 

--- a/middleware/config.example.afc.yaml
+++ b/middleware/config.example.afc.yaml
@@ -87,6 +87,11 @@ scanners:
 
 scanner_topic_prefix: "spoolsense"
 
+# ---- Event publishing (optional) ----------------------------
+# Every scan/activation is published as JSON to spoolsense/events/<action>
+# for Home Assistant automations. On by default; uncomment to disable.
+# publish_events: false
+
 # ---- Tag Writeback (optional) ------------------------------
 # Controls whether SpoolSense writes updated remaining weight back to
 # OpenPrintTag tags when the tag is stale (tag remaining > Spoolman remaining).

--- a/middleware/config.example.single.yaml
+++ b/middleware/config.example.single.yaml
@@ -35,5 +35,10 @@ scanners:
 
 scanner_topic_prefix: "spoolsense"
 
+# ---- Event publishing (optional) ----------------------------
+# Every scan/activation is published as JSON to spoolsense/events/<action>
+# for Home Assistant automations. On by default; uncomment to disable.
+# publish_events: false
+
 # ---- Tag Writeback (optional) ------------------------------
 # tag_writeback_enabled: false

--- a/middleware/config.example.toolchanger.yaml
+++ b/middleware/config.example.toolchanger.yaml
@@ -44,5 +44,10 @@ scanners:
 
 scanner_topic_prefix: "spoolsense"
 
+# ---- Event publishing (optional) ----------------------------
+# Every scan/activation is published as JSON to spoolsense/events/<action>
+# for Home Assistant automations. On by default; uncomment to disable.
+# publish_events: false
+
 # ---- Tag Writeback (optional) ------------------------------
 # tag_writeback_enabled: false

--- a/middleware/config.py
+++ b/middleware/config.py
@@ -34,6 +34,7 @@ DEFAULTS: dict = {
     "scanner_topic_prefix": "spoolsense",
     "scanners": {},
     "tag_writeback_enabled": False,
+    "publish_events": True,
 }
 
 # Legacy keys that trigger auto-migration

--- a/middleware/mqtt_handler.py
+++ b/middleware/mqtt_handler.py
@@ -17,7 +17,8 @@ from typing import TYPE_CHECKING
 import paho.mqtt.client as mqtt
 
 import app_state
-from activation import activate_spool, publish_lock, _activate_from_scan
+from activation import activate_spool, notify_observers, publish_lock, _activate_from_scan
+from publishers.base import Action, SpoolEvent
 from publishers.klipper import display_spoolcolor
 from config import has_afc_scanners
 import moonraker_client
@@ -94,6 +95,26 @@ def _record_spool_tracking(
 
 # ── UID-only tag handling ────────────────────────────────────────────────────
 
+def _uid_only_event(action: str, target: str, spool_id: int, color_hex: str,
+                    material: str, remaining: float | None,
+                    device_id: str | None) -> SpoolEvent:
+    """Build a SpoolEvent for observer notification from UID-only scan data."""
+    return SpoolEvent(
+        spool_id=spool_id,
+        action=Action(action),
+        target=target,
+        color=color_hex,
+        material=material,
+        weight=remaining,
+        nozzle_temp_min=None,
+        nozzle_temp_max=None,
+        bed_temp_min=None,
+        bed_temp_max=None,
+        scanner_id=device_id or "",
+        tag_only=False,
+    )
+
+
 def _handle_uid_only_tag(client: mqtt.Client, scanner_cfg: dict, uid: str, topic: str) -> None:
     """UID-only tag (e.g. NTAG215) — no filament data on tag, look up spool in Spoolman via NFC ID."""
     target_id = _get_scanner_target(scanner_cfg) or _extract_scanner_device_id(topic) or "unknown"
@@ -127,7 +148,9 @@ def _handle_uid_only_tag(client: mqtt.Client, scanner_cfg: dict, uid: str, topic
     # no cache, no lock.
     if action == "happy_hare_stage":
         from happy_hare import bind_spool_to_current_gate
-        bind_spool_to_current_gate(spool_id)
+        if bind_spool_to_current_gate(spool_id):
+            notify_observers(_uid_only_event(action, "", spool_id, color_hex,
+                                             material, remaining, device_id))
         # Still drive low-spool LED feedback on the scanner so users loading
         # multiple spools into MMU gates see when one is nearly empty.
         if device_id and remaining is not None:
@@ -146,10 +169,16 @@ def _handle_uid_only_tag(client: mqtt.Client, scanner_cfg: dict, uid: str, topic
                 "spoolman_id": spool_id,
             }
         logger.info(f"[{action}] Staged spool {spool_id} ({name}) for assignment")
+        # Observer channels (MQTT event stream) still see staged scans even
+        # though no printer command fires yet (#93)
+        notify_observers(_uid_only_event(action, "", spool_id, color_hex,
+                                         material, remaining, device_id))
         return
 
     # Dedicated scanners — activate immediately
-    if not activate_spool(spool_id, action, target):
+    if not activate_spool(spool_id, action, target, color=color_hex,
+                          material=material, weight=remaining,
+                          scanner_id=device_id or "legacy"):
         return
 
     if target:

--- a/middleware/publisher_manager.py
+++ b/middleware/publisher_manager.py
@@ -122,6 +122,26 @@ class PublisherManager:
             return True
         return primary_succeeded
 
+    def notify(self, event: SpoolEvent) -> None:
+        """
+        Fan an event out to SECONDARY publishers only — observation, not action.
+
+        Used by scan paths that must not trigger the primary publisher's
+        printer commands (UID-only staged scans, Happy Hare binds) but should
+        still appear on observer channels like the MQTT event stream (#93).
+        Failures are logged and never raised.
+        """
+        for publisher in self._publishers:
+            if publisher.primary:
+                continue
+            try:
+                publisher.publish(event)
+            except Exception:
+                logger.exception(
+                    "Publisher '%s' raised unexpectedly during notify (event=%s action=%s)",
+                    publisher.name, event.scanner_id, event.action,
+                )
+
     def shutdown(self) -> None:
         """Call teardown() on all registered publishers. Used during graceful shutdown."""
         for publisher in self._publishers:

--- a/middleware/publishers/mqtt_events.py
+++ b/middleware/publishers/mqtt_events.py
@@ -1,0 +1,74 @@
+"""
+publishers/mqtt_events.py — SpoolEvents republished to MQTT (#93).
+
+Every SpoolEvent that flows through PublisherManager is published as JSON
+to `spoolsense/events/<action>` (QoS 1, not retained — these are events,
+not state; the health topic covers state). Home Assistant and anything
+else on the broker get automation hooks for scans, activations, and
+staging with no HA-specific code here.
+
+Wildcard-subscribe `spoolsense/events/#` to see everything.
+
+Secondary publisher: failures are logged by PublisherManager and never
+block activation. Enabled by default; set `publish_events: false` in
+config.yaml to turn it off.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict
+from datetime import datetime, timezone
+
+import app_state
+from publishers.base import Publisher, SpoolEvent
+
+logger = logging.getLogger(__name__)
+
+EVENT_TOPIC_PREFIX = "spoolsense/events"
+
+
+class MqttEventPublisher(Publisher):
+    """Republishes SpoolEvents to the MQTT broker for external consumers."""
+
+    def __init__(self, config: dict) -> None:
+        self._config = config
+
+    @property
+    def name(self) -> str:
+        return "mqtt_events"
+
+    @property
+    def primary(self) -> bool:
+        return False
+
+    def enabled(self, config: dict) -> bool:
+        """On by default — emitting an event is inert. `publish_events: false` disables."""
+        return bool(config.get("publish_events", True))
+
+    def publish(self, event: SpoolEvent) -> bool:
+        """Publish the event as JSON. Never raises; returns False on failure."""
+        client = app_state.mqtt_client
+        if client is None:
+            logger.debug("mqtt_events: no MQTT client yet — dropping event")
+            return False
+
+        payload = asdict(event)
+        # Action is a str-mixin Enum; be explicit so the JSON value and topic
+        # segment are the plain string on every Python version.
+        payload["action"] = event.action.value
+        payload["ts"] = datetime.now(timezone.utc).isoformat()
+
+        topic = f"{EVENT_TOPIC_PREFIX}/{event.action.value}"
+        try:
+            result = client.publish(topic, json.dumps(payload), qos=1)
+            if result.rc != 0:
+                logger.warning("mqtt_events: publish failed (rc=%d) topic=%s", result.rc, topic)
+                return False
+            return True
+        except Exception:
+            logger.exception("mqtt_events: failed to publish to %s", topic)
+            return False
+
+    def teardown(self) -> None:
+        """Stateless — nothing to tear down."""

--- a/middleware/spoolsense.py
+++ b/middleware/spoolsense.py
@@ -45,6 +45,7 @@ from activation import publish_lock
 from afc_status import AfcStatusSync
 from publisher_manager import PublisherManager
 from publishers.klipper import KlipperPublisher
+from publishers.mqtt_events import MqttEventPublisher
 from toolchanger_status import ToolchangerStatusSync
 from toolhead_status import ToolheadStatusSync
 from filament_usage import FilamentUsageSync
@@ -301,9 +302,10 @@ def main() -> None:
     # Load and validate config — exits on invalid config (strict validation)
     app_state.cfg = load_config()
 
-    # Publishers handle output to printer platforms (only Klipper today)
+    # Publishers handle output — Klipper is primary; MQTT events secondary (#93)
     app_state.publisher_manager = PublisherManager()
     app_state.publisher_manager.register(KlipperPublisher(app_state.cfg))
+    app_state.publisher_manager.register(MqttEventPublisher(app_state.cfg))
 
     if args.check_config:
         _print_config_summary()

--- a/middleware/tests/test_activation.py
+++ b/middleware/tests/test_activation.py
@@ -176,5 +176,31 @@ class TestValidateMaterial(unittest.TestCase):
         assert _validate_material("PLA\n") is False
 
 
+class TestStagedObserverEvents(unittest.TestCase):
+    """Tag-only staged rich scans never reach the publisher chain — they must
+    still hit the observer path so the MQTT event stream sees them (#93)."""
+
+    def test_tag_only_staged_notifies_observers(self):
+        from activation import _route_staged
+        from publishers.base import Action
+        event = MagicMock()
+        with patch("activation.notify_observers") as mock_notify, \
+             patch("activation._cache_pending_spool"):
+            _route_staged(Action.AFC_STAGE, False, "FF0000", "PLA", 500.0,
+                          None, event)
+        mock_notify.assert_called_once_with(event)
+
+    def test_spoolman_staged_does_not_double_notify(self):
+        # With a spoolman_id the event already went through the manager —
+        # secondaries saw it there; notifying again would duplicate
+        from activation import _route_staged
+        from publishers.base import Action
+        with patch("activation.notify_observers") as mock_notify, \
+             patch("activation._cache_pending_spool"):
+            _route_staged(Action.AFC_STAGE, True, "FF0000", "PLA", 500.0,
+                          42, MagicMock())
+        mock_notify.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/middleware/tests/test_mqtt_events.py
+++ b/middleware/tests/test_mqtt_events.py
@@ -1,0 +1,129 @@
+"""Tests for publishers/mqtt_events.py — SpoolEvents republished to MQTT (#93)."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+sys.modules.setdefault("paho", MagicMock())
+sys.modules.setdefault("paho.mqtt", MagicMock())
+sys.modules.setdefault("paho.mqtt.client", MagicMock())
+
+import app_state  # noqa: E402
+from publishers.base import Action, SpoolEvent  # noqa: E402
+from publishers.mqtt_events import MqttEventPublisher  # noqa: E402
+
+
+def _event(**overrides) -> SpoolEvent:
+    base = dict(
+        spool_id=131,
+        action=Action.TOOLHEAD,
+        target="T0",
+        color="1E00FF",
+        material="PLA",
+        weight=666.0,
+        nozzle_temp_min=190,
+        nozzle_temp_max=220,
+        bed_temp_min=50,
+        bed_temp_max=60,
+        scanner_id="4d9620",
+        tag_only=False,
+    )
+    base.update(overrides)
+    return SpoolEvent(**base)
+
+
+def _reset(mqtt_client=True):
+    app_state.mqtt_client = MagicMock() if mqtt_client else None
+    if mqtt_client:
+        result = MagicMock()
+        result.rc = 0
+        app_state.mqtt_client.publish.return_value = result
+
+
+class TestEnabled(unittest.TestCase):
+
+    def test_enabled_by_default(self):
+        self.assertTrue(MqttEventPublisher({}).enabled({}))
+
+    def test_disabled_via_config(self):
+        self.assertFalse(MqttEventPublisher({}).enabled({"publish_events": False}))
+
+    def test_is_secondary(self):
+        pub = MqttEventPublisher({})
+        self.assertFalse(pub.primary)
+        self.assertEqual(pub.name, "mqtt_events")
+
+
+class TestPublish(unittest.TestCase):
+
+    def setUp(self):
+        _reset()
+        self.pub = MqttEventPublisher({})
+
+    def _published(self):
+        args, kwargs = app_state.mqtt_client.publish.call_args
+        return args[0], json.loads(args[1]), kwargs
+
+    def test_topic_is_per_action(self):
+        self.assertTrue(self.pub.publish(_event(action=Action.TOOLHEAD)))
+        topic, _, _ = self._published()
+        self.assertEqual(topic, "spoolsense/events/toolhead")
+
+        self.pub.publish(_event(action=Action.AFC_STAGE, target=""))
+        topic, _, _ = self._published()
+        self.assertEqual(topic, "spoolsense/events/afc_stage")
+
+        self.pub.publish(_event(action=Action.HAPPY_HARE_STAGE, target=""))
+        topic, _, _ = self._published()
+        self.assertEqual(topic, "spoolsense/events/happy_hare_stage")
+
+    def test_payload_carries_full_event_plus_ts(self):
+        self.pub.publish(_event())
+        _, payload, _ = self._published()
+        self.assertEqual(payload["spool_id"], 131)
+        self.assertEqual(payload["action"], "toolhead")   # plain string, not enum repr
+        self.assertEqual(payload["target"], "T0")
+        self.assertEqual(payload["color"], "1E00FF")
+        self.assertEqual(payload["material"], "PLA")
+        self.assertEqual(payload["weight"], 666.0)
+        self.assertEqual(payload["scanner_id"], "4d9620")
+        self.assertFalse(payload["tag_only"])
+        # ISO-8601 UTC timestamp
+        self.assertIn("ts", payload)
+        self.assertIn("T", payload["ts"])
+        self.assertTrue(payload["ts"].endswith("+00:00") or payload["ts"].endswith("Z"))
+
+    def test_qos1_not_retained(self):
+        self.pub.publish(_event())
+        _, _, kwargs = self._published()
+        self.assertEqual(kwargs.get("qos"), 1)
+        self.assertFalse(kwargs.get("retain", False))
+
+    def test_tag_only_event_publishes(self):
+        self.assertTrue(self.pub.publish(_event(spool_id=None, tag_only=True)))
+        _, payload, _ = self._published()
+        self.assertIsNone(payload["spool_id"])
+        self.assertTrue(payload["tag_only"])
+
+    def test_no_mqtt_client_returns_false_without_raising(self):
+        _reset(mqtt_client=False)
+        self.assertFalse(self.pub.publish(_event()))
+
+    def test_publish_exception_returns_false(self):
+        app_state.mqtt_client.publish.side_effect = Exception("broker gone")
+        self.assertFalse(self.pub.publish(_event()))
+
+    def test_nonzero_rc_returns_false(self):
+        result = MagicMock()
+        result.rc = 4
+        app_state.mqtt_client.publish.return_value = result
+        self.assertFalse(self.pub.publish(_event()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/middleware/tests/test_mqtt_handler.py
+++ b/middleware/tests/test_mqtt_handler.py
@@ -336,5 +336,67 @@ class TestOnMessageLockBehavior(unittest.TestCase):
         assert app_state.lane_locks["T0"] is False
 
 
+class TestUidOnlyObserverEvents(unittest.TestCase):
+    """UID-only scan paths that bypass PublisherManager still emit observer
+    events for the MQTT event stream (#93)."""
+
+    def setUp(self):
+        _reset_app_state(
+            scanners={"ecb338": {"action": "afc_stage"}},
+        )
+        app_state.DISPATCHER_AVAILABLE = True
+        spool = {
+            "id": 17,
+            "filament": {"name": "Purple", "color_hex": "EE33FF", "material": "PLA"},
+            "remaining_weight": 500.0,
+        }
+        app_state.spoolman_client = MagicMock()
+        app_state.spoolman_client.find_by_nfc.return_value = spool
+
+    def _scan(self, uid="aabbccdd"):
+        from mqtt_handler import _handle_uid_only_tag
+        _handle_uid_only_tag(
+            MagicMock(), app_state.cfg["scanners"]["ecb338"], uid,
+            "spoolsense/ecb338/tag/state",
+        )
+
+    def test_staged_uid_only_scan_notifies_observers(self):
+        with patch("mqtt_handler.notify_observers") as mock_notify:
+            self._scan()
+        mock_notify.assert_called_once()
+        event = mock_notify.call_args.args[0]
+        self.assertEqual(event.action.value, "afc_stage")
+        self.assertEqual(event.spool_id, 17)
+        self.assertEqual(event.scanner_id, "ecb338")
+
+    def test_happy_hare_uid_only_notifies_on_successful_bind(self):
+        app_state.cfg["scanners"]["ecb338"] = {"action": "happy_hare_stage"}
+        with patch("mqtt_handler.notify_observers") as mock_notify, \
+             patch("happy_hare.bind_spool_to_current_gate", return_value=True):
+            self._scan()
+        mock_notify.assert_called_once()
+        self.assertEqual(mock_notify.call_args.args[0].action.value, "happy_hare_stage")
+
+    def test_dedicated_uid_only_event_carries_resolved_metadata(self):
+        # afc_lane/toolhead UID-only scans flow through activate_spool — the
+        # event must carry Spoolman-resolved color/material/weight and the
+        # real scanner id, not the bare "legacy" placeholder (#93)
+        app_state.cfg["scanners"]["ecb338"] = {"action": "afc_lane", "lane": "lane1"}
+        with patch("mqtt_handler.activate_spool", return_value=True) as mock_activate:
+            self._scan()
+        kwargs = mock_activate.call_args.kwargs
+        self.assertEqual(kwargs["color"], "EE33FF")
+        self.assertEqual(kwargs["material"], "PLA")
+        self.assertEqual(kwargs["weight"], 500.0)
+        self.assertEqual(kwargs["scanner_id"], "ecb338")
+
+    def test_happy_hare_uid_only_no_event_on_failed_bind(self):
+        app_state.cfg["scanners"]["ecb338"] = {"action": "happy_hare_stage"}
+        with patch("mqtt_handler.notify_observers") as mock_notify, \
+             patch("happy_hare.bind_spool_to_current_gate", return_value=False):
+            self._scan()
+        mock_notify.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/middleware/tests/test_publisher_manager.py
+++ b/middleware/tests/test_publisher_manager.py
@@ -199,5 +199,40 @@ class TestPublisherManagerShutdown(unittest.TestCase):
         mgr.shutdown()
 
 
+class TestNotify(unittest.TestCase):
+    """notify() is observation-only: secondaries receive, the primary never does."""
+
+    def setUp(self):
+        import app_state
+        app_state.cfg = {}
+
+    def _manager_with(self, *publishers):
+        from publisher_manager import PublisherManager
+        m = PublisherManager()
+        for pub in publishers:
+            m.register(pub)
+        return m
+
+    def test_secondary_receives_primary_does_not(self):
+        primary = _make_publisher("klipper", primary=True, enabled=True, result=True)
+        secondary = _make_publisher("mqtt_events", primary=False, enabled=True, result=True)
+        m = self._manager_with(primary, secondary)
+
+        m.notify(_make_event())
+
+        secondary.publish.assert_called_once()
+        primary.publish.assert_not_called()
+
+    def test_secondary_exception_swallowed(self):
+        secondary = _make_publisher("mqtt_events", primary=False, enabled=True, result=True)
+        secondary.publish.side_effect = Exception("boom")
+        m = self._manager_with(secondary)
+        m.notify(_make_event())  # must not raise
+
+    def test_no_publishers_is_noop(self):
+        m = self._manager_with()
+        m.notify(_make_event())  # must not raise
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #93.

## Summary

Every scan, activation, and staging event is published as JSON to `spoolsense/events/<action>` — QoS 1, not retained (events, not state; the health topic from #41 covers state). Wildcard-subscribe `spoolsense/events/#` for everything. On by default; `publish_events: false` in config.yaml disables.

```json
{
  "spool_id": 131, "action": "toolhead", "target": "T0",
  "color": "1E00FF", "material": "ASA", "weight": 666.0,
  "nozzle_temp_min": 240, "nozzle_temp_max": 260,
  "bed_temp_min": 90, "bed_temp_max": 110,
  "scanner_id": "4d9620", "tag_only": false,
  "ts": "2026-07-06T03:56:35+00:00"
}
```

**What this unlocks:** Home Assistant automations off filament activity with zero custom code — "ASA loaded → check the enclosure", filament journals, wrong-material announcements, staging dashboards. Also a support tool: `mosquitto_sub -t spoolsense/events/#` shows exactly what the middleware resolved for any scan.

## Architecture

- `publishers/mqtt_events.py` — `MqttEventPublisher(Publisher)`, secondary (failures can never block activation). Second real Publisher implementation; validates the ABC.
- **`PublisherManager.notify(event)`** — new: fan-out to secondary publishers only. Building the event stream surfaced that several supported scan paths never reach the manager (UID-only staged scans, Happy Hare binds, tag-only staged scans) — and routing them through `publish()` would make KlipperPublisher act on them (e.g. spurious `SET_NEXT_SPOOL_ID`). `notify()` is observation-without-action; those paths now emit through it, with a guard against double-emitting when the manager already saw the event.
- `activate_spool()` now carries Spoolman-resolved color/material/weight and the real scanner id for UID-only dedicated scans, instead of the bare `"legacy"` placeholder.

## Coverage matrix

| Scan path | Event emitted via |
|---|---|
| Rich tag, dedicated (toolhead/afc_lane) | `publish()` (existing chain) |
| Rich tag, staged, Spoolman ID present | `publish()` (existing chain) |
| Rich tag, staged, tag-only | `notify()` (new) |
| UID-only, dedicated | `publish()` with full metadata (fixed) |
| UID-only, staged | `notify()` (new) |
| Happy Hare (rich + UID-only), successful bind | `notify()` (new) |

## Test plan
- [x] 19 new tests: publisher unit tests, notify() semantics (secondary-only, exception-swallowing), bypass-path coverage, metadata completeness, double-notify guard
- [x] 492 passed / 0 failed; flake8 gate clean
- [x] End-to-end pipeline demonstrated (real manager + publisher + event, mocked broker client): correct topic, QoS, and full payload on both flows
- [x] Two independent review rounds; three coverage gaps found and fixed
- [ ] Live broker verification after deploy: `mosquitto_sub -t spoolsense/events/# -v` + scan a tag