### PR TITLE
Accept partial amounts on the deduction-applied endpoint

### DIFF
--- a/middleware/rest_api.py
+++ b/middleware/rest_api.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 import yaml
-from fastapi import Body, FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
@@ -379,7 +379,7 @@ def get_deduction(uid: str) -> DeductionResponse:
 
 
 @app.post("/api/deductions/{uid}/applied", response_model=DeductionConfirmResponse)
-def confirm_deduction(uid: str, body: Optional[dict] = Body(default=None)) -> DeductionConfirmResponse:
+async def confirm_deduction(uid: str, request: Request) -> DeductionConfirmResponse:
     """Acknowledge a pending deduction after the mobile app writes the tag.
 
     No body / empty ``{}``: clear the full pending value (legacy behavior —
@@ -398,6 +398,26 @@ def confirm_deduction(uid: str, body: Optional[dict] = Body(default=None)) -> De
     """
     uid_lower = uid.lower()
 
+    # Parse the body by hand: FastAPI binds a top-level JSON `null` to the
+    # parameter default, making it indistinguishable from an absent body —
+    # and a malformed payload must never alias the destructive legacy clear.
+    raw = await request.body()
+    if not raw or not raw.strip():
+        body: dict = {}
+    else:
+        try:
+            body = json.loads(raw)
+        except ValueError:
+            body = None  # type: ignore[assignment]
+        if not isinstance(body, dict):
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "code": "invalid_body",
+                    "message": "body must be a JSON object",
+                },
+            )
+
     if not body:
         # Legacy full clear — only an absent or empty body qualifies. A
         # nonempty body without a valid applied_g is rejected below so a
@@ -410,12 +430,18 @@ def confirm_deduction(uid: str, body: Optional[dict] = Body(default=None)) -> De
         return DeductionConfirmResponse(success=True, cleared_g=cleared,
                                         remaining_pending_g=0.0)
 
-    applied_g = body.get("applied_g")
+    raw_applied = body.get("applied_g")
     # bool is an int subclass — reject it along with everything non-numeric.
-    # NaN/Infinity pass numeric comparisons, so require a finite value before
-    # any state is touched.
-    if isinstance(applied_g, bool) or not isinstance(applied_g, (int, float)) \
-            or not math.isfinite(applied_g) or applied_g <= 0:
+    # NaN/Infinity pass numeric comparisons and an arbitrarily large JSON
+    # integer overflows float conversion, so normalize to a finite float
+    # before any state is touched.
+    applied: Optional[float] = None
+    if not isinstance(raw_applied, bool) and isinstance(raw_applied, (int, float)):
+        try:
+            applied = float(raw_applied)
+        except OverflowError:
+            applied = None
+    if applied is None or not math.isfinite(applied) or applied <= 0:
         raise HTTPException(
             status_code=400,
             detail={
@@ -426,7 +452,7 @@ def confirm_deduction(uid: str, body: Optional[dict] = Body(default=None)) -> De
 
     with app_state.state_lock:
         pending = app_state.pending_mobile_deductions.get(uid_lower, 0.0)
-        cleared = min(float(applied_g), pending)
+        cleared = min(applied, pending)
         remaining = pending - cleared
         if remaining <= 1e-9:  # float dust from the subtraction is a full clear
             remaining = 0.0

--- a/middleware/rest_api.py
+++ b/middleware/rest_api.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 import yaml
-from fastapi import FastAPI, HTTPException
+from fastapi import Body, FastAPI, HTTPException
 from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
@@ -364,6 +364,9 @@ class DeductionResponse(BaseModel):
 class DeductionConfirmResponse(BaseModel):
     success: bool
     cleared_g: float
+    # New in 1.8.4 — shipped mobile 1.0.0 requires success + cleared_g to stay;
+    # extra fields are ignored by its decoder
+    remaining_pending_g: float = 0.0
 
 
 @app.get("/api/deductions/{uid}", response_model=DeductionResponse)
@@ -375,15 +378,64 @@ def get_deduction(uid: str) -> DeductionResponse:
 
 
 @app.post("/api/deductions/{uid}/applied", response_model=DeductionConfirmResponse)
-def confirm_deduction(uid: str) -> DeductionConfirmResponse:
-    """Clear a pending deduction after the mobile app confirms the tag write succeeded."""
+def confirm_deduction(uid: str, body: Optional[dict] = Body(default=None)) -> DeductionConfirmResponse:
+    """Acknowledge a pending deduction after the mobile app writes the tag.
+
+    No body / empty ``{}``: clear the full pending value (legacy behavior —
+    shipped mobile 1.0.0 posts an empty body and expects a full clear).
+
+    ``{"applied_g": <float>}``: subtract only what the app actually applied
+    and retain the remainder as still-pending, so a partial tag write no
+    longer forfeits (or double-counts on retry) the rest. An ``applied_g``
+    above the pending value clears everything — clock skew between the
+    phone's apply and a concurrent scanner deduction makes small overshoots
+    legitimate — and can never drive pending negative.
+
+    NOT idempotent: each post subtracts again. A retry after an ambiguous
+    outcome (timeout, transport error) must re-GET /api/deductions/{uid}
+    and reconcile before posting, rather than blindly reposting.
+    """
     uid_lower = uid.lower()
+    applied_g = (body or {}).get("applied_g")
+
+    if applied_g is None:
+        # Legacy full clear
+        with app_state.state_lock:
+            cleared = app_state.pending_mobile_deductions.pop(uid_lower, 0.0)
+        if cleared > 0:
+            _save_deductions()
+            logger.info(f"Mobile deduction: cleared {cleared:.1f}g for {uid_lower}")
+        return DeductionConfirmResponse(success=True, cleared_g=cleared,
+                                        remaining_pending_g=0.0)
+
+    # bool is an int subclass — reject it along with everything non-numeric
+    if isinstance(applied_g, bool) or not isinstance(applied_g, (int, float)) \
+            or applied_g <= 0:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "invalid_applied_g",
+                "message": "applied_g must be a number greater than 0",
+            },
+        )
+
     with app_state.state_lock:
-        cleared = app_state.pending_mobile_deductions.pop(uid_lower, 0.0)
+        pending = app_state.pending_mobile_deductions.get(uid_lower, 0.0)
+        cleared = min(float(applied_g), pending)
+        remaining = pending - cleared
+        if remaining <= 1e-9:  # float dust from the subtraction is a full clear
+            remaining = 0.0
+            app_state.pending_mobile_deductions.pop(uid_lower, None)
+        else:
+            app_state.pending_mobile_deductions[uid_lower] = remaining
     if cleared > 0:
         _save_deductions()
-        logger.info(f"Mobile deduction: cleared {cleared:.1f}g for {uid_lower}")
-    return DeductionConfirmResponse(success=True, cleared_g=cleared)
+        logger.info(
+            f"Mobile deduction: applied {cleared:.1f}g for {uid_lower} "
+            f"({remaining:.1f}g still pending)"
+        )
+    return DeductionConfirmResponse(success=True, cleared_g=cleared,
+                                    remaining_pending_g=remaining)
 
 
 # ── Web config panel endpoints ───────────────────────────────────────────────

--- a/middleware/rest_api.py
+++ b/middleware/rest_api.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import signal
 import subprocess
@@ -396,10 +397,11 @@ def confirm_deduction(uid: str, body: Optional[dict] = Body(default=None)) -> De
     and reconcile before posting, rather than blindly reposting.
     """
     uid_lower = uid.lower()
-    applied_g = (body or {}).get("applied_g")
 
-    if applied_g is None:
-        # Legacy full clear
+    if not body:
+        # Legacy full clear — only an absent or empty body qualifies. A
+        # nonempty body without a valid applied_g is rejected below so a
+        # misspelled field can't silently clear everything.
         with app_state.state_lock:
             cleared = app_state.pending_mobile_deductions.pop(uid_lower, 0.0)
         if cleared > 0:
@@ -408,14 +410,17 @@ def confirm_deduction(uid: str, body: Optional[dict] = Body(default=None)) -> De
         return DeductionConfirmResponse(success=True, cleared_g=cleared,
                                         remaining_pending_g=0.0)
 
-    # bool is an int subclass — reject it along with everything non-numeric
+    applied_g = body.get("applied_g")
+    # bool is an int subclass — reject it along with everything non-numeric.
+    # NaN/Infinity pass numeric comparisons, so require a finite value before
+    # any state is touched.
     if isinstance(applied_g, bool) or not isinstance(applied_g, (int, float)) \
-            or applied_g <= 0:
+            or not math.isfinite(applied_g) or applied_g <= 0:
         raise HTTPException(
             status_code=400,
             detail={
                 "code": "invalid_applied_g",
-                "message": "applied_g must be a number greater than 0",
+                "message": "applied_g must be a finite number greater than 0",
             },
         )
 

--- a/middleware/tests/test_rest_api.py
+++ b/middleware/tests/test_rest_api.py
@@ -498,18 +498,29 @@ class TestDeductionApplied(unittest.TestCase):
         self.assertEqual(resp.status_code, 400)
 
     def test_non_numeric_applied_rejected(self) -> None:
-        for bad in ("10.0", True, [10]):
+        for bad in ("10.0", True, [10], None):
             resp = client.post("/api/deductions/AABB11/applied",
                                json={"applied_g": bad})
             self.assertEqual(resp.status_code, 400, f"bad value: {bad!r}")
         self.assertEqual(app_state.pending_mobile_deductions["aabb11"], 25.5)
 
-    def test_explicit_null_applied_is_legacy_clear(self) -> None:
-        # JSON null is indistinguishable from an absent key — legacy clear
+    def test_non_finite_applied_rejected(self) -> None:
+        # Python's JSON parser accepts bare NaN/Infinity tokens — they pass
+        # numeric comparisons and would corrupt the stored pending value
+        for bad in ("NaN", "Infinity", "-Infinity"):
+            resp = client.post("/api/deductions/AABB11/applied",
+                               content='{"applied_g": %s}' % bad,
+                               headers={"Content-Type": "application/json"})
+            self.assertEqual(resp.status_code, 400, f"bad value: {bad}")
+        self.assertEqual(app_state.pending_mobile_deductions["aabb11"], 25.5)
+
+    def test_nonempty_body_without_applied_g_rejected(self) -> None:
+        # A misspelled field must not silently clear the full pending value —
+        # only an absent or empty body means legacy full clear
         resp = client.post("/api/deductions/AABB11/applied",
-                           json={"applied_g": None})
-        self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp.json()["cleared_g"], 25.5)
+                           json={"appliedG": 10.0})
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(app_state.pending_mobile_deductions["aabb11"], 25.5)
 
     def test_repeated_partial_posts_subtract_again(self) -> None:
         # Documented semantics: NOT idempotent — a retry must re-GET first

--- a/middleware/tests/test_rest_api.py
+++ b/middleware/tests/test_rest_api.py
@@ -427,6 +427,99 @@ class TestUnlockTarget(unittest.TestCase):
         self.assertTrue(app_state.lane_locks["lane1"])
 
 
+class TestDeductionApplied(unittest.TestCase):
+    """POST /api/deductions/{uid}/applied — legacy full clear (empty body,
+    shipped mobile 1.0.0) and partial acknowledgment via applied_g (#94)."""
+
+    def setUp(self) -> None:
+        _reset_app_state()
+        app_state.pending_mobile_deductions = {"aabb11": 25.5}
+
+    def test_empty_body_clears_all_legacy(self) -> None:
+        # Shipped 1.0.0 posts `{}` and expects a full clear
+        resp = client.post("/api/deductions/AABB11/applied", json={})
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertTrue(data["success"])
+        self.assertEqual(data["cleared_g"], 25.5)
+        self.assertEqual(data["remaining_pending_g"], 0.0)
+        self.assertNotIn("aabb11", app_state.pending_mobile_deductions)
+
+    def test_no_body_clears_all_legacy(self) -> None:
+        resp = client.post("/api/deductions/AABB11/applied")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["cleared_g"], 25.5)
+        self.assertNotIn("aabb11", app_state.pending_mobile_deductions)
+
+    def test_partial_apply_retains_remainder(self) -> None:
+        resp = client.post("/api/deductions/AABB11/applied",
+                           json={"applied_g": 10.0})
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertTrue(data["success"])
+        self.assertEqual(data["cleared_g"], 10.0)
+        self.assertEqual(data["remaining_pending_g"], 15.5)
+        # Remainder visible on the read endpoint
+        get_resp = client.get("/api/deductions/AABB11")
+        self.assertEqual(get_resp.json()["pending_g"], 15.5)
+
+    def test_full_amount_clears_entry(self) -> None:
+        resp = client.post("/api/deductions/AABB11/applied",
+                           json={"applied_g": 25.5})
+        self.assertEqual(resp.json()["cleared_g"], 25.5)
+        self.assertEqual(resp.json()["remaining_pending_g"], 0.0)
+        self.assertNotIn("aabb11", app_state.pending_mobile_deductions)
+
+    def test_overshoot_clamps_to_pending(self) -> None:
+        # Clock skew vs a concurrent scanner deduction — clamp, don't error
+        resp = client.post("/api/deductions/AABB11/applied",
+                           json={"applied_g": 30.0})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["cleared_g"], 25.5)
+        self.assertEqual(resp.json()["remaining_pending_g"], 0.0)
+        self.assertNotIn("aabb11", app_state.pending_mobile_deductions)
+
+    def test_apply_against_no_pending_is_noop(self) -> None:
+        resp = client.post("/api/deductions/UNSEEN99/applied",
+                           json={"applied_g": 5.0})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["cleared_g"], 0.0)
+        self.assertEqual(resp.json()["remaining_pending_g"], 0.0)
+
+    def test_zero_applied_rejected(self) -> None:
+        resp = client.post("/api/deductions/AABB11/applied",
+                           json={"applied_g": 0})
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(app_state.pending_mobile_deductions["aabb11"], 25.5)
+
+    def test_negative_applied_rejected(self) -> None:
+        resp = client.post("/api/deductions/AABB11/applied",
+                           json={"applied_g": -5.0})
+        self.assertEqual(resp.status_code, 400)
+
+    def test_non_numeric_applied_rejected(self) -> None:
+        for bad in ("10.0", True, [10]):
+            resp = client.post("/api/deductions/AABB11/applied",
+                               json={"applied_g": bad})
+            self.assertEqual(resp.status_code, 400, f"bad value: {bad!r}")
+        self.assertEqual(app_state.pending_mobile_deductions["aabb11"], 25.5)
+
+    def test_explicit_null_applied_is_legacy_clear(self) -> None:
+        # JSON null is indistinguishable from an absent key — legacy clear
+        resp = client.post("/api/deductions/AABB11/applied",
+                           json={"applied_g": None})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["cleared_g"], 25.5)
+
+    def test_repeated_partial_posts_subtract_again(self) -> None:
+        # Documented semantics: NOT idempotent — a retry must re-GET first
+        client.post("/api/deductions/AABB11/applied", json={"applied_g": 10.0})
+        resp = client.post("/api/deductions/AABB11/applied",
+                           json={"applied_g": 10.0})
+        self.assertEqual(resp.json()["cleared_g"], 10.0)
+        self.assertEqual(resp.json()["remaining_pending_g"], 5.5)
+
+
 class TestSaveConfigDockerRestart(unittest.TestCase):
     """In Docker (SPOOLSENSE_IN_DOCKER set), save-config self-terminates via
     SIGTERM so the container restart policy relaunches with the new config —

--- a/middleware/tests/test_rest_api.py
+++ b/middleware/tests/test_rest_api.py
@@ -514,6 +514,29 @@ class TestDeductionApplied(unittest.TestCase):
             self.assertEqual(resp.status_code, 400, f"bad value: {bad}")
         self.assertEqual(app_state.pending_mobile_deductions["aabb11"], 25.5)
 
+    def test_top_level_null_body_rejected(self) -> None:
+        # Explicit `null` is malformed, not a legacy clear — pending survives
+        resp = client.post("/api/deductions/AABB11/applied",
+                           content="null",
+                           headers={"Content-Type": "application/json"})
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(app_state.pending_mobile_deductions["aabb11"], 25.5)
+
+    def test_malformed_json_body_rejected(self) -> None:
+        resp = client.post("/api/deductions/AABB11/applied",
+                           content='{"applied_g": ',
+                           headers={"Content-Type": "application/json"})
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(app_state.pending_mobile_deductions["aabb11"], 25.5)
+
+    def test_oversized_integer_rejected(self) -> None:
+        # A JSON integer too large for float conversion must 400, not 500
+        resp = client.post("/api/deductions/AABB11/applied",
+                           content='{"applied_g": %s}' % ("9" * 400),
+                           headers={"Content-Type": "application/json"})
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(app_state.pending_mobile_deductions["aabb11"], 25.5)
+
     def test_nonempty_body_without_applied_g_rejected(self) -> None:
         # A misspelled field must not silently clear the full pending value —
         # only an absent or empty body means legacy full clear


### PR DESCRIPTION
`POST /api/deductions/{uid}/applied` now accepts an optional `{"applied_g": <float>}` body so the mobile app can acknowledge exactly what it wrote to the tag (spoolsense-mobile#94). Previously the endpoint could only clear everything, so a partial tag write either forfeited the remainder or double-counted it on retry.

## Semantics

- **Body absent or `{}`** — unchanged legacy behavior: clear the full pending value. The shipped mobile 1.0.0 posts an empty body and depends on this.
- **`{"applied_g": <float>}`** — subtract that amount, floor at 0, retain the remainder as still-pending. `applied_g` above the pending value clamps to a full clear (clock skew between the phone's apply and a concurrent scanner deduction makes small overshoots legitimate).
- **Anything else** — `400` with `{"code": "invalid_applied_g" | "invalid_body"}` and pending untouched: non-object bodies, malformed JSON, missing/misspelled/null keys, zero/negative, non-numeric, NaN/Infinity, and integers too large for float conversion.

Response gains `remaining_pending_g`; `success` and `cleared_g` are unchanged so the shipped decoder is unaffected.

Not idempotent by design (documented in the endpoint docstring): each post subtracts again, so a retry after an ambiguous outcome must re-`GET /api/deductions/{uid}` and reconcile first. The clamp bounds the damage; proper dedup belongs to the event-UUID design when scan/assign/deduct flows adopt it.

The endpoint parses its body by hand: FastAPI binds a top-level JSON `null` to the parameter default, which would make a malformed payload indistinguishable from the destructive legacy clear.

## Testing

- 14 new endpoint tests (550 passing total): partial/full/legacy/no-body, overshoot clamp, no-pending no-op, repeat-post semantics, and the full rejection matrix
- Three review passes; two rounds of findings (destructive-clear aliasing, NaN/bigint state corruption) fixed with regression tests
- Live server matrix verified with real requests: partial → remainder visible on GET, clamp, both legacy clears, every 400 path, and disk persistence
