### PR TITLE
Release v1.8.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ venv/
 # mex scaffold (local AI context, not tracked)
 .mex/
 
+# Git worktrees for isolated feature work
+.worktrees/
+
 # Ollama suggestions (local dev notes)
 ollama_suggestions.md
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to SpoolSense are documented here.
 
 ---
 
+## [1.8.1] - 2026-07-08
+
+### Added
+
+- **MQTT event stream** — every scan, activation, and staging event is
+  published as JSON to `spoolsense/events/<action>` (QoS 1, not retained).
+  Home Assistant, Node-RED, and anything else on the broker can now react to
+  filament activity with no SpoolSense-specific code — trigger on material,
+  scanner, or tool. Wildcard-subscribe `spoolsense/events/#` for everything.
+  On by default; `publish_events: false` disables. Each event carries
+  spool_id, action, target, color, material, weight, temps, the source
+  scanner id, and a timestamp. (#93)
+
+### Fixed
+
+- **Mobile assign-tool could bind the wrong spool** — the mobile flow scans
+  (caches a pending spool) and assigns (`POST /api/assign-tool`) in two calls.
+  A scan landing between them replaced the pending record, silently assigning
+  the wrong spool. `assign-tool` now accepts the scanned `uid`/`spool_id` and
+  returns `409` if the pending record changed since the scan, before any gcode
+  is sent. (#96)
+
+---
+
 ## [1.8.0] - 2026-07-05
 
 ### Added

--- a/middleware/README.md
+++ b/middleware/README.md
@@ -29,7 +29,8 @@ middleware/
 │
 ├── publishers/
 │   ├── base.py                # SpoolEvent dataclass, Publisher ABC, Action enum
-│   └── klipper.py             # KlipperPublisher — gcode commands, Moonraker REST
+│   ├── klipper.py             # KlipperPublisher — gcode commands, Moonraker REST
+│   └── mqtt_events.py         # MqttEventPublisher — SpoolEvents → spoolsense/events/#
 ├── publisher_manager.py       # Fan-out dispatcher — primary + secondary publishers
 │
 ├── afc_status.py              # AFC lane state sync via Moonraker (websocket/polling)

--- a/middleware/activation.py
+++ b/middleware/activation.py
@@ -89,9 +89,14 @@ def _resolve_scan_data(scan: ScanEvent, spool_info: SpoolInfo | None) -> tuple[s
 def _build_spool_event(
     scanner_cfg: dict, action_enum: Action, target: str | None,
     spoolman_id: int | None, color_hex: str, filament_label: str,
-    remaining: float | None, scan: ScanEvent,
+    remaining: float | None, scan: ScanEvent, device_id: str | None = None,
 ) -> SpoolEvent:
     """Build a SpoolEvent from resolved scan data."""
+    # scanner_id source order: the device_id the caller resolved from the MQTT
+    # topic (or "mobile" for REST scans) → an explicit device_id in the config
+    # dict (not normally present) → the target → "unknown". The topic-derived
+    # device_id is what lets event-stream (#93) consumers tell scanners apart.
+    scanner_id = device_id or scanner_cfg.get("device_id") or target or "unknown"
     return SpoolEvent(
         spool_id=spoolman_id,
         action=action_enum,
@@ -103,7 +108,7 @@ def _build_spool_event(
         nozzle_temp_max=getattr(scan, "nozzle_temp_max", None),
         bed_temp_min=getattr(scan, "bed_temp_min", None),
         bed_temp_max=getattr(scan, "bed_temp_max", None),
-        scanner_id=scanner_cfg.get("device_id", target or "unknown"),
+        scanner_id=scanner_id,
         tag_only=spoolman_id is None,
     )
 
@@ -215,6 +220,7 @@ def _activate_from_scan(
     scanner_cfg: dict,
     scan: ScanEvent,
     spool_info: SpoolInfo | None = None,
+    device_id: str | None = None,
 ) -> None:
     """
     Main activation entry point for rich-data tags.
@@ -222,6 +228,9 @@ def _activate_from_scan(
     Two concerns handled separately:
       1. Spool-ID activation (Spoolman-backed) — only when spoolman_id is available
       2. Action routing (always) — stage/cache or lock based on scanner action
+
+    device_id is the scanner that produced the scan (topic-derived, or "mobile"
+    for REST scans); it becomes the event stream's scanner_id (#93).
     """
     action_str = scanner_cfg["action"]
     target     = scanner_cfg.get("lane") or scanner_cfg.get("toolhead")
@@ -237,7 +246,7 @@ def _activate_from_scan(
     spoolman_id = spool_info.spoolman_id if spool_info else None
 
     event = _build_spool_event(scanner_cfg, action_enum, target, spoolman_id,
-                               color_hex, filament_label, remaining, scan)
+                               color_hex, filament_label, remaining, scan, device_id)
 
     # Happy Hare has its own binding path — skip the generic publisher chain
     # so a no-op publisher call doesn't burn a round trip for every scan.

--- a/middleware/activation.py
+++ b/middleware/activation.py
@@ -125,7 +125,7 @@ def _try_spoolman_activation(event: SpoolEvent, spoolman_id: int, target: str | 
 
 def _route_staged(action_enum: Action, spoolman_activated: bool,
                   color_hex: str, filament_label: str, remaining: float | None,
-                  spoolman_id: int | None) -> None:
+                  spoolman_id: int | None, event: SpoolEvent) -> None:
     """Handle afc_stage and toolhead_stage — cache tag data, don't lock."""
     _cache_pending_spool(color_hex, filament_label, remaining, spoolman_id)
     stage_name = "afc_stage" if action_enum == Action.AFC_STAGE else "toolhead_stage"
@@ -133,9 +133,21 @@ def _route_staged(action_enum: Action, spoolman_activated: bool,
         logger.info(f"[{stage_name}] Spool staged with Spoolman ID, scanner remains unlocked")
     else:
         logger.info(f"[{stage_name}] Tag data cached, waiting for assignment. Scanner remains unlocked")
+    if spoolman_id is None:
+        # Tag-only staged scans never reach the publisher chain — the event
+        # stream still gets them via the observer path (#93)
+        notify_observers(event)
 
 
-def _route_happy_hare(spoolman_id: int | None) -> None:
+def notify_observers(event: SpoolEvent) -> None:
+    """Fan an event out to secondary (observer) publishers only — never the
+    primary, so no printer commands fire. No-op when the manager isn't wired."""
+    manager = app_state.publisher_manager
+    if manager is not None:
+        manager.notify(event)
+
+
+def _route_happy_hare(spoolman_id: int | None, event: SpoolEvent) -> None:
     """Handle happy_hare_stage — bind the scanned spool to the currently-selected
     MMU gate via Spoolman extras + Happy Hare sync trigger. No lock, no cache."""
     if spoolman_id is None:
@@ -143,7 +155,8 @@ def _route_happy_hare(spoolman_id: int | None) -> None:
                        "The scanned tag must be registered in Spoolman first.")
         return
     from happy_hare import bind_spool_to_current_gate
-    bind_spool_to_current_gate(spoolman_id)
+    if bind_spool_to_current_gate(spoolman_id):
+        notify_observers(event)
 
 
 def _route_dedicated(action_enum: Action, spoolman_activated: bool,
@@ -162,10 +175,14 @@ def _route_dedicated(action_enum: Action, spoolman_activated: bool,
 
 # ── UID-only activation path ────────────────────────────────────────────────
 
-def activate_spool(spool_id: int, action: str, target: str | None = None) -> bool:
+def activate_spool(spool_id: int, action: str, target: str | None = None,
+                   color: str | None = None, material: str | None = None,
+                   weight: float | None = None,
+                   scanner_id: str = "legacy") -> bool:
     """
     UID-only fallback path — called when tag has no embedded data but maps to a Spoolman spool.
-    Builds a minimal SpoolEvent and routes through publisher_manager.
+    Builds a SpoolEvent (with whatever Spoolman-resolved metadata the caller
+    has) and routes through publisher_manager.
     Returns True if the primary publisher succeeded.
     """
     # Targeted actions need a target (lane or toolhead name)
@@ -183,10 +200,10 @@ def activate_spool(spool_id: int, action: str, target: str | None = None) -> boo
         spool_id=spool_id,
         action=action_enum,
         target=target or "",
-        color=None, material=None, weight=None,
+        color=color, material=material, weight=weight,
         nozzle_temp_min=None, nozzle_temp_max=None,
         bed_temp_min=None, bed_temp_max=None,
-        scanner_id="legacy",
+        scanner_id=scanner_id,
         tag_only=False,
     )
     return _publish_event(event)
@@ -225,7 +242,7 @@ def _activate_from_scan(
     # Happy Hare has its own binding path — skip the generic publisher chain
     # so a no-op publisher call doesn't burn a round trip for every scan.
     if action_enum == Action.HAPPY_HARE_STAGE:
-        _route_happy_hare(spoolman_id)
+        _route_happy_hare(spoolman_id, event)
         if remaining is not None and remaining <= app_state.cfg["low_spool_threshold"]:
             logger.warning(f"Low spool: {filament_label} ({remaining:.1f}g) on {target or 'staged'}")
         return
@@ -243,7 +260,8 @@ def _activate_from_scan(
 
     # Route by action type
     if action_enum in (Action.AFC_STAGE, Action.TOOLHEAD_STAGE):
-        _route_staged(action_enum, spoolman_activated, color_hex, filament_label, remaining, spoolman_id)
+        _route_staged(action_enum, spoolman_activated, color_hex, filament_label,
+                      remaining, spoolman_id, event)
     elif action_enum in (Action.AFC_LANE, Action.TOOLHEAD):
         _route_dedicated(action_enum, spoolman_activated, spoolman_id, target, event)
 

--- a/middleware/config.example.afc.yaml
+++ b/middleware/config.example.afc.yaml
@@ -87,6 +87,11 @@ scanners:
 
 scanner_topic_prefix: "spoolsense"
 
+# ---- Event publishing (optional) ----------------------------
+# Every scan/activation is published as JSON to spoolsense/events/<action>
+# for Home Assistant automations. On by default; uncomment to disable.
+# publish_events: false
+
 # ---- Tag Writeback (optional) ------------------------------
 # Controls whether SpoolSense writes updated remaining weight back to
 # OpenPrintTag tags when the tag is stale (tag remaining > Spoolman remaining).

--- a/middleware/config.example.single.yaml
+++ b/middleware/config.example.single.yaml
@@ -35,5 +35,10 @@ scanners:
 
 scanner_topic_prefix: "spoolsense"
 
+# ---- Event publishing (optional) ----------------------------
+# Every scan/activation is published as JSON to spoolsense/events/<action>
+# for Home Assistant automations. On by default; uncomment to disable.
+# publish_events: false
+
 # ---- Tag Writeback (optional) ------------------------------
 # tag_writeback_enabled: false

--- a/middleware/config.example.toolchanger.yaml
+++ b/middleware/config.example.toolchanger.yaml
@@ -44,5 +44,10 @@ scanners:
 
 scanner_topic_prefix: "spoolsense"
 
+# ---- Event publishing (optional) ----------------------------
+# Every scan/activation is published as JSON to spoolsense/events/<action>
+# for Home Assistant automations. On by default; uncomment to disable.
+# publish_events: false
+
 # ---- Tag Writeback (optional) ------------------------------
 # tag_writeback_enabled: false

--- a/middleware/config.py
+++ b/middleware/config.py
@@ -34,6 +34,7 @@ DEFAULTS: dict = {
     "scanner_topic_prefix": "spoolsense",
     "scanners": {},
     "tag_writeback_enabled": False,
+    "publish_events": True,
 }
 
 # Legacy keys that trigger auto-migration

--- a/middleware/mqtt_handler.py
+++ b/middleware/mqtt_handler.py
@@ -257,10 +257,10 @@ def _handle_rich_tag(client: mqtt.Client, scanner_cfg: dict, payload: dict, topi
 
         # Enrich from Spoolman (best-effort), then activate
         spool_info = _enrich_from_spoolman(scan, topic)
-        _activate_from_scan(scanner_cfg, scan, spool_info=spool_info)
+        device_id = _extract_scanner_device_id(topic)
+        _activate_from_scan(scanner_cfg, scan, spool_info=spool_info, device_id=device_id)
 
         # Record initial weight for UPDATE_TAG filament deduction
-        device_id = _extract_scanner_device_id(topic)
         # tag_format comes from the scanner payload — tells us if this tag supports weight writes
         tag_format = payload.get("tag_format", "unknown")
         _record_spool_tracking(

--- a/middleware/mqtt_handler.py
+++ b/middleware/mqtt_handler.py
@@ -17,7 +17,8 @@ from typing import TYPE_CHECKING
 import paho.mqtt.client as mqtt
 
 import app_state
-from activation import activate_spool, publish_lock, _activate_from_scan
+from activation import activate_spool, notify_observers, publish_lock, _activate_from_scan
+from publishers.base import Action, SpoolEvent
 from publishers.klipper import display_spoolcolor
 from config import has_afc_scanners
 import moonraker_client
@@ -94,6 +95,26 @@ def _record_spool_tracking(
 
 # ── UID-only tag handling ────────────────────────────────────────────────────
 
+def _uid_only_event(action: str, target: str, spool_id: int, color_hex: str,
+                    material: str, remaining: float | None,
+                    device_id: str | None) -> SpoolEvent:
+    """Build a SpoolEvent for observer notification from UID-only scan data."""
+    return SpoolEvent(
+        spool_id=spool_id,
+        action=Action(action),
+        target=target,
+        color=color_hex,
+        material=material,
+        weight=remaining,
+        nozzle_temp_min=None,
+        nozzle_temp_max=None,
+        bed_temp_min=None,
+        bed_temp_max=None,
+        scanner_id=device_id or "",
+        tag_only=False,
+    )
+
+
 def _handle_uid_only_tag(client: mqtt.Client, scanner_cfg: dict, uid: str, topic: str) -> None:
     """UID-only tag (e.g. NTAG215) — no filament data on tag, look up spool in Spoolman via NFC ID."""
     target_id = _get_scanner_target(scanner_cfg) or _extract_scanner_device_id(topic) or "unknown"
@@ -127,7 +148,9 @@ def _handle_uid_only_tag(client: mqtt.Client, scanner_cfg: dict, uid: str, topic
     # no cache, no lock.
     if action == "happy_hare_stage":
         from happy_hare import bind_spool_to_current_gate
-        bind_spool_to_current_gate(spool_id)
+        if bind_spool_to_current_gate(spool_id):
+            notify_observers(_uid_only_event(action, "", spool_id, color_hex,
+                                             material, remaining, device_id))
         # Still drive low-spool LED feedback on the scanner so users loading
         # multiple spools into MMU gates see when one is nearly empty.
         if device_id and remaining is not None:
@@ -146,10 +169,16 @@ def _handle_uid_only_tag(client: mqtt.Client, scanner_cfg: dict, uid: str, topic
                 "spoolman_id": spool_id,
             }
         logger.info(f"[{action}] Staged spool {spool_id} ({name}) for assignment")
+        # Observer channels (MQTT event stream) still see staged scans even
+        # though no printer command fires yet (#93)
+        notify_observers(_uid_only_event(action, "", spool_id, color_hex,
+                                         material, remaining, device_id))
         return
 
     # Dedicated scanners — activate immediately
-    if not activate_spool(spool_id, action, target):
+    if not activate_spool(spool_id, action, target, color=color_hex,
+                          material=material, weight=remaining,
+                          scanner_id=device_id or "legacy"):
         return
 
     if target:

--- a/middleware/publisher_manager.py
+++ b/middleware/publisher_manager.py
@@ -122,6 +122,26 @@ class PublisherManager:
             return True
         return primary_succeeded
 
+    def notify(self, event: SpoolEvent) -> None:
+        """
+        Fan an event out to SECONDARY publishers only — observation, not action.
+
+        Used by scan paths that must not trigger the primary publisher's
+        printer commands (UID-only staged scans, Happy Hare binds) but should
+        still appear on observer channels like the MQTT event stream (#93).
+        Failures are logged and never raised.
+        """
+        for publisher in self._publishers:
+            if publisher.primary:
+                continue
+            try:
+                publisher.publish(event)
+            except Exception:
+                logger.exception(
+                    "Publisher '%s' raised unexpectedly during notify (event=%s action=%s)",
+                    publisher.name, event.scanner_id, event.action,
+                )
+
     def shutdown(self) -> None:
         """Call teardown() on all registered publishers. Used during graceful shutdown."""
         for publisher in self._publishers:

--- a/middleware/publishers/mqtt_events.py
+++ b/middleware/publishers/mqtt_events.py
@@ -1,0 +1,74 @@
+"""
+publishers/mqtt_events.py — SpoolEvents republished to MQTT (#93).
+
+Every SpoolEvent that flows through PublisherManager is published as JSON
+to `spoolsense/events/<action>` (QoS 1, not retained — these are events,
+not state; the health topic covers state). Home Assistant and anything
+else on the broker get automation hooks for scans, activations, and
+staging with no HA-specific code here.
+
+Wildcard-subscribe `spoolsense/events/#` to see everything.
+
+Secondary publisher: failures are logged by PublisherManager and never
+block activation. Enabled by default; set `publish_events: false` in
+config.yaml to turn it off.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict
+from datetime import datetime, timezone
+
+import app_state
+from publishers.base import Publisher, SpoolEvent
+
+logger = logging.getLogger(__name__)
+
+EVENT_TOPIC_PREFIX = "spoolsense/events"
+
+
+class MqttEventPublisher(Publisher):
+    """Republishes SpoolEvents to the MQTT broker for external consumers."""
+
+    def __init__(self, config: dict) -> None:
+        self._config = config
+
+    @property
+    def name(self) -> str:
+        return "mqtt_events"
+
+    @property
+    def primary(self) -> bool:
+        return False
+
+    def enabled(self, config: dict) -> bool:
+        """On by default — emitting an event is inert. `publish_events: false` disables."""
+        return bool(config.get("publish_events", True))
+
+    def publish(self, event: SpoolEvent) -> bool:
+        """Publish the event as JSON. Never raises; returns False on failure."""
+        client = app_state.mqtt_client
+        if client is None:
+            logger.debug("mqtt_events: no MQTT client yet — dropping event")
+            return False
+
+        payload = asdict(event)
+        # Action is a str-mixin Enum; be explicit so the JSON value and topic
+        # segment are the plain string on every Python version.
+        payload["action"] = event.action.value
+        payload["ts"] = datetime.now(timezone.utc).isoformat()
+
+        topic = f"{EVENT_TOPIC_PREFIX}/{event.action.value}"
+        try:
+            result = client.publish(topic, json.dumps(payload), qos=1)
+            if result.rc != 0:
+                logger.warning("mqtt_events: publish failed (rc=%d) topic=%s", result.rc, topic)
+                return False
+            return True
+        except Exception:
+            logger.exception("mqtt_events: failed to publish to %s", topic)
+            return False
+
+    def teardown(self) -> None:
+        """Stateless — nothing to tear down."""

--- a/middleware/rest_api.py
+++ b/middleware/rest_api.py
@@ -217,7 +217,7 @@ def mobile_scan(req: MobileScanRequest) -> ApiResponse:
         except Exception:
             logger.exception("Spoolman sync failed for mobile scan — continuing with tag-only")
 
-    _activate_from_scan(scanner_cfg, scan, spool_info=spool_info)
+    _activate_from_scan(scanner_cfg, scan, spool_info=spool_info, device_id="mobile")
 
     # Record for UPDATE_TAG deduction tracking — device_id="" signals mobile-scanned
     target = _get_scanner_target(scanner_cfg)

--- a/middleware/rest_api.py
+++ b/middleware/rest_api.py
@@ -57,6 +57,8 @@ class MobileScanRequest(BaseModel):
 
 class AssignToolRequest(BaseModel):
     toolhead: str
+    uid: Optional[str] = None            # uid from the originating scan — binds the assignment to that spool (#31)
+    spool_id: Optional[int] = None       # spoolman id from the scan — rides along with uid for newer clients
 
 
 class ApiResponse(BaseModel):
@@ -258,6 +260,17 @@ def assign_tool(req: AssignToolRequest) -> ApiResponse:
         pending = app_state.pending_spool
         if not pending:
             raise HTTPException(status_code=409, detail="No pending spool — scan a tag first")
+        # Spool binding (spoolsense-mobile #31): newer clients echo back the uid
+        # they scanned. pending_spool is a single last-write-wins slot, so a scan
+        # from any phone landing between mobile-scan and assign-tool would hand
+        # this assignment the wrong spool — reject before any gcode goes out.
+        # Case-insensitive: mobile sends uppercase hex, parsers store lowercase.
+        # Omitted uid = legacy client, keep the old unchecked behavior.
+        if req.uid and req.uid.lower() != (pending.get("uid") or "").lower():
+            raise HTTPException(
+                status_code=409,
+                detail="Pending spool changed since scan — rescan and try again",
+            )
         # Don't clear pending_spool here — toolchanger_status.py watcher
         # consumes it when it detects the ASSIGN_SPOOL macro variable change
 

--- a/middleware/spoolsense.py
+++ b/middleware/spoolsense.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
-__version__ = "1.8.0"
+__version__ = "1.8.1"
 """
 SpoolSense NFC Middleware
 =========================

--- a/middleware/spoolsense.py
+++ b/middleware/spoolsense.py
@@ -45,6 +45,7 @@ from activation import publish_lock
 from afc_status import AfcStatusSync
 from publisher_manager import PublisherManager
 from publishers.klipper import KlipperPublisher
+from publishers.mqtt_events import MqttEventPublisher
 from toolchanger_status import ToolchangerStatusSync
 from toolhead_status import ToolheadStatusSync
 from filament_usage import FilamentUsageSync
@@ -301,9 +302,10 @@ def main() -> None:
     # Load and validate config — exits on invalid config (strict validation)
     app_state.cfg = load_config()
 
-    # Publishers handle output to printer platforms (only Klipper today)
+    # Publishers handle output — Klipper is primary; MQTT events secondary (#93)
     app_state.publisher_manager = PublisherManager()
     app_state.publisher_manager.register(KlipperPublisher(app_state.cfg))
+    app_state.publisher_manager.register(MqttEventPublisher(app_state.cfg))
 
     if args.check_config:
         _print_config_summary()

--- a/middleware/tests/test_activation.py
+++ b/middleware/tests/test_activation.py
@@ -202,5 +202,33 @@ class TestStagedObserverEvents(unittest.TestCase):
         mock_notify.assert_not_called()
 
 
+class TestBuildSpoolEventScannerId(unittest.TestCase):
+    """scanner_id must carry the source scanner so event-stream (#93)
+    consumers can tell scanners apart — regression for the live finding
+    where rich staged scans published scanner_id="unknown"."""
+
+    def _event(self, scanner_cfg, target, device_id):
+        from activation import _build_spool_event
+        from publishers.base import Action
+        scan = MagicMock(nozzle_temp_min=None, nozzle_temp_max=None,
+                         bed_temp_min=None, bed_temp_max=None)
+        return _build_spool_event(scanner_cfg, Action.TOOLHEAD_STAGE, target,
+                                  None, "FF0000", "PLA", 500.0, scan,
+                                  device_id=device_id)
+
+    def test_topic_device_id_wins(self):
+        # Stage scanner (no target) — device_id from the topic must show up
+        ev = self._event({"action": "toolhead_stage"}, None, "f3d360")
+        self.assertEqual(ev.scanner_id, "f3d360")
+
+    def test_falls_back_to_target_when_no_device_id(self):
+        ev = self._event({"action": "toolhead"}, "T0", None)
+        self.assertEqual(ev.scanner_id, "T0")
+
+    def test_unknown_only_when_nothing_available(self):
+        ev = self._event({"action": "toolhead_stage"}, None, None)
+        self.assertEqual(ev.scanner_id, "unknown")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/middleware/tests/test_activation.py
+++ b/middleware/tests/test_activation.py
@@ -176,5 +176,31 @@ class TestValidateMaterial(unittest.TestCase):
         assert _validate_material("PLA\n") is False
 
 
+class TestStagedObserverEvents(unittest.TestCase):
+    """Tag-only staged rich scans never reach the publisher chain — they must
+    still hit the observer path so the MQTT event stream sees them (#93)."""
+
+    def test_tag_only_staged_notifies_observers(self):
+        from activation import _route_staged
+        from publishers.base import Action
+        event = MagicMock()
+        with patch("activation.notify_observers") as mock_notify, \
+             patch("activation._cache_pending_spool"):
+            _route_staged(Action.AFC_STAGE, False, "FF0000", "PLA", 500.0,
+                          None, event)
+        mock_notify.assert_called_once_with(event)
+
+    def test_spoolman_staged_does_not_double_notify(self):
+        # With a spoolman_id the event already went through the manager —
+        # secondaries saw it there; notifying again would duplicate
+        from activation import _route_staged
+        from publishers.base import Action
+        with patch("activation.notify_observers") as mock_notify, \
+             patch("activation._cache_pending_spool"):
+            _route_staged(Action.AFC_STAGE, True, "FF0000", "PLA", 500.0,
+                          42, MagicMock())
+        mock_notify.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/middleware/tests/test_mqtt_events.py
+++ b/middleware/tests/test_mqtt_events.py
@@ -1,0 +1,129 @@
+"""Tests for publishers/mqtt_events.py — SpoolEvents republished to MQTT (#93)."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+sys.modules.setdefault("paho", MagicMock())
+sys.modules.setdefault("paho.mqtt", MagicMock())
+sys.modules.setdefault("paho.mqtt.client", MagicMock())
+
+import app_state  # noqa: E402
+from publishers.base import Action, SpoolEvent  # noqa: E402
+from publishers.mqtt_events import MqttEventPublisher  # noqa: E402
+
+
+def _event(**overrides) -> SpoolEvent:
+    base = dict(
+        spool_id=131,
+        action=Action.TOOLHEAD,
+        target="T0",
+        color="1E00FF",
+        material="PLA",
+        weight=666.0,
+        nozzle_temp_min=190,
+        nozzle_temp_max=220,
+        bed_temp_min=50,
+        bed_temp_max=60,
+        scanner_id="4d9620",
+        tag_only=False,
+    )
+    base.update(overrides)
+    return SpoolEvent(**base)
+
+
+def _reset(mqtt_client=True):
+    app_state.mqtt_client = MagicMock() if mqtt_client else None
+    if mqtt_client:
+        result = MagicMock()
+        result.rc = 0
+        app_state.mqtt_client.publish.return_value = result
+
+
+class TestEnabled(unittest.TestCase):
+
+    def test_enabled_by_default(self):
+        self.assertTrue(MqttEventPublisher({}).enabled({}))
+
+    def test_disabled_via_config(self):
+        self.assertFalse(MqttEventPublisher({}).enabled({"publish_events": False}))
+
+    def test_is_secondary(self):
+        pub = MqttEventPublisher({})
+        self.assertFalse(pub.primary)
+        self.assertEqual(pub.name, "mqtt_events")
+
+
+class TestPublish(unittest.TestCase):
+
+    def setUp(self):
+        _reset()
+        self.pub = MqttEventPublisher({})
+
+    def _published(self):
+        args, kwargs = app_state.mqtt_client.publish.call_args
+        return args[0], json.loads(args[1]), kwargs
+
+    def test_topic_is_per_action(self):
+        self.assertTrue(self.pub.publish(_event(action=Action.TOOLHEAD)))
+        topic, _, _ = self._published()
+        self.assertEqual(topic, "spoolsense/events/toolhead")
+
+        self.pub.publish(_event(action=Action.AFC_STAGE, target=""))
+        topic, _, _ = self._published()
+        self.assertEqual(topic, "spoolsense/events/afc_stage")
+
+        self.pub.publish(_event(action=Action.HAPPY_HARE_STAGE, target=""))
+        topic, _, _ = self._published()
+        self.assertEqual(topic, "spoolsense/events/happy_hare_stage")
+
+    def test_payload_carries_full_event_plus_ts(self):
+        self.pub.publish(_event())
+        _, payload, _ = self._published()
+        self.assertEqual(payload["spool_id"], 131)
+        self.assertEqual(payload["action"], "toolhead")   # plain string, not enum repr
+        self.assertEqual(payload["target"], "T0")
+        self.assertEqual(payload["color"], "1E00FF")
+        self.assertEqual(payload["material"], "PLA")
+        self.assertEqual(payload["weight"], 666.0)
+        self.assertEqual(payload["scanner_id"], "4d9620")
+        self.assertFalse(payload["tag_only"])
+        # ISO-8601 UTC timestamp
+        self.assertIn("ts", payload)
+        self.assertIn("T", payload["ts"])
+        self.assertTrue(payload["ts"].endswith("+00:00") or payload["ts"].endswith("Z"))
+
+    def test_qos1_not_retained(self):
+        self.pub.publish(_event())
+        _, _, kwargs = self._published()
+        self.assertEqual(kwargs.get("qos"), 1)
+        self.assertFalse(kwargs.get("retain", False))
+
+    def test_tag_only_event_publishes(self):
+        self.assertTrue(self.pub.publish(_event(spool_id=None, tag_only=True)))
+        _, payload, _ = self._published()
+        self.assertIsNone(payload["spool_id"])
+        self.assertTrue(payload["tag_only"])
+
+    def test_no_mqtt_client_returns_false_without_raising(self):
+        _reset(mqtt_client=False)
+        self.assertFalse(self.pub.publish(_event()))
+
+    def test_publish_exception_returns_false(self):
+        app_state.mqtt_client.publish.side_effect = Exception("broker gone")
+        self.assertFalse(self.pub.publish(_event()))
+
+    def test_nonzero_rc_returns_false(self):
+        result = MagicMock()
+        result.rc = 4
+        app_state.mqtt_client.publish.return_value = result
+        self.assertFalse(self.pub.publish(_event()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/middleware/tests/test_mqtt_handler.py
+++ b/middleware/tests/test_mqtt_handler.py
@@ -336,5 +336,67 @@ class TestOnMessageLockBehavior(unittest.TestCase):
         assert app_state.lane_locks["T0"] is False
 
 
+class TestUidOnlyObserverEvents(unittest.TestCase):
+    """UID-only scan paths that bypass PublisherManager still emit observer
+    events for the MQTT event stream (#93)."""
+
+    def setUp(self):
+        _reset_app_state(
+            scanners={"ecb338": {"action": "afc_stage"}},
+        )
+        app_state.DISPATCHER_AVAILABLE = True
+        spool = {
+            "id": 17,
+            "filament": {"name": "Purple", "color_hex": "EE33FF", "material": "PLA"},
+            "remaining_weight": 500.0,
+        }
+        app_state.spoolman_client = MagicMock()
+        app_state.spoolman_client.find_by_nfc.return_value = spool
+
+    def _scan(self, uid="aabbccdd"):
+        from mqtt_handler import _handle_uid_only_tag
+        _handle_uid_only_tag(
+            MagicMock(), app_state.cfg["scanners"]["ecb338"], uid,
+            "spoolsense/ecb338/tag/state",
+        )
+
+    def test_staged_uid_only_scan_notifies_observers(self):
+        with patch("mqtt_handler.notify_observers") as mock_notify:
+            self._scan()
+        mock_notify.assert_called_once()
+        event = mock_notify.call_args.args[0]
+        self.assertEqual(event.action.value, "afc_stage")
+        self.assertEqual(event.spool_id, 17)
+        self.assertEqual(event.scanner_id, "ecb338")
+
+    def test_happy_hare_uid_only_notifies_on_successful_bind(self):
+        app_state.cfg["scanners"]["ecb338"] = {"action": "happy_hare_stage"}
+        with patch("mqtt_handler.notify_observers") as mock_notify, \
+             patch("happy_hare.bind_spool_to_current_gate", return_value=True):
+            self._scan()
+        mock_notify.assert_called_once()
+        self.assertEqual(mock_notify.call_args.args[0].action.value, "happy_hare_stage")
+
+    def test_dedicated_uid_only_event_carries_resolved_metadata(self):
+        # afc_lane/toolhead UID-only scans flow through activate_spool — the
+        # event must carry Spoolman-resolved color/material/weight and the
+        # real scanner id, not the bare "legacy" placeholder (#93)
+        app_state.cfg["scanners"]["ecb338"] = {"action": "afc_lane", "lane": "lane1"}
+        with patch("mqtt_handler.activate_spool", return_value=True) as mock_activate:
+            self._scan()
+        kwargs = mock_activate.call_args.kwargs
+        self.assertEqual(kwargs["color"], "EE33FF")
+        self.assertEqual(kwargs["material"], "PLA")
+        self.assertEqual(kwargs["weight"], 500.0)
+        self.assertEqual(kwargs["scanner_id"], "ecb338")
+
+    def test_happy_hare_uid_only_no_event_on_failed_bind(self):
+        app_state.cfg["scanners"]["ecb338"] = {"action": "happy_hare_stage"}
+        with patch("mqtt_handler.notify_observers") as mock_notify, \
+             patch("happy_hare.bind_spool_to_current_gate", return_value=False):
+            self._scan()
+        mock_notify.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/middleware/tests/test_publisher_manager.py
+++ b/middleware/tests/test_publisher_manager.py
@@ -199,5 +199,40 @@ class TestPublisherManagerShutdown(unittest.TestCase):
         mgr.shutdown()
 
 
+class TestNotify(unittest.TestCase):
+    """notify() is observation-only: secondaries receive, the primary never does."""
+
+    def setUp(self):
+        import app_state
+        app_state.cfg = {}
+
+    def _manager_with(self, *publishers):
+        from publisher_manager import PublisherManager
+        m = PublisherManager()
+        for pub in publishers:
+            m.register(pub)
+        return m
+
+    def test_secondary_receives_primary_does_not(self):
+        primary = _make_publisher("klipper", primary=True, enabled=True, result=True)
+        secondary = _make_publisher("mqtt_events", primary=False, enabled=True, result=True)
+        m = self._manager_with(primary, secondary)
+
+        m.notify(_make_event())
+
+        secondary.publish.assert_called_once()
+        primary.publish.assert_not_called()
+
+    def test_secondary_exception_swallowed(self):
+        secondary = _make_publisher("mqtt_events", primary=False, enabled=True, result=True)
+        secondary.publish.side_effect = Exception("boom")
+        m = self._manager_with(secondary)
+        m.notify(_make_event())  # must not raise
+
+    def test_no_publishers_is_noop(self):
+        m = self._manager_with()
+        m.notify(_make_event())  # must not raise
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/middleware/tests/test_rest_api.py
+++ b/middleware/tests/test_rest_api.py
@@ -267,6 +267,88 @@ class TestAssignTool(unittest.TestCase):
         self.assertEqual(resp.json()["spool_id"], 42)
 
 
+class TestAssignToolSpoolBinding(unittest.TestCase):
+    """POST /api/assign-tool with uid binding — rejects stale assignments
+    when another scan replaced pending_spool between mobile-scan and
+    assign-tool (spoolsense-mobile #31)."""
+
+    def setUp(self):
+        _reset_app_state(mobile_enabled=True, mobile_action="toolhead_stage")
+        app_state.pending_spool = {
+            "uid": "aabbccdd",
+            "spoolman_id": 42,
+            "color_hex": "FF0000",
+            "material": "PLA",
+            "remaining_g": 200.0,
+        }
+
+    def _post(self, payload: dict):
+        return client.post("/api/assign-tool", json=payload)
+
+    def test_matching_uid_assigns(self):
+        with patch("rest_api.send_gcode") as mock_gcode:
+            resp = self._post({"toolhead": "T0", "uid": "aabbccdd"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.json()["success"])
+        mock_gcode.assert_called_once()
+
+    def test_uid_match_is_case_insensitive(self):
+        # Mobile sends uppercase hex; middleware stores lowercase elsewhere
+        with patch("rest_api.send_gcode") as mock_gcode:
+            resp = self._post({"toolhead": "T0", "uid": "AABBCCDD"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.json()["success"])
+        mock_gcode.assert_called_once()
+
+    def test_mismatched_uid_returns_409(self):
+        # A second scan replaced pending_spool after this client scanned
+        with patch("rest_api.send_gcode") as mock_gcode:
+            resp = self._post({"toolhead": "T0", "uid": "11223344"})
+        self.assertEqual(resp.status_code, 409)
+        self.assertIn("rescan", resp.json()["detail"].lower())
+        # Must reject before any gcode goes out — never assign the wrong spool
+        mock_gcode.assert_not_called()
+
+    def test_omitted_uid_preserves_old_behavior(self):
+        # Old mobile clients send only {"toolhead": ...} — no binding check
+        with patch("rest_api.send_gcode") as mock_gcode:
+            resp = self._post({"toolhead": "T0"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.json()["success"])
+        mock_gcode.assert_called_once()
+
+    def test_uid_with_no_pending_returns_409(self):
+        app_state.pending_spool = None
+        with patch("rest_api.send_gcode") as mock_gcode:
+            resp = self._post({"toolhead": "T0", "uid": "aabbccdd"})
+        self.assertEqual(resp.status_code, 409)
+        mock_gcode.assert_not_called()
+
+    def test_pending_record_without_uid_returns_409(self):
+        # Pending record lacks a uid — binding can't be verified, refuse to guess
+        app_state.pending_spool = {"spoolman_id": 42}
+        with patch("rest_api.send_gcode") as mock_gcode:
+            resp = self._post({"toolhead": "T0", "uid": "aabbccdd"})
+        self.assertEqual(resp.status_code, 409)
+        mock_gcode.assert_not_called()
+
+    def test_spool_id_accepted(self):
+        # spool_id rides along for the mobile half — accepted without error;
+        # response spool_id still comes from the pending record
+        with patch("rest_api.send_gcode"):
+            resp = self._post({"toolhead": "T0", "uid": "aabbccdd", "spool_id": 42})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["spool_id"], 42)
+
+    def test_mismatch_rejected_before_moonraker_call(self):
+        # If the check ran after the gcode call, a stale uid would surface as
+        # 502 (Moonraker down) instead of 409 — pin the ordering
+        with patch("rest_api.send_gcode", side_effect=Exception("unreachable")) as mock_gcode:
+            resp = self._post({"toolhead": "T0", "uid": "deadbeef"})
+        self.assertEqual(resp.status_code, 409)
+        mock_gcode.assert_not_called()
+
+
 class TestUnlockTarget(unittest.TestCase):
     """POST /api/unlock/{target} — explicit unlock for #76."""
 


### PR DESCRIPTION
v1.8.1 — MQTT event stream + mobile assign-tool race fix.

## Added
- MQTT event stream — every scan/activation/staging event published to `spoolsense/events/<action>` (QoS 1, not retained). HA/Node-RED automations off filament activity, no custom code. On by default; `publish_events: false` disables. (#93)

## Fixed
- Mobile assign-tool could bind the wrong spool when a scan landed between the two mobile calls; now rejects a changed pending record with 409 before any gcode. (#96)

## Test plan
- [x] 503 tests pass under CI on 3.9 + 3.12
- [x] Hardware soak: health topic + event stream verified live on the printer; scanner_id gap found and fixed (#97)