### PR TITLE
Fix scanner_id="unknown" on rich-tag event stream

### DIFF
--- a/middleware/activation.py
+++ b/middleware/activation.py
@@ -89,9 +89,14 @@ def _resolve_scan_data(scan: ScanEvent, spool_info: SpoolInfo | None) -> tuple[s
 def _build_spool_event(
     scanner_cfg: dict, action_enum: Action, target: str | None,
     spoolman_id: int | None, color_hex: str, filament_label: str,
-    remaining: float | None, scan: ScanEvent,
+    remaining: float | None, scan: ScanEvent, device_id: str | None = None,
 ) -> SpoolEvent:
     """Build a SpoolEvent from resolved scan data."""
+    # scanner_id source order: the device_id the caller resolved from the MQTT
+    # topic (or "mobile" for REST scans) → an explicit device_id in the config
+    # dict (not normally present) → the target → "unknown". The topic-derived
+    # device_id is what lets event-stream (#93) consumers tell scanners apart.
+    scanner_id = device_id or scanner_cfg.get("device_id") or target or "unknown"
     return SpoolEvent(
         spool_id=spoolman_id,
         action=action_enum,
@@ -103,7 +108,7 @@ def _build_spool_event(
         nozzle_temp_max=getattr(scan, "nozzle_temp_max", None),
         bed_temp_min=getattr(scan, "bed_temp_min", None),
         bed_temp_max=getattr(scan, "bed_temp_max", None),
-        scanner_id=scanner_cfg.get("device_id", target or "unknown"),
+        scanner_id=scanner_id,
         tag_only=spoolman_id is None,
     )
 
@@ -215,6 +220,7 @@ def _activate_from_scan(
     scanner_cfg: dict,
     scan: ScanEvent,
     spool_info: SpoolInfo | None = None,
+    device_id: str | None = None,
 ) -> None:
     """
     Main activation entry point for rich-data tags.
@@ -222,6 +228,9 @@ def _activate_from_scan(
     Two concerns handled separately:
       1. Spool-ID activation (Spoolman-backed) — only when spoolman_id is available
       2. Action routing (always) — stage/cache or lock based on scanner action
+
+    device_id is the scanner that produced the scan (topic-derived, or "mobile"
+    for REST scans); it becomes the event stream's scanner_id (#93).
     """
     action_str = scanner_cfg["action"]
     target     = scanner_cfg.get("lane") or scanner_cfg.get("toolhead")
@@ -237,7 +246,7 @@ def _activate_from_scan(
     spoolman_id = spool_info.spoolman_id if spool_info else None
 
     event = _build_spool_event(scanner_cfg, action_enum, target, spoolman_id,
-                               color_hex, filament_label, remaining, scan)
+                               color_hex, filament_label, remaining, scan, device_id)
 
     # Happy Hare has its own binding path — skip the generic publisher chain
     # so a no-op publisher call doesn't burn a round trip for every scan.

--- a/middleware/mqtt_handler.py
+++ b/middleware/mqtt_handler.py
@@ -257,10 +257,10 @@ def _handle_rich_tag(client: mqtt.Client, scanner_cfg: dict, payload: dict, topi
 
         # Enrich from Spoolman (best-effort), then activate
         spool_info = _enrich_from_spoolman(scan, topic)
-        _activate_from_scan(scanner_cfg, scan, spool_info=spool_info)
+        device_id = _extract_scanner_device_id(topic)
+        _activate_from_scan(scanner_cfg, scan, spool_info=spool_info, device_id=device_id)
 
         # Record initial weight for UPDATE_TAG filament deduction
-        device_id = _extract_scanner_device_id(topic)
         # tag_format comes from the scanner payload — tells us if this tag supports weight writes
         tag_format = payload.get("tag_format", "unknown")
         _record_spool_tracking(

--- a/middleware/rest_api.py
+++ b/middleware/rest_api.py
@@ -217,7 +217,7 @@ def mobile_scan(req: MobileScanRequest) -> ApiResponse:
         except Exception:
             logger.exception("Spoolman sync failed for mobile scan — continuing with tag-only")
 
-    _activate_from_scan(scanner_cfg, scan, spool_info=spool_info)
+    _activate_from_scan(scanner_cfg, scan, spool_info=spool_info, device_id="mobile")
 
     # Record for UPDATE_TAG deduction tracking — device_id="" signals mobile-scanned
     target = _get_scanner_target(scanner_cfg)

--- a/middleware/tests/test_activation.py
+++ b/middleware/tests/test_activation.py
@@ -202,5 +202,33 @@ class TestStagedObserverEvents(unittest.TestCase):
         mock_notify.assert_not_called()
 
 
+class TestBuildSpoolEventScannerId(unittest.TestCase):
+    """scanner_id must carry the source scanner so event-stream (#93)
+    consumers can tell scanners apart — regression for the live finding
+    where rich staged scans published scanner_id="unknown"."""
+
+    def _event(self, scanner_cfg, target, device_id):
+        from activation import _build_spool_event
+        from publishers.base import Action
+        scan = MagicMock(nozzle_temp_min=None, nozzle_temp_max=None,
+                         bed_temp_min=None, bed_temp_max=None)
+        return _build_spool_event(scanner_cfg, Action.TOOLHEAD_STAGE, target,
+                                  None, "FF0000", "PLA", 500.0, scan,
+                                  device_id=device_id)
+
+    def test_topic_device_id_wins(self):
+        # Stage scanner (no target) — device_id from the topic must show up
+        ev = self._event({"action": "toolhead_stage"}, None, "f3d360")
+        self.assertEqual(ev.scanner_id, "f3d360")
+
+    def test_falls_back_to_target_when_no_device_id(self):
+        ev = self._event({"action": "toolhead"}, "T0", None)
+        self.assertEqual(ev.scanner_id, "T0")
+
+    def test_unknown_only_when_nothing_available(self):
+        ev = self._event({"action": "toolhead_stage"}, None, None)
+        self.assertEqual(ev.scanner_id, "unknown")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Follow-up to #93, caught while soaking the event publisher on real hardware.

## Problem

Rich-tag scans published `scanner_id: "unknown"` on `spoolsense/events/#`. `_build_spool_event` read the id from `scanner_cfg.get("device_id")` — a key that never exists, since the scanners config is keyed *by* device id and each value holds only `action`/`lane`/`toolhead`. Per-scanner HA automations (a core reason for the event stream) couldn't tell scanners apart.

The UID-only path was already correct; only the rich-tag path was never threaded the device_id.

## Fix

Thread the topic-derived `device_id` through `_activate_from_scan` into `_build_spool_event`. REST mobile scans pass `"mobile"`. Source order for `scanner_id`: topic device_id → config `device_id` (rare) → target → `"unknown"`.

## Verified on hardware

Same synthetic `toolhead_stage` scan, before vs after:
- before: `"scanner_id": "unknown"`
- after: `"scanner_id": "f3d360"`

## Test plan
- [x] 3 regression tests in `test_activation.py` (topic id wins, target fallback, unknown only when nothing available)
- [x] 503 passed / 0 failed; flake8 gate clean
- [x] Live re-test on the printer confirms the real device id now publishes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scanner identification during activation so scan events now carry a more accurate device name.
  * Rich-tag scans now use the scanner’s device ID earlier in the flow, helping event tracking and follow-up actions stay aligned.
  * Mobile scans now consistently record as coming from a mobile source, improving scan attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->