### PR TITLE
Release v1.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to SpoolSense are documented here.
 
 ---
 
-## [Unreleased]
+## [1.8.5] - 2026-07-18
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to SpoolSense are documented here.
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **Bondtech INDX live active-tool sync** — INDX's Klipper macros record the
+  mounted tool in `save_variables.active_tool`; the middleware now follows it
+  on the existing websocket stream. On every tool pickup, Spoolman's active
+  spool switches to the spool assigned to that tool (`ASSIGN_SPOOL` binding),
+  so live usage accrues to the spool actually printing during multi-tool jobs.
+  Exposed as `active_tool` in `GET /api/status`. Opt out with
+  `active_tool_sync: false`. Inert on printers that never write the variable.
+  (#91)
+
+### Changed
+
+- **INDX example config** — updated for Bondtech's published macros: INDX has
+  no Klipper `tool` objects, so per-tool deduction uses the slicer's per-tool
+  weights automatically (no extra install), and the new active-tool sync is
+  documented. (#91)
+
+---
+
 ## [1.8.4] - 2026-07-12
 
 ### Added

--- a/docker/README.md
+++ b/docker/README.md
@@ -71,12 +71,19 @@ Not using the mobile app or panel? Remove the `ports:` mapping from
 
 ## Upgrade
 
+The image is built locally from the repo — there is no auto-update. Pull the
+new code and rebuild:
+
 ```bash
 cd spoolsense_middleware
 git pull
 cd docker
 docker compose up -d --build
 ```
+
+The `--build` flag is required. A plain `docker compose up -d` reuses the
+existing image and silently keeps running the old version. Your config and
+state in `./spoolsense-data/` carry across the rebuild untouched.
 
 ## Logs and state
 

--- a/middleware/app_state.py
+++ b/middleware/app_state.py
@@ -62,6 +62,10 @@ lane_load_states: dict[str, bool] = {}
 # lane load; toolchanger_status (and the mobile assign flow) consume the
 # toolhead slot on ASSIGN_SPOOL. Protected by state_lock.
 pending_spool_afc: dict | None = None
+
+# Currently mounted INDX tool (int) or None when parked / not an INDX
+# setup. Written by indx_status.on_active_tool. Protected by state_lock.
+indx_active_tool: int | None = None
 pending_spool_toolhead: dict | None = None
 
 # Tag writeback cooldown — tracks recent writes to prevent loops.

--- a/middleware/config.example.indx.yaml
+++ b/middleware/config.example.indx.yaml
@@ -50,7 +50,11 @@ scanner_topic_prefix: "spoolsense"
 #   variable_spool_id on each tool macro (T0..Tn)
 #   [delayed_gcode RESTORE_SPOOL_IDS]  restores assignments on boot
 #
-# Per-tool usage deduction during multi-tool prints additionally needs
-# klipper-toolchanger's per-tool filament tracking (tool T<n> objects
-# exposing filament_used). Without it, deduction falls back to slicer
-# estimates.
+# Per-tool usage deduction: Bondtech's INDX macros do not create Klipper
+# `tool` objects, so per-tool deduction uses the slicer's per-tool
+# filament weights from the job metadata (automatic, nothing to install).
+#
+# Live active-spool sync: INDX records the mounted tool in Klipper
+# save_variables (`active_tool`). The middleware follows it automatically —
+# on every tool pickup, Spoolman's active spool switches to the spool
+# assigned to that tool. Disable with `active_tool_sync: false`.

--- a/middleware/config.py
+++ b/middleware/config.py
@@ -34,6 +34,9 @@ DEFAULTS: dict = {
     "scanner_topic_prefix": "spoolsense",
     "scanners": {},
     "tag_writeback_enabled": False,
+    # Bondtech INDX: mirror save_variables.active_tool to Spoolman's active
+    # spool on each tool pickup. Inert on non-INDX printers.
+    "active_tool_sync": True,
     "publish_events": True,
 }
 

--- a/middleware/indx_status.py
+++ b/middleware/indx_status.py
@@ -1,0 +1,114 @@
+"""
+indx_status.py — Bondtech INDX active-tool sync (#91).
+
+INDX's published Klipper macros (BondtechAB/INDX `macros/`) persist the
+mounted tool in `save_variables.active_tool`: the index is written after
+every successful pickup and set to -1 when the toolhead parks. Consuming
+that variable from the existing save_variables websocket stream gives
+real-time knowledge of which tool is printing — no polling, no
+INDX-specific transport, and setups that never write `active_tool`
+(every non-INDX printer) are completely unaffected.
+
+On each pickup transition (active_tool -> N >= 0):
+  - remember the tool in app_state.indx_active_tool
+  - resolve the spool bound to that tool (t<N>_spool_id, the same
+    binding ASSIGN_SPOOL and klipper_vars maintain)
+  - set Spoolman's active spool so live usage accrues to the spool
+    actually printing (gated by config `active_tool_sync`)
+
+Park transitions (-1) are transient inside every toolchange, so they
+update app_state but never touch Spoolman — otherwise a 4-tool print
+would thrash the active spool twice per swap.
+
+Wired from klipper_vars.on_ws_save_variables — INDX state arrives on
+the same object stream as the spool bindings.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+
+import app_state
+from moonraker_client import set_active_spool_id
+
+logger = logging.getLogger(__name__)
+
+# Last spool id pushed to Spoolman by this module; avoids repeat POSTs
+# when Moonraker resends the full variables dict for unrelated changes.
+# Protected by app_state.state_lock.
+_last_synced_spool: int | None = None
+
+
+def _resolve_bound_spool(tool: int, variables: dict) -> int | None:
+    """Spool bound to T<tool>: the vars dict itself is authoritative
+    (same delta stream that carries the binding), active_spools is the
+    fallback for bindings made before this connection."""
+    raw = variables.get(f"t{tool}_spool_id")
+    try:
+        spool_id = int(raw) if raw not in (None, "") else None
+    except (TypeError, ValueError):
+        spool_id = None
+    if spool_id == 0:
+        spool_id = None
+    if spool_id is None:
+        with app_state.state_lock:
+            spool_id = app_state.active_spools.get(f"T{tool}")
+    return spool_id
+
+
+def _push_active_spool(spool_id: int, tool: int) -> None:
+    """POST the active spool to Moonraker/Spoolman off the websocket
+    thread; a slow HTTP call must not stall status dispatch."""
+    moonraker = app_state.cfg.get("moonraker_url", "")
+    if not moonraker:
+        return
+
+    def _worker() -> None:
+        global _last_synced_spool
+        try:
+            set_active_spool_id(moonraker, spool_id)
+        except Exception as exc:
+            logger.error(
+                "INDX sync: failed to set Spoolman active spool %s for T%d: %s",
+                spool_id, tool, exc,
+            )
+            return
+        with app_state.state_lock:
+            _last_synced_spool = spool_id
+        logger.info("INDX sync: T%d active -> Spoolman spool %s", tool, spool_id)
+
+    threading.Thread(target=_worker, name="indx-spool-sync", daemon=True).start()
+
+
+def on_active_tool(variables: dict) -> None:
+    """Handle a save_variables delta that contains `active_tool`."""
+    raw = variables.get("active_tool")
+    try:
+        tool = int(raw)
+    except (TypeError, ValueError):
+        logger.debug("INDX sync: ignoring non-integer active_tool=%r", raw)
+        return
+
+    parked = tool < 0
+    with app_state.state_lock:
+        prev = app_state.indx_active_tool
+        app_state.indx_active_tool = None if parked else tool
+        last_synced = _last_synced_spool
+    if (None if parked else tool) == prev:
+        return  # full-dict resend with no transition
+
+    if parked:
+        logger.debug("INDX sync: toolhead parked")
+        return
+
+    logger.info("INDX sync: active tool -> T%d", tool)
+
+    if not app_state.cfg.get("active_tool_sync", True):
+        return
+    spool_id = _resolve_bound_spool(tool, variables)
+    if spool_id is None:
+        logger.info("INDX sync: T%d has no bound spool, leaving Spoolman as-is", tool)
+        return
+    if spool_id == last_synced:
+        return
+    _push_active_spool(spool_id, tool)

--- a/middleware/indx_status.py
+++ b/middleware/indx_status.py
@@ -9,7 +9,8 @@ real-time knowledge of which tool is printing — no polling, no
 INDX-specific transport, and setups that never write `active_tool`
 (every non-INDX printer) are completely unaffected.
 
-On each pickup transition (active_tool -> N >= 0):
+On each pickup (active_tool -> N >= 0), and on a rebind of the mounted
+tool (t<N>_spool_id changing while N stays mounted):
   - remember the tool in app_state.indx_active_tool
   - resolve the spool bound to that tool (t<N>_spool_id, the same
     binding ASSIGN_SPOOL and klipper_vars maintain)
@@ -19,6 +20,16 @@ On each pickup transition (active_tool -> N >= 0):
 Park transitions (-1) are transient inside every toolchange, so they
 update app_state but never touch Spoolman — otherwise a 4-tool print
 would thrash the active spool twice per swap.
+
+Moonraker resends the complete variables dict on any save_variables
+change; identical (tool, spool) observations are ignored so unrelated
+variable writes don't repost. Genuine transitions always POST — other
+components also write Spoolman's active spool, so no assumption is made
+about its current value.
+
+Spoolman POSTs run on one serialized latest-wins worker: rapid
+toolchanges coalesce and the newest transition is guaranteed to be the
+last one applied, which per-transition threads could not guarantee.
 
 Wired from klipper_vars.on_ws_save_variables — INDX state arrives on
 the same object stream as the spool bindings.
@@ -33,10 +44,15 @@ from moonraker_client import set_active_spool_id
 
 logger = logging.getLogger(__name__)
 
-# Last spool id pushed to Spoolman by this module; avoids repeat POSTs
-# when Moonraker resends the full variables dict for unrelated changes.
+# Last (tool, spool) pair observed from the variables stream — dedupes
+# Moonraker's full-dict resends. Distinct from "last synced": genuine
+# transitions always POST. Protected by app_state.state_lock.
+_last_observed: tuple[int, int | None] | None = None
+
+# Latest-wins sync target consumed by the single worker thread.
 # Protected by app_state.state_lock.
-_last_synced_spool: int | None = None
+_pending_sync: tuple[int, int] | None = None   # (spool_id, tool)
+_worker_running: bool = False
 
 
 def _resolve_bound_spool(tool: int, variables: dict) -> int | None:
@@ -52,36 +68,52 @@ def _resolve_bound_spool(tool: int, variables: dict) -> int | None:
         spool_id = None
     if spool_id is None:
         with app_state.state_lock:
-            spool_id = app_state.active_spools.get(f"T{tool}")
+            fallback = app_state.active_spools.get(f"T{tool}")
+        spool_id = fallback if isinstance(fallback, int) else None
     return spool_id
 
 
-def _push_active_spool(spool_id: int, tool: int) -> None:
-    """POST the active spool to Moonraker/Spoolman off the websocket
-    thread; a slow HTTP call must not stall status dispatch."""
-    moonraker = app_state.cfg.get("moonraker_url", "")
-    if not moonraker:
-        return
-
-    def _worker() -> None:
-        global _last_synced_spool
+def _sync_worker() -> None:
+    """Drain _pending_sync until empty, always applying the newest target.
+    One instance runs at a time; each POST happens outside the lock."""
+    global _pending_sync, _worker_running
+    while True:
+        with app_state.state_lock:
+            target = _pending_sync
+            _pending_sync = None
+            if target is None:
+                _worker_running = False
+                return
+        spool_id, tool = target
+        moonraker = app_state.cfg.get("moonraker_url", "")
+        if not moonraker:
+            continue
         try:
             set_active_spool_id(moonraker, spool_id)
+            logger.info("INDX sync: T%d active -> Spoolman spool %s", tool, spool_id)
         except Exception as exc:
             logger.error(
                 "INDX sync: failed to set Spoolman active spool %s for T%d: %s",
                 spool_id, tool, exc,
             )
-            return
-        with app_state.state_lock:
-            _last_synced_spool = spool_id
-        logger.info("INDX sync: T%d active -> Spoolman spool %s", tool, spool_id)
 
-    threading.Thread(target=_worker, name="indx-spool-sync", daemon=True).start()
+
+def _enqueue_sync(spool_id: int, tool: int) -> None:
+    """Replace any not-yet-applied target and ensure the worker runs."""
+    global _pending_sync, _worker_running
+    with app_state.state_lock:
+        _pending_sync = (spool_id, tool)
+        start = not _worker_running
+        if start:
+            _worker_running = True
+    if start:
+        threading.Thread(target=_sync_worker, name="indx-spool-sync",
+                         daemon=True).start()
 
 
 def on_active_tool(variables: dict) -> None:
     """Handle a save_variables delta that contains `active_tool`."""
+    global _last_observed
     raw = variables.get("active_tool")
     try:
         tool = int(raw)
@@ -89,26 +121,30 @@ def on_active_tool(variables: dict) -> None:
         logger.debug("INDX sync: ignoring non-integer active_tool=%r", raw)
         return
 
-    parked = tool < 0
-    with app_state.state_lock:
-        prev = app_state.indx_active_tool
-        app_state.indx_active_tool = None if parked else tool
-        last_synced = _last_synced_spool
-    if (None if parked else tool) == prev:
-        return  # full-dict resend with no transition
-
-    if parked:
-        logger.debug("INDX sync: toolhead parked")
+    if tool < 0:
+        with app_state.state_lock:
+            was_mounted = app_state.indx_active_tool is not None
+            app_state.indx_active_tool = None
+            _last_observed = (tool, None)
+        if was_mounted:
+            logger.debug("INDX sync: toolhead parked")
         return
 
-    logger.info("INDX sync: active tool -> T%d", tool)
+    spool_id = _resolve_bound_spool(tool, variables)
+    observed = (tool, spool_id)
+    with app_state.state_lock:
+        if _last_observed == observed:
+            return  # full-dict resend, nothing changed
+        transition = app_state.indx_active_tool != tool
+        app_state.indx_active_tool = tool
+        _last_observed = observed
+
+    if transition:
+        logger.info("INDX sync: active tool -> T%d", tool)
 
     if not app_state.cfg.get("active_tool_sync", True):
         return
-    spool_id = _resolve_bound_spool(tool, variables)
     if spool_id is None:
         logger.info("INDX sync: T%d has no bound spool, leaving Spoolman as-is", tool)
         return
-    if spool_id == last_synced:
-        return
-    _push_active_spool(spool_id, tool)
+    _enqueue_sync(spool_id, tool)

--- a/middleware/klipper_vars.py
+++ b/middleware/klipper_vars.py
@@ -44,6 +44,12 @@ def on_ws_save_variables(variables: dict) -> None:
     if not isinstance(variables, dict):
         return
 
+    if "active_tool" in variables:
+        # Bondtech INDX publishes the mounted tool here (see indx_status.py);
+        # inert on printers that never write the variable.
+        from indx_status import on_active_tool
+        on_active_tool(variables)
+
     for t in app_state.cfg.get("toolheads", []):
         m = _TOOLHEAD_RE.fullmatch(t)
         if not m:

--- a/middleware/rest_api.py
+++ b/middleware/rest_api.py
@@ -112,9 +112,11 @@ def get_status() -> dict[str, Any]:
         pending_afc = app_state.pending_spool_afc.copy() if app_state.pending_spool_afc else None
         pending_toolhead = app_state.pending_spool_toolhead.copy() if app_state.pending_spool_toolhead else None
         locked = [k for k, v in app_state.lane_locks.items() if v]
+        indx_tool = app_state.indx_active_tool
 
     return {
         "active_spools": active,
+        "active_tool": indx_tool,
         # Legacy combined view (web panel pending dot) + explicit slots
         "pending_spool": pending_toolhead or pending_afc,
         "pending_spool_afc": pending_afc,

--- a/middleware/spoolsense.py
+++ b/middleware/spoolsense.py
@@ -262,9 +262,11 @@ def _start_sync_services(use_ws: bool) -> None:
         app_state.moonraker_ws.on_update_tag = app_state.filament_usage_sync.on_ws_update_tag
 
     # Klipper save_variables — syncs spool IDs on manual changes (SAVE_VARIABLE
-    # in Mainsail/console). Websocket-only; without the websocket, manual var
-    # changes are picked up by ToolheadStatusSync's eject polling alone.
-    if has_toolhead_scanners(cfg):
+    # in Mainsail/console) and carries INDX's active_tool. Websocket-only;
+    # without the websocket, manual var changes are picked up by
+    # ToolheadStatusSync's eject polling alone. toolhead_stage configs (INDX)
+    # need this too — their bindings and active_tool live in the same object.
+    if has_toolhead_scanners(cfg) or has_toolhead_stage_scanners(cfg):
         if use_ws:
             app_state.moonraker_ws.on_save_variables = on_ws_save_variables
         else:

--- a/middleware/spoolsense.py
+++ b/middleware/spoolsense.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
-__version__ = "1.8.4"
+__version__ = "1.8.5"
 """
 SpoolSense NFC Middleware
 =========================

--- a/middleware/tests/test_indx_status.py
+++ b/middleware/tests/test_indx_status.py
@@ -1,0 +1,111 @@
+"""Tests for indx_status.py — INDX active_tool → Spoolman sync."""
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+sys.modules.setdefault("paho", MagicMock())
+sys.modules.setdefault("paho.mqtt", MagicMock())
+sys.modules.setdefault("paho.mqtt.client", MagicMock())
+
+import app_state  # noqa: E402
+import indx_status  # noqa: E402
+from indx_status import on_active_tool  # noqa: E402
+
+
+def _reset(active_tool_sync: bool = True) -> None:
+    app_state.cfg = {
+        "moonraker_url": "http://moon",
+        "toolheads": ["T0", "T1"],
+        "active_tool_sync": active_tool_sync,
+    }
+    app_state.active_spools = {}
+    app_state.state_lock = threading.Lock()
+    app_state.indx_active_tool = None
+    indx_status._last_synced_spool = None
+
+
+def _run_sync(variables: dict) -> None:
+    """Call on_active_tool with the worker thread made synchronous."""
+    with patch.object(indx_status.threading, "Thread",
+                      side_effect=lambda target, **kw: MagicMock(start=target)):
+        on_active_tool(variables)
+
+
+class TestOnActiveTool(unittest.TestCase):
+
+    def setUp(self):
+        _reset()
+
+    def test_pickup_sets_state_and_pushes_bound_spool(self):
+        with patch.object(indx_status, "set_active_spool_id") as post:
+            _run_sync({"active_tool": 1, "t1_spool_id": 42})
+        self.assertEqual(app_state.indx_active_tool, 1)
+        post.assert_called_once_with("http://moon", 42)
+        self.assertEqual(indx_status._last_synced_spool, 42)
+
+    def test_park_updates_state_without_spoolman_call(self):
+        _run_sync({"active_tool": 2, "t2_spool_id": 7})
+        with patch.object(indx_status, "set_active_spool_id") as post:
+            on_active_tool({"active_tool": -1})
+        self.assertIsNone(app_state.indx_active_tool)
+        post.assert_not_called()
+
+    def test_resend_of_same_tool_is_ignored(self):
+        with patch.object(indx_status, "set_active_spool_id") as post:
+            _run_sync({"active_tool": 0, "t0_spool_id": 5})
+            _run_sync({"active_tool": 0, "t0_spool_id": 5})
+        self.assertEqual(post.call_count, 1)
+
+    def test_unbound_tool_leaves_spoolman_alone(self):
+        with patch.object(indx_status, "set_active_spool_id") as post:
+            _run_sync({"active_tool": 1})
+        self.assertEqual(app_state.indx_active_tool, 1)
+        post.assert_not_called()
+
+    def test_falls_back_to_active_spools_binding(self):
+        app_state.active_spools["T3"] = 99
+        with patch.object(indx_status, "set_active_spool_id") as post:
+            _run_sync({"active_tool": 3})
+        post.assert_called_once_with("http://moon", 99)
+
+    def test_sync_disabled_still_tracks_tool(self):
+        _reset(active_tool_sync=False)
+        with patch.object(indx_status, "set_active_spool_id") as post:
+            _run_sync({"active_tool": 1, "t1_spool_id": 42})
+        self.assertEqual(app_state.indx_active_tool, 1)
+        post.assert_not_called()
+
+    def test_spoolman_failure_logged_not_raised(self):
+        with patch.object(indx_status, "set_active_spool_id",
+                          side_effect=RuntimeError("boom")):
+            _run_sync({"active_tool": 1, "t1_spool_id": 42})
+        # failure must not mark the spool as synced
+        self.assertIsNone(indx_status._last_synced_spool)
+
+    def test_repeat_pickup_same_spool_skips_post(self):
+        with patch.object(indx_status, "set_active_spool_id") as post:
+            _run_sync({"active_tool": 0, "t0_spool_id": 5, "t1_spool_id": 5})
+            on_active_tool({"active_tool": -1})
+            _run_sync({"active_tool": 1, "t0_spool_id": 5, "t1_spool_id": 5})
+        self.assertEqual(post.call_count, 1)  # same spool on both tools
+
+    def test_garbage_active_tool_ignored(self):
+        with patch.object(indx_status, "set_active_spool_id") as post:
+            on_active_tool({"active_tool": "banana"})
+        self.assertIsNone(app_state.indx_active_tool)
+        post.assert_not_called()
+
+    def test_zero_spool_id_treated_as_unbound(self):
+        with patch.object(indx_status, "set_active_spool_id") as post:
+            _run_sync({"active_tool": 1, "t1_spool_id": 0})
+        post.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/middleware/tests/test_indx_status.py
+++ b/middleware/tests/test_indx_status.py
@@ -27,84 +27,139 @@ def _reset(active_tool_sync: bool = True) -> None:
     app_state.active_spools = {}
     app_state.state_lock = threading.Lock()
     app_state.indx_active_tool = None
-    indx_status._last_synced_spool = None
+    indx_status._last_observed = None
+    indx_status._pending_sync = None
+    indx_status._worker_running = False
 
 
-def _run_sync(variables: dict) -> None:
-    """Call on_active_tool with the worker thread made synchronous."""
-    with patch.object(indx_status.threading, "Thread",
-                      side_effect=lambda target, **kw: MagicMock(start=target)):
-        on_active_tool(variables)
+class _SyncThread:
+    """threading.Thread stand-in that runs the worker synchronously."""
+
+    def __init__(self, target, **kwargs) -> None:
+        self._target = target
+
+    def start(self) -> None:
+        self._target()
 
 
 class TestOnActiveTool(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         _reset()
+        self._thread_patch = patch.object(
+            indx_status.threading, "Thread", _SyncThread)
+        self._thread_patch.start()
 
-    def test_pickup_sets_state_and_pushes_bound_spool(self):
+    def tearDown(self) -> None:
+        self._thread_patch.stop()
+
+    def test_pickup_sets_state_and_pushes_bound_spool(self) -> None:
         with patch.object(indx_status, "set_active_spool_id") as post:
-            _run_sync({"active_tool": 1, "t1_spool_id": 42})
+            on_active_tool({"active_tool": 1, "t1_spool_id": 42})
         self.assertEqual(app_state.indx_active_tool, 1)
         post.assert_called_once_with("http://moon", 42)
-        self.assertEqual(indx_status._last_synced_spool, 42)
 
-    def test_park_updates_state_without_spoolman_call(self):
-        _run_sync({"active_tool": 2, "t2_spool_id": 7})
+    def test_park_updates_state_without_spoolman_call(self) -> None:
         with patch.object(indx_status, "set_active_spool_id") as post:
+            on_active_tool({"active_tool": 2, "t2_spool_id": 7})
+            post.reset_mock()
             on_active_tool({"active_tool": -1})
-        self.assertIsNone(app_state.indx_active_tool)
-        post.assert_not_called()
+            self.assertIsNone(app_state.indx_active_tool)
+            post.assert_not_called()
 
-    def test_resend_of_same_tool_is_ignored(self):
+    def test_resend_of_same_pair_is_ignored(self) -> None:
         with patch.object(indx_status, "set_active_spool_id") as post:
-            _run_sync({"active_tool": 0, "t0_spool_id": 5})
-            _run_sync({"active_tool": 0, "t0_spool_id": 5})
+            on_active_tool({"active_tool": 0, "t0_spool_id": 5})
+            on_active_tool({"active_tool": 0, "t0_spool_id": 5})
         self.assertEqual(post.call_count, 1)
 
-    def test_unbound_tool_leaves_spoolman_alone(self):
+    def test_rebind_of_mounted_tool_triggers_sync(self) -> None:
         with patch.object(indx_status, "set_active_spool_id") as post:
-            _run_sync({"active_tool": 1})
+            on_active_tool({"active_tool": 0, "t0_spool_id": 5})
+            on_active_tool({"active_tool": 0, "t0_spool_id": 9})
+        self.assertEqual(post.call_count, 2)
+        post.assert_called_with("http://moon", 9)
+
+    def test_repickup_after_park_reposts(self) -> None:
+        # Other components also write Spoolman's active spool — a genuine
+        # pickup must always POST even if the pair matches the last mount.
+        with patch.object(indx_status, "set_active_spool_id") as post:
+            on_active_tool({"active_tool": 0, "t0_spool_id": 5})
+            on_active_tool({"active_tool": -1})
+            on_active_tool({"active_tool": 0, "t0_spool_id": 5})
+        self.assertEqual(post.call_count, 2)
+
+    def test_unbound_tool_leaves_spoolman_alone(self) -> None:
+        with patch.object(indx_status, "set_active_spool_id") as post:
+            on_active_tool({"active_tool": 1})
         self.assertEqual(app_state.indx_active_tool, 1)
         post.assert_not_called()
 
-    def test_falls_back_to_active_spools_binding(self):
+    def test_falls_back_to_active_spools_binding(self) -> None:
         app_state.active_spools["T3"] = 99
         with patch.object(indx_status, "set_active_spool_id") as post:
-            _run_sync({"active_tool": 3})
+            on_active_tool({"active_tool": 3})
         post.assert_called_once_with("http://moon", 99)
 
-    def test_sync_disabled_still_tracks_tool(self):
+    def test_sync_disabled_still_tracks_tool(self) -> None:
         _reset(active_tool_sync=False)
         with patch.object(indx_status, "set_active_spool_id") as post:
-            _run_sync({"active_tool": 1, "t1_spool_id": 42})
+            on_active_tool({"active_tool": 1, "t1_spool_id": 42})
         self.assertEqual(app_state.indx_active_tool, 1)
         post.assert_not_called()
 
-    def test_spoolman_failure_logged_not_raised(self):
+    def test_spoolman_failure_logged_and_next_pickup_retries(self) -> None:
         with patch.object(indx_status, "set_active_spool_id",
-                          side_effect=RuntimeError("boom")):
-            _run_sync({"active_tool": 1, "t1_spool_id": 42})
-        # failure must not mark the spool as synced
-        self.assertIsNone(indx_status._last_synced_spool)
-
-    def test_repeat_pickup_same_spool_skips_post(self):
+                          side_effect=RuntimeError("boom")) as post:
+            with self.assertLogs("indx_status", level="ERROR") as logs:
+                on_active_tool({"active_tool": 1, "t1_spool_id": 42})
+        self.assertIn("failed to set Spoolman active spool", logs.output[0])
+        # a later genuine transition retries
         with patch.object(indx_status, "set_active_spool_id") as post:
-            _run_sync({"active_tool": 0, "t0_spool_id": 5, "t1_spool_id": 5})
             on_active_tool({"active_tool": -1})
-            _run_sync({"active_tool": 1, "t0_spool_id": 5, "t1_spool_id": 5})
-        self.assertEqual(post.call_count, 1)  # same spool on both tools
+            on_active_tool({"active_tool": 1, "t1_spool_id": 42})
+        post.assert_called_once_with("http://moon", 42)
 
-    def test_garbage_active_tool_ignored(self):
+    def test_latest_wins_when_worker_backlogged(self) -> None:
+        # Simulate transitions arriving while the worker has not run yet:
+        # only the newest target must be applied.
+        with patch.object(indx_status.threading, "Thread") as never_runs:
+            never_runs.return_value = MagicMock()  # start() does nothing
+            on_active_tool({"active_tool": 0, "t0_spool_id": 5})
+            on_active_tool({"active_tool": -1})
+            on_active_tool({"active_tool": 1, "t1_spool_id": 8})
+        with patch.object(indx_status, "set_active_spool_id") as post:
+            indx_status._sync_worker()
+        post.assert_called_once_with("http://moon", 8)
+
+    def test_garbage_active_tool_ignored(self) -> None:
         with patch.object(indx_status, "set_active_spool_id") as post:
             on_active_tool({"active_tool": "banana"})
         self.assertIsNone(app_state.indx_active_tool)
         post.assert_not_called()
 
-    def test_zero_spool_id_treated_as_unbound(self):
+    def test_zero_spool_id_treated_as_unbound(self) -> None:
         with patch.object(indx_status, "set_active_spool_id") as post:
-            _run_sync({"active_tool": 1, "t1_spool_id": 0})
+            on_active_tool({"active_tool": 1, "t1_spool_id": 0})
         post.assert_not_called()
+
+
+class TestSaveVariablesWiring(unittest.TestCase):
+    """The save_variables callback must be wired for toolhead_stage (INDX)
+    configs, not only direct-toolhead ones (codex High finding)."""
+
+    def test_stage_only_config_wires_save_variables(self) -> None:
+        import config as config_mod
+        cfg = {"scanners": {"abc123": {"action": "toolhead_stage"}}}
+        self.assertFalse(config_mod.has_toolhead_scanners(cfg))
+        self.assertTrue(config_mod.has_toolhead_stage_scanners(cfg))
+        src = open(os.path.join(os.path.dirname(os.path.dirname(__file__)),
+                                "spoolsense.py")).read()
+        self.assertIn(
+            "has_toolhead_scanners(cfg) or has_toolhead_stage_scanners(cfg)",
+            src,
+            "save_variables wiring must cover toolhead_stage configs",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Promote dev to master for the v1.8.5 release.

- Bondtech INDX live active-tool sync — follows save_variables.active_tool and switches Spoolman's active spool per tool pickup; adds active_tool to /api/status; opt out via active_tool_sync (#91)
- INDX example config updated for Bondtech's published macros (#91)
- docs: Docker upgrade section notes no auto-update and that --build is required (#113)

See CHANGELOG for details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live Bondtech INDX active-tool synchronization with SpoolMan.
  * Active tool information is now available through the status API.
  * Added an option to disable active-tool synchronization.

* **Documentation**
  * Updated INDX configuration guidance and examples.
  * Clarified Docker upgrade steps, including rebuilding images to apply updates.

* **Release**
  * Updated the application version to 1.8.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->