### PR TITLE
Release v1.8.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to SpoolSense are documented here.
 
 ---
 
+## [1.8.1.1] - 2026-07-09
+
+### Changed
+
+- **assign-tool 409 responses carry machine-readable codes** — minor change
+  prepping for the SpoolSense Mobile iOS release. The error body now includes
+  `code: "no_pending_spool"` or `code: "pending_spool_changed"` so upcoming
+  app versions can distinguish the two failure causes. Status codes and
+  behavior are unchanged, and the current shipped app is unaffected. (#99)
+
+---
+
 ## [1.8.1] - 2026-07-08
 
 ### Added

--- a/middleware/rest_api.py
+++ b/middleware/rest_api.py
@@ -259,7 +259,14 @@ def assign_tool(req: AssignToolRequest) -> ApiResponse:
     with app_state.state_lock:
         pending = app_state.pending_spool
         if not pending:
-            raise HTTPException(status_code=409, detail="No pending spool — scan a tag first")
+            # detail carries a machine-readable code for clients that parse
+            # error bodies. The shipped iOS 1.0.0 build ignores non-2xx bodies
+            # entirely (status code only), so this is free to evolve; the
+            # status codes themselves are the frozen contract.
+            raise HTTPException(status_code=409, detail={
+                "code": "no_pending_spool",
+                "message": "No pending spool — scan a tag first",
+            })
         # Spool binding (spoolsense-mobile #31): newer clients echo back the uid
         # they scanned. pending_spool is a single last-write-wins slot, so a scan
         # from any phone landing between mobile-scan and assign-tool would hand
@@ -267,10 +274,10 @@ def assign_tool(req: AssignToolRequest) -> ApiResponse:
         # Case-insensitive: mobile sends uppercase hex, parsers store lowercase.
         # Omitted uid = legacy client, keep the old unchecked behavior.
         if req.uid and req.uid.lower() != (pending.get("uid") or "").lower():
-            raise HTTPException(
-                status_code=409,
-                detail="Pending spool changed since scan — rescan and try again",
-            )
+            raise HTTPException(status_code=409, detail={
+                "code": "pending_spool_changed",
+                "message": "Pending spool changed since scan — rescan and try again",
+            })
         # Don't clear pending_spool here — toolchanger_status.py watcher
         # consumes it when it detects the ASSIGN_SPOOL macro variable change
 

--- a/middleware/spoolsense.py
+++ b/middleware/spoolsense.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
-__version__ = "1.8.1"
+__version__ = "1.8.1.1"
 """
 SpoolSense NFC Middleware
 =========================

--- a/middleware/tests/test_rest_api.py
+++ b/middleware/tests/test_rest_api.py
@@ -305,7 +305,9 @@ class TestAssignToolSpoolBinding(unittest.TestCase):
         with patch("rest_api.send_gcode") as mock_gcode:
             resp = self._post({"toolhead": "T0", "uid": "11223344"})
         self.assertEqual(resp.status_code, 409)
-        self.assertIn("rescan", resp.json()["detail"].lower())
+        detail = resp.json()["detail"]
+        self.assertEqual(detail["code"], "pending_spool_changed")
+        self.assertIn("rescan", detail["message"].lower())
         # Must reject before any gcode goes out — never assign the wrong spool
         mock_gcode.assert_not_called()
 


### PR DESCRIPTION
v1.8.1.1 — minor change prepping for the SpoolSense Mobile iOS release.

## Changed
- assign-tool 409 responses now carry machine-readable codes (`no_pending_spool` / `pending_spool_changed`) so upcoming app versions can distinguish the two failure causes. Status codes and behavior unchanged; the current shipped app is unaffected. (#99)

## Test plan
- [x] 503 tests pass under CI on 3.9 + 3.12
- [x] Verified against a read-only audit of the shipped iOS 1.0.0 build: non-2xx bodies are discarded by that build, so this change is invisible to current App Store users