### PR TITLE
feat: assign-tool accepts uid/spool_id binding — reject stale assignments with 409

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ venv/
 # mex scaffold (local AI context, not tracked)
 .mex/
 
+# Git worktrees for isolated feature work
+.worktrees/
+
 # Ollama suggestions (local dev notes)
 ollama_suggestions.md
 

--- a/middleware/rest_api.py
+++ b/middleware/rest_api.py
@@ -57,6 +57,8 @@ class MobileScanRequest(BaseModel):
 
 class AssignToolRequest(BaseModel):
     toolhead: str
+    uid: Optional[str] = None            # uid from the originating scan — binds the assignment to that spool (#31)
+    spool_id: Optional[int] = None       # spoolman id from the scan — rides along with uid for newer clients
 
 
 class ApiResponse(BaseModel):
@@ -258,6 +260,17 @@ def assign_tool(req: AssignToolRequest) -> ApiResponse:
         pending = app_state.pending_spool
         if not pending:
             raise HTTPException(status_code=409, detail="No pending spool — scan a tag first")
+        # Spool binding (spoolsense-mobile #31): newer clients echo back the uid
+        # they scanned. pending_spool is a single last-write-wins slot, so a scan
+        # from any phone landing between mobile-scan and assign-tool would hand
+        # this assignment the wrong spool — reject before any gcode goes out.
+        # Case-insensitive: mobile sends uppercase hex, parsers store lowercase.
+        # Omitted uid = legacy client, keep the old unchecked behavior.
+        if req.uid and req.uid.lower() != (pending.get("uid") or "").lower():
+            raise HTTPException(
+                status_code=409,
+                detail="Pending spool changed since scan — rescan and try again",
+            )
         # Don't clear pending_spool here — toolchanger_status.py watcher
         # consumes it when it detects the ASSIGN_SPOOL macro variable change
 

--- a/middleware/tests/test_rest_api.py
+++ b/middleware/tests/test_rest_api.py
@@ -267,6 +267,88 @@ class TestAssignTool(unittest.TestCase):
         self.assertEqual(resp.json()["spool_id"], 42)
 
 
+class TestAssignToolSpoolBinding(unittest.TestCase):
+    """POST /api/assign-tool with uid binding — rejects stale assignments
+    when another scan replaced pending_spool between mobile-scan and
+    assign-tool (spoolsense-mobile #31)."""
+
+    def setUp(self):
+        _reset_app_state(mobile_enabled=True, mobile_action="toolhead_stage")
+        app_state.pending_spool = {
+            "uid": "aabbccdd",
+            "spoolman_id": 42,
+            "color_hex": "FF0000",
+            "material": "PLA",
+            "remaining_g": 200.0,
+        }
+
+    def _post(self, payload: dict):
+        return client.post("/api/assign-tool", json=payload)
+
+    def test_matching_uid_assigns(self):
+        with patch("rest_api.send_gcode") as mock_gcode:
+            resp = self._post({"toolhead": "T0", "uid": "aabbccdd"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.json()["success"])
+        mock_gcode.assert_called_once()
+
+    def test_uid_match_is_case_insensitive(self):
+        # Mobile sends uppercase hex; middleware stores lowercase elsewhere
+        with patch("rest_api.send_gcode") as mock_gcode:
+            resp = self._post({"toolhead": "T0", "uid": "AABBCCDD"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.json()["success"])
+        mock_gcode.assert_called_once()
+
+    def test_mismatched_uid_returns_409(self):
+        # A second scan replaced pending_spool after this client scanned
+        with patch("rest_api.send_gcode") as mock_gcode:
+            resp = self._post({"toolhead": "T0", "uid": "11223344"})
+        self.assertEqual(resp.status_code, 409)
+        self.assertIn("rescan", resp.json()["detail"].lower())
+        # Must reject before any gcode goes out — never assign the wrong spool
+        mock_gcode.assert_not_called()
+
+    def test_omitted_uid_preserves_old_behavior(self):
+        # Old mobile clients send only {"toolhead": ...} — no binding check
+        with patch("rest_api.send_gcode") as mock_gcode:
+            resp = self._post({"toolhead": "T0"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.json()["success"])
+        mock_gcode.assert_called_once()
+
+    def test_uid_with_no_pending_returns_409(self):
+        app_state.pending_spool = None
+        with patch("rest_api.send_gcode") as mock_gcode:
+            resp = self._post({"toolhead": "T0", "uid": "aabbccdd"})
+        self.assertEqual(resp.status_code, 409)
+        mock_gcode.assert_not_called()
+
+    def test_pending_record_without_uid_returns_409(self):
+        # Pending record lacks a uid — binding can't be verified, refuse to guess
+        app_state.pending_spool = {"spoolman_id": 42}
+        with patch("rest_api.send_gcode") as mock_gcode:
+            resp = self._post({"toolhead": "T0", "uid": "aabbccdd"})
+        self.assertEqual(resp.status_code, 409)
+        mock_gcode.assert_not_called()
+
+    def test_spool_id_accepted(self):
+        # spool_id rides along for the mobile half — accepted without error;
+        # response spool_id still comes from the pending record
+        with patch("rest_api.send_gcode"):
+            resp = self._post({"toolhead": "T0", "uid": "aabbccdd", "spool_id": 42})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["spool_id"], 42)
+
+    def test_mismatch_rejected_before_moonraker_call(self):
+        # If the check ran after the gcode call, a stale uid would surface as
+        # 502 (Moonraker down) instead of 409 — pin the ordering
+        with patch("rest_api.send_gcode", side_effect=Exception("unreachable")) as mock_gcode:
+            resp = self._post({"toolhead": "T0", "uid": "deadbeef"})
+        self.assertEqual(resp.status_code, 409)
+        mock_gcode.assert_not_called()
+
+
 class TestUnlockTarget(unittest.TestCase):
     """POST /api/unlock/{target} — explicit unlock for #76."""
 


### PR DESCRIPTION
## The race

Spool→toolhead assignment from the mobile app is two HTTP calls:

1. `POST /api/mobile-scan` (toolhead_stage) caches the scan in `app_state.pending_spool` — a single, global, last-write-wins slot
2. `POST /api/assign-tool` sends only `{"toolhead": "T0"}` and assigns whatever is pending

Any scan landing between the two — another phone, or a re-scan on the same phone — replaces the pending record, and step 2 silently assigns the wrong spool to the tool.

## The fix

`AssignToolRequest` gains two optional fields, `uid` and `spool_id`. When `uid` is present and doesn't match the pending record's uid (case-insensitive — mobile sends uppercase hex, the parsers store lowercase), the handler returns `409 "Pending spool changed since scan — rescan and try again"` before any gcode reaches Moonraker. The check runs inside `state_lock` alongside the existing no-pending 409, and the pending record consumed by the response is the same snapshot the check validated.

## Backward compatibility

- `uid` omitted → exactly the old unchecked behavior; existing app versions keep working
- `spool_id` is accepted but not validated — pending records can lack a `spoolman_id` for tags not yet in Spoolman, so uid is the binding key
- No response-shape changes

Server half of SpoolSense/spoolsense-mobile#31 — the mobile half that sends these fields ships separately.

## Tests

8 new tests in `TestAssignToolSpoolBinding`: mismatch → 409 (pinned to fire before the Moonraker call), exact match, case-insensitive match, omitted-uid legacy path, uid with no pending, pending record without uid, spool_id pass-through. Full middleware suite: **500 passed**.
