### PR TITLE
Hygiene fixes: cleanup-script dedup bug, deductions makedirs, import-time logging

### DIFF
--- a/middleware/moonraker_ws.py
+++ b/middleware/moonraker_ws.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import json
 import logging
 import threading
-import time
 from collections.abc import Callable
 
 logger = logging.getLogger(__name__)

--- a/middleware/rest_api.py
+++ b/middleware/rest_api.py
@@ -338,6 +338,7 @@ def _save_deductions() -> None:
     with app_state.state_lock:
         snapshot = dict(app_state.pending_mobile_deductions)
     try:
+        os.makedirs(os.path.dirname(app_state.DEDUCTIONS_FILE), exist_ok=True)
         tmp_path = app_state.DEDUCTIONS_FILE + ".tmp"
         with open(tmp_path, "w") as f:
             json.dump(snapshot, f)

--- a/middleware/spoolsense.py
+++ b/middleware/spoolsense.py
@@ -58,14 +58,30 @@ LOG_FILE         = os.path.expanduser('~/SpoolSense/middleware/spoolsense.log')
 LOG_MAX_BYTES    = 5 * 1024 * 1024                                              # 5MB per log file
 LOG_BACKUP_COUNT = 3                                                            # keep 3 rotated copies
 
-logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
-os.makedirs(os.path.dirname(LOG_FILE), exist_ok=True)
-_file_handler = RotatingFileHandler(LOG_FILE, maxBytes=LOG_MAX_BYTES, backupCount=LOG_BACKUP_COUNT)
-_file_handler.setFormatter(logging.Formatter(LOG_FORMAT))
-_file_handler.setLevel(logging.INFO)
-logging.getLogger().addHandler(_file_handler)
-
 logger = logging.getLogger(__name__)
+
+
+def _configure_logging(log_file: str = LOG_FILE) -> None:
+    """Add rotating file logging without making module import touch the disk."""
+    logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
+    root_logger = logging.getLogger()
+    if any(getattr(handler, "_spoolsense_handler", False)
+           for handler in root_logger.handlers):
+        return
+    try:
+        os.makedirs(os.path.dirname(log_file), exist_ok=True)
+        file_handler = RotatingFileHandler(
+            log_file,
+            maxBytes=LOG_MAX_BYTES,
+            backupCount=LOG_BACKUP_COUNT,
+        )
+    except OSError:
+        logger.warning("File logging unavailable at %s", log_file, exc_info=True)
+        return
+    file_handler.setFormatter(logging.Formatter(LOG_FORMAT))
+    file_handler.setLevel(logging.INFO)
+    file_handler._spoolsense_handler = True
+    root_logger.addHandler(file_handler)
 
 
 # ── Shutdown ─────────────────────────────────────────────────────────────────
@@ -298,6 +314,8 @@ def main() -> None:
     parser.add_argument("--check-config", action="store_true",
                         help="Validate config and print a summary, then exit.")
     args = parser.parse_args()
+
+    _configure_logging()
 
     # Load and validate config — exits on invalid config (strict validation)
     app_state.cfg = load_config()

--- a/middleware/tests/test_spoolman_cleanup.py
+++ b/middleware/tests/test_spoolman_cleanup.py
@@ -1,0 +1,35 @@
+"""Regression tests for the standalone Spoolman cleanup utility."""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+_SCRIPT = Path(__file__).parents[2] / "scripts" / "spoolman-cleanup.py"
+_SPEC = importlib.util.spec_from_file_location("spoolman_cleanup", _SCRIPT)
+assert _SPEC is not None and _SPEC.loader is not None
+cleanup = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(cleanup)
+
+
+def test_filaments_without_identity_are_not_grouped_as_duplicates():
+    filaments = [{"id": 1}, {"id": 2}, {"id": 3}]
+    assert cleanup.find_duplicate_filaments(filaments) == {}
+
+
+def test_filaments_with_same_identity_are_grouped():
+    filaments = [
+        {"id": 1, "material": "PLA", "color_hex": "FF0000"},
+        {"id": 2, "material": "pla", "color_hex": "ff0000"},
+    ]
+    groups = cleanup.find_duplicate_filaments(filaments)
+    assert list(groups.values()) == [filaments]
+
+
+def test_nfc_ids_are_compared_case_insensitively():
+    spools = [
+        {"id": 1, "extra": {"nfc_id": '"AABBCC"'}},
+        {"id": 2, "extra": {"nfc_id": '"aabbcc"'}},
+    ]
+    groups = cleanup.find_duplicate_spools(spools)
+    assert list(groups.values()) == [spools]

--- a/middleware/tests/test_spoolsense_main.py
+++ b/middleware/tests/test_spoolsense_main.py
@@ -26,8 +26,6 @@ sys.modules.setdefault("watchdog.observers", MagicMock())
 
 sys.modules.setdefault("watchdog.events", MagicMock())
 
-# spoolsense.py configures file logging at import time — redirect to avoid
-# creating ~/SpoolSense/middleware/spoolsense.log during tests
 sys.modules.setdefault("uvicorn", MagicMock())
 
 import app_state  # noqa: E402

--- a/scripts/spoolman-cleanup.py
+++ b/scripts/spoolman-cleanup.py
@@ -24,18 +24,21 @@ Features:
 import requests
 import sys
 
+REQUEST_TIMEOUT = 10
+
+
 def get_all_spools(url):
-    response = requests.get(f"{url}/api/v1/spool")
+    response = requests.get(f"{url}/api/v1/spool", timeout=REQUEST_TIMEOUT)
     response.raise_for_status()
     return response.json()
 
 def get_all_filaments(url):
-    response = requests.get(f"{url}/api/v1/filament")
+    response = requests.get(f"{url}/api/v1/filament", timeout=REQUEST_TIMEOUT)
     response.raise_for_status()
     return response.json()
 
 def get_all_vendors(url):
-    response = requests.get(f"{url}/api/v1/vendor")
+    response = requests.get(f"{url}/api/v1/vendor", timeout=REQUEST_TIMEOUT)
     response.raise_for_status()
     return response.json()
 
@@ -44,10 +47,17 @@ def strip_quotes(s):
         return s[1:-1]
     return s
 
+
+def normalize_key(value):
+    """Normalize optional API text fields for duplicate comparisons."""
+    return str(value).strip().lower() if value is not None else ''
+
+
 def find_duplicate_spools(spools):
     groups = {}
     for spool in spools:
-        nfc_id = strip_quotes(spool.get('extra', {}).get('nfc_id', ''))
+        extra = spool.get('extra') or {}
+        nfc_id = normalize_key(strip_quotes(extra.get('nfc_id', '')))
         if not nfc_id:
             continue
         if nfc_id not in groups:
@@ -58,12 +68,14 @@ def find_duplicate_spools(spools):
 def find_duplicate_filaments(filaments):
     groups = {}
     for filament in filaments:
-        vendor = filament.get('vendor', {}).get('name', '').lower()
-        material = filament.get('material', '').lower()
-        color = filament.get('color_hex', '').lower()
-        key = f"{vendor}::{material}::{color}"
-        if not key:
+        vendor = normalize_key((filament.get('vendor') or {}).get('name'))
+        material = normalize_key(filament.get('material'))
+        color = normalize_key(filament.get('color_hex'))
+        # The old string key was "::::" when every field was absent, so all
+        # unknown filaments were incorrectly offered for deletion as duplicates.
+        if not any((vendor, material, color)):
             continue
+        key = (vendor, material, color)
         if key not in groups:
             groups[key] = []
         groups[key].append(filament)
@@ -72,7 +84,7 @@ def find_duplicate_filaments(filaments):
 def find_duplicate_vendors(vendors):
     groups = {}
     for vendor in vendors:
-        name = vendor.get('name', '').lower()
+        name = normalize_key(vendor.get('name'))
         if not name:
             continue
         if name not in groups:
@@ -116,7 +128,10 @@ def get_user_choice():
             return choice
 
 def delete_entity(url, entity_type, entity_id):
-    response = requests.delete(f"{url}/api/v1/{entity_type}/{entity_id}")
+    response = requests.delete(
+        f"{url}/api/v1/{entity_type}/{entity_id}",
+        timeout=REQUEST_TIMEOUT,
+    )
     response.raise_for_status()
 
 def main():


### PR DESCRIPTION
Three low-risk hygiene fixes, each in its own commit.

## Fixes

- **spoolman-cleanup duplicate grouping** — the filament dedup key was an f-string that was never empty (always at least `"::::"`), so the emptiness guard never fired and filaments with no vendor/material/color got grouped together and offered for deletion as duplicates. Switched to a tuple key gated on `any()` identity field present, hardened optional-field access against explicit nulls, and added a 10s timeout to every request so a hung Spoolman can't block the script. New regression tests cover the grouping and case handling.

- **Deductions dir created before write** — `_save_deductions` assumed `~/SpoolSense/` already existed; on a fresh install the first mobile deduction save would raise before the atomic rename. `makedirs(exist_ok=True)` matches the tracking-store path.

- **File-logging setup deferred out of module import** — importing `spoolsense.py` configured logging and opened the rotating log file as an import side effect, so a read-only or missing log dir crashed import (tests, `--check-config`, containers). Moved into a guarded, idempotent `_configure_logging()` called at the top of `main()`; on `OSError` it warns and continues without file logging. Also dropped an unused `time` import in `moonraker_ws.py`.

## Testing

553 tests pass; flake8 gate clean.

## Scope note

These are the pieces of a larger cleanup pass that were self-contained and carried no contract or AFC-path risk. The remaining candidates are tracked separately for their own evaluation: #108 (toolchanger restore on failed assign), #109 (staged-scan deduction baseline), #110 (AFC startup discovery removal — needs AFC hardware).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deductions now save successfully even when their storage directory does not yet exist.
  * Cleanup operations now avoid hanging indefinitely by applying request time limits.
  * Improved duplicate detection by consistently handling capitalization, spacing, missing values, and quoted identifiers.
  * Prevented unknown, empty records from being incorrectly treated as duplicates.

* **Reliability**
  * Logging setup now continues safely when file logging cannot be initialized.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->