### PR TITLE
Release v1.8.2

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# Keep the image to runtime code only
+.git
+.github
+.venv
+docs
+esphome
+scripts
+middleware/tests
+middleware/docs
+middleware/static/*.map
+**/__pycache__
+*.pyc
+docker/spoolsense-data
+docker/compose.yaml
+docker/README.md
+CHANGELOG.md
+*.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,39 @@ jobs:
 
       - name: Test
         run: pytest middleware/tests/ -q
+
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build image
+        run: docker build -f docker/Dockerfile -t spoolsense-middleware .
+
+      - name: Smoke test — missing config seeds examples and waits with instructions
+        run: |
+          docker run -d --name firstrun -v /tmp/ssdata-empty:/home/spoolsense/SpoolSense spoolsense-middleware
+          sleep 5
+          docker logs firstrun 2>&1 | tee /tmp/firstrun.log
+          grep -q "No config.yaml found" /tmp/firstrun.log
+          # container must still be running (waiting), not crash-looping
+          test "$(docker inspect -f '{{.State.Running}}' firstrun)" = "true"
+          sudo test -f /tmp/ssdata-empty/config.example.single.yaml
+          # dropping a config in must auto-start the middleware
+          sudo cp /tmp/ssdata-empty/config.example.single.yaml /tmp/ssdata-empty/config.yaml
+          sleep 10
+          docker logs firstrun 2>&1 | grep -q "config.yaml detected"
+          docker rm -f firstrun
+
+      - name: Smoke test — --check-config passes with a valid config
+        run: |
+          mkdir -p /tmp/ssdata
+          cat > /tmp/ssdata/config.yaml <<'YAML'
+          mqtt:
+            broker: 127.0.0.1
+          moonraker_url: http://127.0.0.1:7125
+          scanners:
+            aabbcc:
+              action: toolhead_stage
+          YAML
+          docker run --rm -v /tmp/ssdata:/home/spoolsense/SpoolSense spoolsense-middleware python middleware/spoolsense.py --check-config

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ venv/
 # Ollama suggestions (local dev notes)
 ollama_suggestions.md
 
+# Docker volume data (user config/state, never committed)
+docker/spoolsense-data/
+
 # OS
 .DS_Store
 Thumbs.db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to SpoolSense are documented here.
 
 ---
 
+## [1.8.2] - 2026-07-10
+
+### Added
+
+- **Docker deployment** — run the middleware in a container on any machine on
+  the printer's LAN (home server, NAS, the box running Spoolman). Useful when
+  the printer host can't run it directly (e.g. Snapmaker U1). `cd docker &&
+  docker compose up -d`; the first run seeds config examples into the volume
+  and starts automatically once `config.yaml` is created. Full guide in
+  `docker/README.md`. The web panel's save-and-restart works in-container
+  (clean self-restart via the container restart policy). (#102)
+
+---
+
 ## [1.8.1.1] - 2026-07-09
 
 ### Changed

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,37 @@
+# SpoolSense middleware — LAN deployment for printers whose host can't run
+# it directly (#102). The middleware is fully network-native (MQTT, Moonraker
+# HTTP/websocket, Spoolman HTTP), so it runs anywhere on the printer's LAN.
+#
+#   docker compose up -d          (see compose.yaml)
+#
+# Config, log, and deduction state live in one volume mounted at
+# /home/spoolsense/SpoolSense — the same ~/SpoolSense layout as a bare install.
+
+FROM python:3.12-slim
+
+# Non-root user; HOME drives the middleware's ~/SpoolSense paths
+RUN useradd --create-home --uid 1000 spoolsense
+
+WORKDIR /app
+COPY middleware/requirements.txt middleware/requirements.txt
+RUN pip install --no-cache-dir -r middleware/requirements.txt
+
+COPY middleware/ middleware/
+COPY docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh && chown -R spoolsense:spoolsense /app
+
+# The entrypoint starts as root ONLY to fix bind-mount ownership (Docker
+# creates missing bind sources root-owned), then drops to the spoolsense
+# user via setpriv before running anything.
+ENV HOME=/home/spoolsense
+# Signals rest_api's save-and-restart to self-terminate cleanly (the restart
+# policy relaunches with the new config) instead of calling systemctl.
+ENV SPOOLSENSE_IN_DOCKER=1
+
+# REST API / web panel (only bound if mobile.enabled in config.yaml)
+EXPOSE 5001
+
+VOLUME ["/home/spoolsense/SpoolSense"]
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["python", "middleware/spoolsense.py"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,97 @@
+# Running the SpoolSense middleware in Docker
+
+Run the middleware on any machine on your printer's LAN — a home server, NAS,
+or the box already running Spoolman. Useful when the printer host can't run it
+directly (e.g. Snapmaker U1) or you just prefer containers.
+
+The middleware is fully network-native: it talks to your MQTT broker, Moonraker,
+and Spoolman over the LAN. Nothing needs to run on the printer host itself.
+
+> **Run exactly ONE middleware instance per printer.** A second instance (for
+> example one on the printer host *and* this container, pointed at the same
+> broker) will fight over the retained MQTT status topics and double-process
+> every scan.
+
+## Prerequisites
+
+- Docker with the compose plugin (`docker compose version` should work)
+- Network reachability from this machine to your MQTT broker, Moonraker, and
+  Spoolman
+
+## Install
+
+```bash
+git clone https://github.com/SpoolSense/spoolsense_middleware.git
+cd spoolsense_middleware/docker
+docker compose up -d
+```
+
+The first start seeds `./spoolsense-data/` with the config examples and waits.
+Create your config from the example matching your printer:
+
+```bash
+cp spoolsense-data/config.example.single.yaml spoolsense-data/config.yaml
+# or config.example.afc.yaml / config.example.toolchanger.yaml / config.example.happy_hare.yaml
+```
+
+Edit `spoolsense-data/config.yaml` — at minimum:
+
+- `mqtt.broker` — your broker's IP (and username/password if required)
+- `moonraker_url` — e.g. `http://192.168.1.50:7125`
+- `spoolman_url` — e.g. `http://192.168.1.32:7912` (optional, tag-only mode without it)
+- `scanners` — your scanner device IDs and actions
+
+The waiting container starts the middleware automatically within a few
+seconds of `config.yaml` appearing — no restart needed:
+
+```bash
+docker compose logs -f     # watch it come up
+```
+
+A healthy start logs `Starting SpoolSense Middleware v…`, connects to MQTT,
+and (if configured) refreshes the Spoolman cache.
+
+## Validate a config without starting
+
+```bash
+docker compose run --rm spoolsense python middleware/spoolsense.py --check-config
+```
+
+## Web panel / mobile app
+
+If `mobile.enabled: true` in your config, the REST API and web panel are served
+on port 5001 (mapped in `compose.yaml`): `http://<docker-host>:5001`.
+
+Saving config from the web panel restarts the container automatically so the
+new settings take effect (the container self-terminates cleanly and Docker's
+restart policy brings it back).
+
+Not using the mobile app or panel? Remove the `ports:` mapping from
+`compose.yaml`.
+
+## Upgrade
+
+```bash
+cd spoolsense_middleware
+git pull
+cd docker
+docker compose up -d --build
+```
+
+## Logs and state
+
+Everything lives in `./spoolsense-data/` (mounted at `~/SpoolSense` inside the
+container, same layout as a bare install):
+
+| File | Purpose |
+|---|---|
+| `config.yaml` | your configuration |
+| `middleware/spoolsense.log` | rotating log file (same content as `docker compose logs`) |
+| `deductions.json` | pending mobile filament deductions |
+
+## Uninstall
+
+```bash
+docker compose down
+# your config/state stays in ./spoolsense-data — delete it if you're done
+```

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -1,0 +1,38 @@
+# SpoolSense middleware — run on any machine on the printer's LAN (#102).
+#
+# First run:
+#   cd docker && docker compose up -d
+#   # the container seeds ./spoolsense-data/ with config examples and waits
+#   cp spoolsense-data/config.example.single.yaml spoolsense-data/config.yaml
+#   # edit config.yaml: MQTT broker, Moonraker URL, Spoolman URL, scanners
+#   # the middleware starts automatically once config.yaml appears
+#
+# Upgrading:
+#   git pull && docker compose up -d --build
+#
+# NOTE: run exactly ONE middleware instance per printer/broker. A second
+# instance (e.g. one on the printer host AND this container) will fight over
+# the retained MQTT status topics and double-process every scan.
+
+services:
+  spoolsense:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    container_name: spoolsense-middleware
+    restart: unless-stopped
+    volumes:
+      # config.yaml, spoolsense.log, deductions.json all live here —
+      # same layout as ~/SpoolSense on a bare install
+      - ./spoolsense-data:/home/spoolsense/SpoolSense
+    ports:
+      # REST API + web panel — only served if mobile.enabled in config.yaml.
+      # Remove this mapping if you don't use the mobile app or web panel.
+      - "5001:5001"
+    logging:
+      # Middleware also keeps a rotated log file in the volume; cap Docker's
+      # own capture so container logs can't grow unbounded.
+      driver: json-file
+      options:
+        max-size: "5m"
+        max-file: "3"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+# Stage 1 (root): Docker creates missing bind-mount sources owned by root,
+# which would break the non-root middleware (it writes config/log/deductions
+# into the volume). Fix ownership, then drop privileges and re-exec.
+# Stage 2 (spoolsense): first-run config guard, then hand off to the CMD.
+set -e
+
+CONFIG_DIR="$HOME/SpoolSense"
+
+if [ "$(id -u)" = "0" ]; then
+    mkdir -p "$CONFIG_DIR"
+    chown -R spoolsense:spoolsense "$CONFIG_DIR"
+    exec setpriv --reuid=spoolsense --regid=spoolsense --clear-groups "$0" "$@"
+fi
+
+mkdir -p "$CONFIG_DIR"
+
+if [ ! -f "$CONFIG_DIR/config.yaml" ]; then
+    cp -n /app/middleware/config.example.*.yaml "$CONFIG_DIR/" 2>/dev/null || true
+    echo "============================================================"
+    echo " No config.yaml found in the SpoolSense volume."
+    echo ""
+    echo " Config examples have been copied into the volume."
+    echo " On the host, copy the one matching your printer to"
+    echo " config.yaml and edit it (MQTT broker, Moonraker URL,"
+    echo " scanners):"
+    echo ""
+    echo "   cp spoolsense-data/config.example.single.yaml \\"
+    echo "      spoolsense-data/config.yaml"
+    echo ""
+    echo " The middleware starts automatically once config.yaml"
+    echo " appears — no restart needed. Waiting..."
+    echo "============================================================"
+    # Waiting (not exiting) avoids a restart/backoff loop under
+    # restart: unless-stopped. Trap so `docker stop` works promptly
+    # while we're PID 1 in the wait loop.
+    trap 'exit 0' TERM INT
+    while [ ! -f "$CONFIG_DIR/config.yaml" ]; do
+        sleep 5
+    done
+    echo "config.yaml detected — starting middleware"
+fi
+
+exec "$@"

--- a/middleware/rest_api.py
+++ b/middleware/rest_api.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 import json
 import logging
 import os
+import signal
 import subprocess
 import sys
+import threading
 from pathlib import Path
 from typing import Any, Optional
 
@@ -417,14 +419,20 @@ def save_config(req: SaveConfigRequest) -> dict[str, Any]:
         os.replace(tmp_path, CONFIG_PATH)
         logger.info("Web panel: config saved to %s", CONFIG_PATH)
 
-        # Restart the middleware service
-        try:
-            subprocess.Popen(
-                ["sudo", "systemctl", "restart", "spoolsense"],
-                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-            )
-        except Exception:
-            logger.warning("Web panel: could not restart spoolsense service")
+        # Restart so the new config takes effect. In Docker there is no
+        # systemctl — a clean self-terminate lets the container's restart
+        # policy relaunch with the new config (SPOOLSENSE_IN_DOCKER is set
+        # by the image). The short delay lets this response reach the client.
+        if os.environ.get("SPOOLSENSE_IN_DOCKER"):
+            threading.Timer(0.5, lambda: os.kill(os.getpid(), signal.SIGTERM)).start()
+        else:
+            try:
+                subprocess.Popen(
+                    ["sudo", "systemctl", "restart", "spoolsense"],
+                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                )
+            except Exception:
+                logger.warning("Web panel: could not restart spoolsense service")
 
         return {"success": True, "message": "Config saved — restarting"}
     except Exception as e:

--- a/middleware/spoolsense.py
+++ b/middleware/spoolsense.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
-__version__ = "1.8.1.1"
+__version__ = "1.8.2"
 """
 SpoolSense NFC Middleware
 =========================

--- a/middleware/tests/test_rest_api.py
+++ b/middleware/tests/test_rest_api.py
@@ -399,5 +399,55 @@ class TestUnlockTarget(unittest.TestCase):
         self.assertTrue(app_state.lane_locks["lane1"])
 
 
+class TestSaveConfigDockerRestart(unittest.TestCase):
+    """In Docker (SPOOLSENSE_IN_DOCKER set), save-config self-terminates via
+    SIGTERM so the container restart policy relaunches with the new config —
+    systemctl doesn't exist there (#102)."""
+
+    def _post_save(self):
+        return client.post("/api/save-config", json={
+            "moonraker_url": "http://moonraker:7125",
+            "spoolman_url": "",
+            "mqtt": {"broker": "192.168.1.167"},
+        })
+
+    def test_docker_env_schedules_self_sigterm_not_systemctl(self):
+        import tempfile, yaml as yamlmod  # noqa: F401
+        with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
+            f.write("moonraker_url: http://old:7125\n")
+            tmp = f.name
+        try:
+            with patch("rest_api.CONFIG_PATH", tmp), \
+                 patch.dict(os.environ, {"SPOOLSENSE_IN_DOCKER": "1"}), \
+                 patch("rest_api.threading.Timer") as mock_timer, \
+                 patch("rest_api.subprocess.Popen") as mock_popen:
+                resp = self._post_save()
+            self.assertEqual(resp.status_code, 200)
+            self.assertTrue(resp.json()["success"])
+            mock_timer.assert_called_once()
+            mock_timer.return_value.start.assert_called_once()
+            mock_popen.assert_not_called()
+        finally:
+            os.unlink(tmp)
+
+    def test_bare_install_uses_systemctl(self):
+        import tempfile
+        with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
+            f.write("moonraker_url: http://old:7125\n")
+            tmp = f.name
+        try:
+            env = {k: v for k, v in os.environ.items() if k != "SPOOLSENSE_IN_DOCKER"}
+            with patch("rest_api.CONFIG_PATH", tmp), \
+                 patch.dict(os.environ, env, clear=True), \
+                 patch("rest_api.threading.Timer") as mock_timer, \
+                 patch("rest_api.subprocess.Popen") as mock_popen:
+                resp = self._post_save()
+            self.assertEqual(resp.status_code, 200)
+            mock_popen.assert_called_once()
+            mock_timer.assert_not_called()
+        finally:
+            os.unlink(tmp)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
v1.8.2 — Docker deployment.

## Added
- Docker image + compose for running the middleware anywhere on the printer's LAN (#102). First run seeds config examples and auto-starts once config.yaml appears. Guide in docker/README.md. Container-aware web-panel restart.

## Test plan
- [x] 505 tests pass under CI on 3.9 + 3.12; new docker CI job builds the image and smoke-tests first-run + --check-config
- [x] Verified end to end in a running container against real Moonraker, Spoolman, and a broker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Docker deployment support for running SpoolSense in a container.
  * Added automatic first-run configuration setup and persistent storage.
  * Added configuration validation and support for web-panel save-and-restart behavior in Docker.
  * Added Docker usage, upgrade, and troubleshooting documentation.

* **Bug Fixes**
  * Improved container startup handling when configuration is missing or invalid.

* **Tests**
  * Added Docker smoke tests covering startup, configuration discovery, and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->