### PR TITLE
Release v1.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to SpoolSense are documented here.
 
 ---
 
+## [1.8.4] - 2026-07-12
+
+### Added
+
+- **Partial deduction acknowledgment** — `POST /api/deductions/{uid}/applied`
+  now accepts an optional `{"applied_g": <float>}` body so a client can
+  confirm exactly what it wrote to the tag. The middleware subtracts that
+  amount and keeps the remainder pending, instead of the previous all-or-
+  nothing clear. An empty body still clears the full pending value, so
+  existing clients are unaffected. The response gains `remaining_pending_g`.
+  (#94)
+
+### Fixed
+
+- **spoolman-cleanup could offer unrelated filaments for deletion** — the
+  duplicate-detection key was never empty, so filaments with no vendor,
+  material, or color were grouped together and listed as duplicates. It now
+  only groups filaments that share at least one identity field, and every
+  request carries a timeout. (#111)
+- **First mobile deduction save on a fresh install** — `_save_deductions`
+  now creates `~/SpoolSense/` before writing, so the first save can't crash
+  when the directory doesn't exist yet. (#111)
+- **File-logging setup no longer runs at import** — configuring the rotating
+  log file is deferred to startup and tolerates a read-only or missing log
+  directory, so import (tests, `--check-config`, containers) can't crash on
+  it. (#111)
+
+---
+
 ## [1.8.3] - 2026-07-11
 
 ### Added

--- a/middleware/moonraker_ws.py
+++ b/middleware/moonraker_ws.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import json
 import logging
 import threading
-import time
 from collections.abc import Callable
 
 logger = logging.getLogger(__name__)

--- a/middleware/rest_api.py
+++ b/middleware/rest_api.py
@@ -338,6 +338,7 @@ def _save_deductions() -> None:
     with app_state.state_lock:
         snapshot = dict(app_state.pending_mobile_deductions)
     try:
+        os.makedirs(os.path.dirname(app_state.DEDUCTIONS_FILE), exist_ok=True)
         tmp_path = app_state.DEDUCTIONS_FILE + ".tmp"
         with open(tmp_path, "w") as f:
             json.dump(snapshot, f)

--- a/middleware/rest_api.py
+++ b/middleware/rest_api.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import signal
 import subprocess
@@ -17,7 +18,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 import yaml
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
@@ -364,6 +365,9 @@ class DeductionResponse(BaseModel):
 class DeductionConfirmResponse(BaseModel):
     success: bool
     cleared_g: float
+    # New in 1.8.4 — shipped mobile 1.0.0 requires success + cleared_g to stay;
+    # extra fields are ignored by its decoder
+    remaining_pending_g: float = 0.0
 
 
 @app.get("/api/deductions/{uid}", response_model=DeductionResponse)
@@ -375,15 +379,94 @@ def get_deduction(uid: str) -> DeductionResponse:
 
 
 @app.post("/api/deductions/{uid}/applied", response_model=DeductionConfirmResponse)
-def confirm_deduction(uid: str) -> DeductionConfirmResponse:
-    """Clear a pending deduction after the mobile app confirms the tag write succeeded."""
+async def confirm_deduction(uid: str, request: Request) -> DeductionConfirmResponse:
+    """Acknowledge a pending deduction after the mobile app writes the tag.
+
+    No body / empty ``{}``: clear the full pending value (legacy behavior —
+    shipped mobile 1.0.0 posts an empty body and expects a full clear).
+
+    ``{"applied_g": <float>}``: subtract only what the app actually applied
+    and retain the remainder as still-pending, so a partial tag write no
+    longer forfeits (or double-counts on retry) the rest. An ``applied_g``
+    above the pending value clears everything — clock skew between the
+    phone's apply and a concurrent scanner deduction makes small overshoots
+    legitimate — and can never drive pending negative.
+
+    NOT idempotent: each post subtracts again. A retry after an ambiguous
+    outcome (timeout, transport error) must re-GET /api/deductions/{uid}
+    and reconcile before posting, rather than blindly reposting.
+    """
     uid_lower = uid.lower()
+
+    # Parse the body by hand: FastAPI binds a top-level JSON `null` to the
+    # parameter default, making it indistinguishable from an absent body —
+    # and a malformed payload must never alias the destructive legacy clear.
+    raw = await request.body()
+    if not raw or not raw.strip():
+        body: dict = {}
+    else:
+        try:
+            body = json.loads(raw)
+        except ValueError:
+            body = None  # type: ignore[assignment]
+        if not isinstance(body, dict):
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "code": "invalid_body",
+                    "message": "body must be a JSON object",
+                },
+            )
+
+    if not body:
+        # Legacy full clear — only an absent or empty body qualifies. A
+        # nonempty body without a valid applied_g is rejected below so a
+        # misspelled field can't silently clear everything.
+        with app_state.state_lock:
+            cleared = app_state.pending_mobile_deductions.pop(uid_lower, 0.0)
+        if cleared > 0:
+            _save_deductions()
+            logger.info(f"Mobile deduction: cleared {cleared:.1f}g for {uid_lower}")
+        return DeductionConfirmResponse(success=True, cleared_g=cleared,
+                                        remaining_pending_g=0.0)
+
+    raw_applied = body.get("applied_g")
+    # bool is an int subclass — reject it along with everything non-numeric.
+    # NaN/Infinity pass numeric comparisons and an arbitrarily large JSON
+    # integer overflows float conversion, so normalize to a finite float
+    # before any state is touched.
+    applied: Optional[float] = None
+    if not isinstance(raw_applied, bool) and isinstance(raw_applied, (int, float)):
+        try:
+            applied = float(raw_applied)
+        except OverflowError:
+            applied = None
+    if applied is None or not math.isfinite(applied) or applied <= 0:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "invalid_applied_g",
+                "message": "applied_g must be a finite number greater than 0",
+            },
+        )
+
     with app_state.state_lock:
-        cleared = app_state.pending_mobile_deductions.pop(uid_lower, 0.0)
+        pending = app_state.pending_mobile_deductions.get(uid_lower, 0.0)
+        cleared = min(applied, pending)
+        remaining = pending - cleared
+        if remaining <= 1e-9:  # float dust from the subtraction is a full clear
+            remaining = 0.0
+            app_state.pending_mobile_deductions.pop(uid_lower, None)
+        else:
+            app_state.pending_mobile_deductions[uid_lower] = remaining
     if cleared > 0:
         _save_deductions()
-        logger.info(f"Mobile deduction: cleared {cleared:.1f}g for {uid_lower}")
-    return DeductionConfirmResponse(success=True, cleared_g=cleared)
+        logger.info(
+            f"Mobile deduction: applied {cleared:.1f}g for {uid_lower} "
+            f"({remaining:.1f}g still pending)"
+        )
+    return DeductionConfirmResponse(success=True, cleared_g=cleared,
+                                    remaining_pending_g=remaining)
 
 
 # ── Web config panel endpoints ───────────────────────────────────────────────

--- a/middleware/spoolsense.py
+++ b/middleware/spoolsense.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
-__version__ = "1.8.3"
+__version__ = "1.8.4"
 """
 SpoolSense NFC Middleware
 =========================

--- a/middleware/spoolsense.py
+++ b/middleware/spoolsense.py
@@ -58,14 +58,30 @@ LOG_FILE         = os.path.expanduser('~/SpoolSense/middleware/spoolsense.log')
 LOG_MAX_BYTES    = 5 * 1024 * 1024                                              # 5MB per log file
 LOG_BACKUP_COUNT = 3                                                            # keep 3 rotated copies
 
-logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
-os.makedirs(os.path.dirname(LOG_FILE), exist_ok=True)
-_file_handler = RotatingFileHandler(LOG_FILE, maxBytes=LOG_MAX_BYTES, backupCount=LOG_BACKUP_COUNT)
-_file_handler.setFormatter(logging.Formatter(LOG_FORMAT))
-_file_handler.setLevel(logging.INFO)
-logging.getLogger().addHandler(_file_handler)
-
 logger = logging.getLogger(__name__)
+
+
+def _configure_logging(log_file: str = LOG_FILE) -> None:
+    """Add rotating file logging without making module import touch the disk."""
+    logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
+    root_logger = logging.getLogger()
+    if any(getattr(handler, "_spoolsense_handler", False)
+           for handler in root_logger.handlers):
+        return
+    try:
+        os.makedirs(os.path.dirname(log_file), exist_ok=True)
+        file_handler = RotatingFileHandler(
+            log_file,
+            maxBytes=LOG_MAX_BYTES,
+            backupCount=LOG_BACKUP_COUNT,
+        )
+    except OSError:
+        logger.warning("File logging unavailable at %s", log_file, exc_info=True)
+        return
+    file_handler.setFormatter(logging.Formatter(LOG_FORMAT))
+    file_handler.setLevel(logging.INFO)
+    file_handler._spoolsense_handler = True
+    root_logger.addHandler(file_handler)
 
 
 # ── Shutdown ─────────────────────────────────────────────────────────────────
@@ -298,6 +314,8 @@ def main() -> None:
     parser.add_argument("--check-config", action="store_true",
                         help="Validate config and print a summary, then exit.")
     args = parser.parse_args()
+
+    _configure_logging()
 
     # Load and validate config — exits on invalid config (strict validation)
     app_state.cfg = load_config()

--- a/middleware/tests/test_rest_api.py
+++ b/middleware/tests/test_rest_api.py
@@ -427,6 +427,133 @@ class TestUnlockTarget(unittest.TestCase):
         self.assertTrue(app_state.lane_locks["lane1"])
 
 
+class TestDeductionApplied(unittest.TestCase):
+    """POST /api/deductions/{uid}/applied — legacy full clear (empty body,
+    shipped mobile 1.0.0) and partial acknowledgment via applied_g (#94)."""
+
+    def setUp(self) -> None:
+        _reset_app_state()
+        app_state.pending_mobile_deductions = {"aabb11": 25.5}
+
+    def test_empty_body_clears_all_legacy(self) -> None:
+        # Shipped 1.0.0 posts `{}` and expects a full clear
+        resp = client.post("/api/deductions/AABB11/applied", json={})
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertTrue(data["success"])
+        self.assertEqual(data["cleared_g"], 25.5)
+        self.assertEqual(data["remaining_pending_g"], 0.0)
+        self.assertNotIn("aabb11", app_state.pending_mobile_deductions)
+
+    def test_no_body_clears_all_legacy(self) -> None:
+        resp = client.post("/api/deductions/AABB11/applied")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["cleared_g"], 25.5)
+        self.assertNotIn("aabb11", app_state.pending_mobile_deductions)
+
+    def test_partial_apply_retains_remainder(self) -> None:
+        resp = client.post("/api/deductions/AABB11/applied",
+                           json={"applied_g": 10.0})
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertTrue(data["success"])
+        self.assertEqual(data["cleared_g"], 10.0)
+        self.assertEqual(data["remaining_pending_g"], 15.5)
+        # Remainder visible on the read endpoint
+        get_resp = client.get("/api/deductions/AABB11")
+        self.assertEqual(get_resp.json()["pending_g"], 15.5)
+
+    def test_full_amount_clears_entry(self) -> None:
+        resp = client.post("/api/deductions/AABB11/applied",
+                           json={"applied_g": 25.5})
+        self.assertEqual(resp.json()["cleared_g"], 25.5)
+        self.assertEqual(resp.json()["remaining_pending_g"], 0.0)
+        self.assertNotIn("aabb11", app_state.pending_mobile_deductions)
+
+    def test_overshoot_clamps_to_pending(self) -> None:
+        # Clock skew vs a concurrent scanner deduction — clamp, don't error
+        resp = client.post("/api/deductions/AABB11/applied",
+                           json={"applied_g": 30.0})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["cleared_g"], 25.5)
+        self.assertEqual(resp.json()["remaining_pending_g"], 0.0)
+        self.assertNotIn("aabb11", app_state.pending_mobile_deductions)
+
+    def test_apply_against_no_pending_is_noop(self) -> None:
+        resp = client.post("/api/deductions/UNSEEN99/applied",
+                           json={"applied_g": 5.0})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["cleared_g"], 0.0)
+        self.assertEqual(resp.json()["remaining_pending_g"], 0.0)
+
+    def test_zero_applied_rejected(self) -> None:
+        resp = client.post("/api/deductions/AABB11/applied",
+                           json={"applied_g": 0})
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(app_state.pending_mobile_deductions["aabb11"], 25.5)
+
+    def test_negative_applied_rejected(self) -> None:
+        resp = client.post("/api/deductions/AABB11/applied",
+                           json={"applied_g": -5.0})
+        self.assertEqual(resp.status_code, 400)
+
+    def test_non_numeric_applied_rejected(self) -> None:
+        for bad in ("10.0", True, [10], None):
+            resp = client.post("/api/deductions/AABB11/applied",
+                               json={"applied_g": bad})
+            self.assertEqual(resp.status_code, 400, f"bad value: {bad!r}")
+        self.assertEqual(app_state.pending_mobile_deductions["aabb11"], 25.5)
+
+    def test_non_finite_applied_rejected(self) -> None:
+        # Python's JSON parser accepts bare NaN/Infinity tokens — they pass
+        # numeric comparisons and would corrupt the stored pending value
+        for bad in ("NaN", "Infinity", "-Infinity"):
+            resp = client.post("/api/deductions/AABB11/applied",
+                               content='{"applied_g": %s}' % bad,
+                               headers={"Content-Type": "application/json"})
+            self.assertEqual(resp.status_code, 400, f"bad value: {bad}")
+        self.assertEqual(app_state.pending_mobile_deductions["aabb11"], 25.5)
+
+    def test_top_level_null_body_rejected(self) -> None:
+        # Explicit `null` is malformed, not a legacy clear — pending survives
+        resp = client.post("/api/deductions/AABB11/applied",
+                           content="null",
+                           headers={"Content-Type": "application/json"})
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(app_state.pending_mobile_deductions["aabb11"], 25.5)
+
+    def test_malformed_json_body_rejected(self) -> None:
+        resp = client.post("/api/deductions/AABB11/applied",
+                           content='{"applied_g": ',
+                           headers={"Content-Type": "application/json"})
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(app_state.pending_mobile_deductions["aabb11"], 25.5)
+
+    def test_oversized_integer_rejected(self) -> None:
+        # A JSON integer too large for float conversion must 400, not 500
+        resp = client.post("/api/deductions/AABB11/applied",
+                           content='{"applied_g": %s}' % ("9" * 400),
+                           headers={"Content-Type": "application/json"})
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(app_state.pending_mobile_deductions["aabb11"], 25.5)
+
+    def test_nonempty_body_without_applied_g_rejected(self) -> None:
+        # A misspelled field must not silently clear the full pending value —
+        # only an absent or empty body means legacy full clear
+        resp = client.post("/api/deductions/AABB11/applied",
+                           json={"appliedG": 10.0})
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(app_state.pending_mobile_deductions["aabb11"], 25.5)
+
+    def test_repeated_partial_posts_subtract_again(self) -> None:
+        # Documented semantics: NOT idempotent — a retry must re-GET first
+        client.post("/api/deductions/AABB11/applied", json={"applied_g": 10.0})
+        resp = client.post("/api/deductions/AABB11/applied",
+                           json={"applied_g": 10.0})
+        self.assertEqual(resp.json()["cleared_g"], 10.0)
+        self.assertEqual(resp.json()["remaining_pending_g"], 5.5)
+
+
 class TestSaveConfigDockerRestart(unittest.TestCase):
     """In Docker (SPOOLSENSE_IN_DOCKER set), save-config self-terminates via
     SIGTERM so the container restart policy relaunches with the new config —

--- a/middleware/tests/test_spoolman_cleanup.py
+++ b/middleware/tests/test_spoolman_cleanup.py
@@ -1,0 +1,35 @@
+"""Regression tests for the standalone Spoolman cleanup utility."""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+_SCRIPT = Path(__file__).parents[2] / "scripts" / "spoolman-cleanup.py"
+_SPEC = importlib.util.spec_from_file_location("spoolman_cleanup", _SCRIPT)
+assert _SPEC is not None and _SPEC.loader is not None
+cleanup = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(cleanup)
+
+
+def test_filaments_without_identity_are_not_grouped_as_duplicates():
+    filaments = [{"id": 1}, {"id": 2}, {"id": 3}]
+    assert cleanup.find_duplicate_filaments(filaments) == {}
+
+
+def test_filaments_with_same_identity_are_grouped():
+    filaments = [
+        {"id": 1, "material": "PLA", "color_hex": "FF0000"},
+        {"id": 2, "material": "pla", "color_hex": "ff0000"},
+    ]
+    groups = cleanup.find_duplicate_filaments(filaments)
+    assert list(groups.values()) == [filaments]
+
+
+def test_nfc_ids_are_compared_case_insensitively():
+    spools = [
+        {"id": 1, "extra": {"nfc_id": '"AABBCC"'}},
+        {"id": 2, "extra": {"nfc_id": '"aabbcc"'}},
+    ]
+    groups = cleanup.find_duplicate_spools(spools)
+    assert list(groups.values()) == [spools]

--- a/middleware/tests/test_spoolsense_main.py
+++ b/middleware/tests/test_spoolsense_main.py
@@ -26,8 +26,6 @@ sys.modules.setdefault("watchdog.observers", MagicMock())
 
 sys.modules.setdefault("watchdog.events", MagicMock())
 
-# spoolsense.py configures file logging at import time — redirect to avoid
-# creating ~/SpoolSense/middleware/spoolsense.log during tests
 sys.modules.setdefault("uvicorn", MagicMock())
 
 import app_state  # noqa: E402

--- a/scripts/spoolman-cleanup.py
+++ b/scripts/spoolman-cleanup.py
@@ -24,18 +24,21 @@ Features:
 import requests
 import sys
 
+REQUEST_TIMEOUT = 10
+
+
 def get_all_spools(url):
-    response = requests.get(f"{url}/api/v1/spool")
+    response = requests.get(f"{url}/api/v1/spool", timeout=REQUEST_TIMEOUT)
     response.raise_for_status()
     return response.json()
 
 def get_all_filaments(url):
-    response = requests.get(f"{url}/api/v1/filament")
+    response = requests.get(f"{url}/api/v1/filament", timeout=REQUEST_TIMEOUT)
     response.raise_for_status()
     return response.json()
 
 def get_all_vendors(url):
-    response = requests.get(f"{url}/api/v1/vendor")
+    response = requests.get(f"{url}/api/v1/vendor", timeout=REQUEST_TIMEOUT)
     response.raise_for_status()
     return response.json()
 
@@ -44,10 +47,17 @@ def strip_quotes(s):
         return s[1:-1]
     return s
 
+
+def normalize_key(value):
+    """Normalize optional API text fields for duplicate comparisons."""
+    return str(value).strip().lower() if value is not None else ''
+
+
 def find_duplicate_spools(spools):
     groups = {}
     for spool in spools:
-        nfc_id = strip_quotes(spool.get('extra', {}).get('nfc_id', ''))
+        extra = spool.get('extra') or {}
+        nfc_id = normalize_key(strip_quotes(extra.get('nfc_id', '')))
         if not nfc_id:
             continue
         if nfc_id not in groups:
@@ -58,12 +68,14 @@ def find_duplicate_spools(spools):
 def find_duplicate_filaments(filaments):
     groups = {}
     for filament in filaments:
-        vendor = filament.get('vendor', {}).get('name', '').lower()
-        material = filament.get('material', '').lower()
-        color = filament.get('color_hex', '').lower()
-        key = f"{vendor}::{material}::{color}"
-        if not key:
+        vendor = normalize_key((filament.get('vendor') or {}).get('name'))
+        material = normalize_key(filament.get('material'))
+        color = normalize_key(filament.get('color_hex'))
+        # The old string key was "::::" when every field was absent, so all
+        # unknown filaments were incorrectly offered for deletion as duplicates.
+        if not any((vendor, material, color)):
             continue
+        key = (vendor, material, color)
         if key not in groups:
             groups[key] = []
         groups[key].append(filament)
@@ -72,7 +84,7 @@ def find_duplicate_filaments(filaments):
 def find_duplicate_vendors(vendors):
     groups = {}
     for vendor in vendors:
-        name = vendor.get('name', '').lower()
+        name = normalize_key(vendor.get('name'))
         if not name:
             continue
         if name not in groups:
@@ -116,7 +128,10 @@ def get_user_choice():
             return choice
 
 def delete_entity(url, entity_type, entity_id):
-    response = requests.delete(f"{url}/api/v1/{entity_type}/{entity_id}")
+    response = requests.delete(
+        f"{url}/api/v1/{entity_type}/{entity_id}",
+        timeout=REQUEST_TIMEOUT,
+    )
     response.raise_for_status()
 
 def main():


### PR DESCRIPTION
Promote dev to master for the v1.8.4 release.

- Partial deduction acknowledgment: `applied_g` on POST /api/deductions/{uid}/applied (#94)
- Fix: spoolman-cleanup grouped identity-less filaments as duplicates; added request timeouts (#111)
- Fix: _save_deductions creates ~/SpoolSense/ before first write (#111)
- Fix: file-logging setup deferred out of module import (#111)

See CHANGELOG for details.