### PR TITLE
Staged assignment hardening: restore on failure, deduction baselines for staged scans

### DIFF
--- a/docs/klipper-setup.md
+++ b/docs/klipper-setup.md
@@ -106,6 +106,33 @@ gcode:
   {% endif %}
 ```
 
+## Bondtech INDX
+
+INDX on Klipper presents as a plain toolchanger (T0–T9), so the setup is the
+toolchanger flow above with one shared scanner instead of one per tool. Start
+from `middleware/config.example.indx.yaml`.
+
+What you need in `printer.cfg`:
+
+- The `ASSIGN_SPOOL` and `UPDATE_TAG` macros from the SpoolSense macro set
+- `variable_spool_id: None` on each tool macro (`T0`..`Tn`), exactly as in
+  the toolchanger section above
+- The `RESTORE_SPOOL_IDS` delayed gcode so assignments survive reboots
+
+Workflow: scan a spool on the shared scanner, then assign it to a tool with
+the keypad, web UI, mobile app, or `ASSIGN_SPOOL TOOL=Tn` in the console.
+
+Two things work automatically on INDX:
+
+- **Per-tool deduction** — Bondtech's macros do not create Klipper `tool`
+  objects, so `UPDATE_TAG` uses the slicer's per-tool filament weights from
+  the job metadata. Nothing extra to install.
+- **Live active-spool sync** — INDX records the mounted tool in
+  `save_variables.active_tool`; on every tool pickup the middleware switches
+  Spoolman's active spool to the spool assigned to that tool, so usage
+  accrues to the spool actually printing. Disable with
+  `active_tool_sync: false` in `config.yaml`.
+
 ## Restart Klipper
 
 ```bash

--- a/docs/klipper-setup.md
+++ b/docs/klipper-setup.md
@@ -126,12 +126,16 @@ Two things work automatically on INDX:
 
 - **Per-tool deduction** — Bondtech's macros do not create Klipper `tool`
   objects, so `UPDATE_TAG` uses the slicer's per-tool filament weights from
-  the job metadata. Nothing extra to install.
+  the job metadata. Nothing extra to install, but your slicer must write
+  per-tool filament usage into the gcode (OrcaSlicer and PrusaSlicer do);
+  without that metadata the deduction is skipped.
 - **Live active-spool sync** — INDX records the mounted tool in
   `save_variables.active_tool`; on every tool pickup the middleware switches
   Spoolman's active spool to the spool assigned to that tool, so usage
-  accrues to the spool actually printing. Disable with
-  `active_tool_sync: false` in `config.yaml`.
+  accrues to the spool actually printing. If the picked tool has no spool
+  assigned (or the head is parked), Spoolman is left unchanged, so usage
+  keeps accruing to the previously active spool until the next assigned
+  pickup. Disable with `active_tool_sync: false` in `config.yaml`.
 
 ## Restart Klipper
 

--- a/middleware/activation.py
+++ b/middleware/activation.py
@@ -169,6 +169,10 @@ def _route_staged(action_enum: Action, spoolman_activated: bool,
     """Handle afc_stage and toolhead_stage — cache tag data, don't lock."""
     slot = "afc" if action_enum == Action.AFC_STAGE else "toolhead"
     raw = getattr(scan, "raw", None) or {}
+    # spoolsense_scanner payloads carry the format in the payload; direct
+    # OpenTag3D/OpenPrintTag payloads have no such key — their parser puts
+    # the format name in scan.source, which matches _WRITABLE_FORMATS
+    tag_format = raw.get("tag_format") or getattr(scan, "source", None)
     _cache_pending_spool(slot, color_hex, filament_label, remaining, spoolman_id,
                          event.nozzle_temp_min, event.nozzle_temp_max,
                          event.bed_temp_min, event.bed_temp_max,
@@ -176,7 +180,7 @@ def _route_staged(action_enum: Action, spoolman_activated: bool,
                          device_id=device_id or "",
                          diameter_mm=getattr(scan, "diameter_mm", None),
                          density=getattr(scan, "density", None),
-                         tag_format=raw.get("tag_format"))
+                         tag_format=tag_format)
     stage_name = "afc_stage" if action_enum == Action.AFC_STAGE else "toolhead_stage"
     if spoolman_activated:
         logger.info(f"[{stage_name}] Spool staged with Spoolman ID, scanner remains unlocked")

--- a/middleware/activation.py
+++ b/middleware/activation.py
@@ -173,11 +173,15 @@ def _route_staged(action_enum: Action, spoolman_activated: bool,
     # OpenTag3D/OpenPrintTag payloads have no such key — their parser puts
     # the format name in scan.source, which matches _WRITABLE_FORMATS
     tag_format = raw.get("tag_format") or getattr(scan, "source", None)
+    # "mobile" is the REST marker for event attribution, not an MQTT scanner.
+    # Deduction routing keys off the tracking device_id — empty means mobile
+    # (store for GET /api/deductions), nonempty means publish to that scanner.
+    tracking_device = "" if device_id == "mobile" else (device_id or "")
     _cache_pending_spool(slot, color_hex, filament_label, remaining, spoolman_id,
                          event.nozzle_temp_min, event.nozzle_temp_max,
                          event.bed_temp_min, event.bed_temp_max,
                          uid=getattr(scan, "uid", None),
-                         device_id=device_id or "",
+                         device_id=tracking_device,
                          diameter_mm=getattr(scan, "diameter_mm", None),
                          density=getattr(scan, "density", None),
                          tag_format=tag_format)

--- a/middleware/activation.py
+++ b/middleware/activation.py
@@ -63,9 +63,19 @@ def _cache_pending_spool(
     color_hex: str, material: str, remaining: float | None, spoolman_id: int | None,
     nozzle_temp_min: int | None = None, nozzle_temp_max: int | None = None,
     bed_temp_min: int | None = None, bed_temp_max: int | None = None,
-) -> None:
+    uid: str | None = None, device_id: str = "",
+    diameter_mm: float | None = None, density: float | None = None,
+    tag_format: str | None = None,
+) -> bool:
     """Store tag data in the per-consumer pending slot ("afc" is consumed by
-    afc_status on lane load; "toolhead" by toolchanger_status on ASSIGN_SPOOL)."""
+    afc_status on lane load; "toolhead" by toolchanger_status on ASSIGN_SPOOL).
+
+    The uid is stored exactly as the caller sent it — /api/status echoes this
+    dict and the shipped mobile app reads it back (consumers that need a
+    canonical form lowercase at their own boundary). uid and the filament
+    props let the consumer record a deduction baseline on assignment (#109).
+
+    Returns True if an earlier pending spool was replaced."""
     pending = {
         "color_hex": color_hex,
         "material": material,
@@ -75,12 +85,20 @@ def _cache_pending_spool(
         "nozzle_temp_max": nozzle_temp_max,
         "bed_temp_min": bed_temp_min,
         "bed_temp_max": bed_temp_max,
+        "uid": uid,
+        "device_id": device_id,
+        "diameter_mm": diameter_mm,
+        "density": density,
+        "tag_format": tag_format or "unknown",
     }
     with app_state.state_lock:
         if slot == "afc":
+            replaced = app_state.pending_spool_afc is not None
             app_state.pending_spool_afc = pending
         else:
+            replaced = app_state.pending_spool_toolhead is not None
             app_state.pending_spool_toolhead = pending
+    return replaced
 
 
 # ── Event building ───────────────────────────────────────────────────────────
@@ -145,12 +163,20 @@ def _try_spoolman_activation(event: SpoolEvent, spoolman_id: int, target: str | 
 
 def _route_staged(action_enum: Action, spoolman_activated: bool,
                   color_hex: str, filament_label: str, remaining: float | None,
-                  spoolman_id: int | None, event: SpoolEvent) -> None:
+                  spoolman_id: int | None, event: SpoolEvent,
+                  scan: ScanEvent | None = None,
+                  device_id: str | None = None) -> None:
     """Handle afc_stage and toolhead_stage — cache tag data, don't lock."""
     slot = "afc" if action_enum == Action.AFC_STAGE else "toolhead"
+    raw = getattr(scan, "raw", None) or {}
     _cache_pending_spool(slot, color_hex, filament_label, remaining, spoolman_id,
                          event.nozzle_temp_min, event.nozzle_temp_max,
-                         event.bed_temp_min, event.bed_temp_max)
+                         event.bed_temp_min, event.bed_temp_max,
+                         uid=getattr(scan, "uid", None),
+                         device_id=device_id or "",
+                         diameter_mm=getattr(scan, "diameter_mm", None),
+                         density=getattr(scan, "density", None),
+                         tag_format=raw.get("tag_format"))
     stage_name = "afc_stage" if action_enum == Action.AFC_STAGE else "toolhead_stage"
     if spoolman_activated:
         logger.info(f"[{stage_name}] Spool staged with Spoolman ID, scanner remains unlocked")
@@ -288,7 +314,7 @@ def _activate_from_scan(
     # Route by action type
     if action_enum in (Action.AFC_STAGE, Action.TOOLHEAD_STAGE):
         _route_staged(action_enum, spoolman_activated, color_hex, filament_label,
-                      remaining, spoolman_id, event)
+                      remaining, spoolman_id, event, scan, device_id)
     elif action_enum in (Action.AFC_LANE, Action.TOOLHEAD):
         _route_dedicated(action_enum, spoolman_activated, spoolman_id, target, event)
 

--- a/middleware/afc_status.py
+++ b/middleware/afc_status.py
@@ -115,7 +115,8 @@ def _publish_lane_actions(lane_name: str, action: str | None, pending: dict | No
     if newly_loaded and pending:
         # Deduction baseline for UPDATE_TAG (#109) — the staged scan carried
         # the uid; recording on lane-load matches what dedicated afc_lane
-        # scanners do at scan time
+        # scanners do at scan time. If the new spool can't be recorded, drop
+        # any previous baseline instead — it describes a removed spool.
         uid = pending.get("uid")
         if uid and pending.get("remaining_g") is not None:
             from tracking_store import record_tracking
@@ -123,6 +124,9 @@ def _publish_lane_actions(lane_name: str, action: str | None, pending: dict | No
                             pending.get("remaining_g"),
                             pending.get("diameter_mm"), pending.get("density"),
                             pending.get("tag_format"))
+        else:
+            from tracking_store import clear_tracking
+            clear_tracking(lane_name)
         # Delayed 2s to let AFC's own load sequence finish first — if sent too early,
         # AFC overwrites material/weight during its load process.
         logger.info(f"AFC {source}: {lane_name} just loaded — scheduling lane data (2s delay)")
@@ -181,7 +185,11 @@ def _sync_lane_state(data: dict) -> None:
                         action = "clear"
                     app_state.active_spools[lane_name] = None
 
-            if action == "clear" or swapped:
+            # Unload transition must clear independently of lock/spool-id
+            # state: tag-only staged lanes (#109) have neither, so the
+            # action-based clear below never fires for them
+            unloaded = was_loaded and not lane_is_loaded
+            if action == "clear" or swapped or unloaded:
                 # Spool left the lane (or was swapped from outside) — drop its
                 # deduction baseline so a restart can't resurrect it (#91)
                 from tracking_store import clear_tracking
@@ -223,9 +231,12 @@ def _sync_lane_state_single(lane_name: str, data: dict) -> None:
                 swapped = True
 
         # Track load transitions
+        unloaded = False
         if load_state is not None:
             if load_state and not prev_load:
                 newly_loaded = True
+            elif prev_load and not load_state:
+                unloaded = True
             app_state.lane_load_states[lane_name] = load_state
 
         # Consume pending afc_stage data on load transition
@@ -238,7 +249,9 @@ def _sync_lane_state_single(lane_name: str, data: dict) -> None:
         if status is not None:
             app_state.lane_statuses[lane_name] = status
 
-    if action == "clear" or swapped:
+    # Unload must clear independently of lock/spool-id state — tag-only
+    # staged lanes (#109) have neither, so action never becomes "clear"
+    if action == "clear" or swapped or unloaded:
         from tracking_store import clear_tracking
         clear_tracking(lane_name)
 

--- a/middleware/afc_status.py
+++ b/middleware/afc_status.py
@@ -175,15 +175,21 @@ def _sync_lane_state(data: dict) -> None:
                     if spool_id and prev_spool and spool_id != prev_spool:
                         swapped = True
                     app_state.active_spools[lane_name] = spool_id
-                elif lane_is_loaded and not was_loaded and app_state.pending_spool_afc:
-                    # Lane transitioned unloaded → loaded with pending afc_stage data
-                    newly_loaded = True
-                    pending = app_state.pending_spool_afc
-                    app_state.pending_spool_afc = None
-                else:
+                elif not (lane_is_loaded and not was_loaded
+                          and app_state.pending_spool_afc):
                     if is_locked:
                         action = "clear"
                     app_state.active_spools[lane_name] = None
+
+                # Consume staged afc_stage data on any unloaded → loaded
+                # transition. A Spoolman-backed staged load reports load=true
+                # AND a spool_id in the same poll (SET_NEXT_SPOOL_ID landed
+                # first), so consumption can't live in an else-branch keyed
+                # off spool_id being absent.
+                if lane_is_loaded and not was_loaded and app_state.pending_spool_afc:
+                    newly_loaded = True
+                    pending = app_state.pending_spool_afc
+                    app_state.pending_spool_afc = None
 
             # Unload transition must clear independently of lock/spool-id
             # state: tag-only staged lanes (#109) have neither, so the

--- a/middleware/afc_status.py
+++ b/middleware/afc_status.py
@@ -252,10 +252,13 @@ def _sync_lane_state_single(lane_name: str, data: dict) -> None:
 
         # Consume pending afc_stage data on load transition — same id-match
         # rule as the poll path: never eat a staged spool while the lane
-        # reports a different Spoolman id
+        # holds a different Spoolman id. Deltas are partial: an absent
+        # spool_id key means "unchanged", so compare against the cached id;
+        # an explicit null means the lane has no spool.
         if newly_loaded and app_state.pending_spool_afc:
             staged_id = app_state.pending_spool_afc.get("spoolman_id")
-            if staged_id is None or spool_id is None or staged_id == spool_id:
+            lane_id = spool_id if "spool_id" in data else prev_spool
+            if staged_id is None or lane_id is None or staged_id == lane_id:
                 pending = app_state.pending_spool_afc
                 app_state.pending_spool_afc = None
 

--- a/middleware/afc_status.py
+++ b/middleware/afc_status.py
@@ -195,7 +195,8 @@ def _sync_lane_state(data: dict) -> None:
                 # consumes anything (SET_NEXT_SPOOL_ID may land after load).
                 if lane_is_loaded and not was_loaded and app_state.pending_spool_afc:
                     staged_id = app_state.pending_spool_afc.get("spoolman_id")
-                    if spool_id is None or staged_id == spool_id:
+                    lane_id = spool_id or None  # AFC uses 0 for "no spool"
+                    if lane_id is None or staged_id == lane_id:
                         newly_loaded = True
                         pending = app_state.pending_spool_afc
                         app_state.pending_spool_afc = None
@@ -264,7 +265,8 @@ def _sync_lane_state_single(lane_name: str, data: dict) -> None:
         # an explicit null means the lane has no spool.
         if newly_loaded and app_state.pending_spool_afc:
             staged_id = app_state.pending_spool_afc.get("spoolman_id")
-            lane_id = spool_id if "spool_id" in data else prev_spool
+            # AFC uses 0 for "no spool" — normalize before matching
+            lane_id = (spool_id or None) if "spool_id" in data else (prev_spool or None)
             if lane_id is None or staged_id == lane_id:
                 pending = app_state.pending_spool_afc
                 app_state.pending_spool_afc = None

--- a/middleware/afc_status.py
+++ b/middleware/afc_status.py
@@ -113,6 +113,16 @@ def _publish_lane_actions(lane_name: str, action: str | None, pending: dict | No
         publish_lock(lane_name, "clear")
 
     if newly_loaded and pending:
+        # Deduction baseline for UPDATE_TAG (#109) — the staged scan carried
+        # the uid; recording on lane-load matches what dedicated afc_lane
+        # scanners do at scan time
+        uid = pending.get("uid")
+        if uid and pending.get("remaining_g") is not None:
+            from tracking_store import record_tracking
+            record_tracking(lane_name, uid, pending.get("device_id", ""),
+                            pending.get("remaining_g"),
+                            pending.get("diameter_mm"), pending.get("density"),
+                            pending.get("tag_format"))
         # Delayed 2s to let AFC's own load sequence finish first — if sent too early,
         # AFC overwrites material/weight during its load process.
         logger.info(f"AFC {source}: {lane_name} just loaded — scheduling lane data (2s delay)")

--- a/middleware/afc_status.py
+++ b/middleware/afc_status.py
@@ -189,9 +189,13 @@ def _sync_lane_state(data: dict) -> None:
                 # Spoolman spool (assigned externally) must not eat the
                 # staged one — only consume when the ids agree or either
                 # side is tag-only.
+                # A lane reporting an id only consumes staged data whose id
+                # agrees — a tag-only staged spool must not be claimed by an
+                # externally-assigned Spoolman spool. A lane with no id yet
+                # consumes anything (SET_NEXT_SPOOL_ID may land after load).
                 if lane_is_loaded and not was_loaded and app_state.pending_spool_afc:
                     staged_id = app_state.pending_spool_afc.get("spoolman_id")
-                    if staged_id is None or spool_id is None or staged_id == spool_id:
+                    if spool_id is None or staged_id == spool_id:
                         newly_loaded = True
                         pending = app_state.pending_spool_afc
                         app_state.pending_spool_afc = None
@@ -225,8 +229,11 @@ def _sync_lane_state_single(lane_name: str, data: dict) -> None:
         prev_spool = app_state.active_spools.get(lane_name)
         prev_load  = app_state.lane_load_states.get(lane_name, False)
 
-        # Update spool tracking
-        if spool_id is not None:
+        # Update spool tracking. Key presence matters: absent means
+        # "unchanged" (partial delta), while an explicit null/0 is a
+        # removal and must clear the cached id — otherwise a later
+        # load-only delta compares staged spools against a stale id.
+        if "spool_id" in data:
             if spool_id and not prev_spool:
                 app_state.active_spools[lane_name] = spool_id
                 action = "lock"
@@ -258,7 +265,7 @@ def _sync_lane_state_single(lane_name: str, data: dict) -> None:
         if newly_loaded and app_state.pending_spool_afc:
             staged_id = app_state.pending_spool_afc.get("spoolman_id")
             lane_id = spool_id if "spool_id" in data else prev_spool
-            if staged_id is None or lane_id is None or staged_id == lane_id:
+            if lane_id is None or staged_id == lane_id:
                 pending = app_state.pending_spool_afc
                 app_state.pending_spool_afc = None
 

--- a/middleware/afc_status.py
+++ b/middleware/afc_status.py
@@ -185,11 +185,16 @@ def _sync_lane_state(data: dict) -> None:
                 # transition. A Spoolman-backed staged load reports load=true
                 # AND a spool_id in the same poll (SET_NEXT_SPOOL_ID landed
                 # first), so consumption can't live in an else-branch keyed
-                # off spool_id being absent.
+                # off spool_id being absent. But a lane loading a DIFFERENT
+                # Spoolman spool (assigned externally) must not eat the
+                # staged one — only consume when the ids agree or either
+                # side is tag-only.
                 if lane_is_loaded and not was_loaded and app_state.pending_spool_afc:
-                    newly_loaded = True
-                    pending = app_state.pending_spool_afc
-                    app_state.pending_spool_afc = None
+                    staged_id = app_state.pending_spool_afc.get("spoolman_id")
+                    if staged_id is None or spool_id is None or staged_id == spool_id:
+                        newly_loaded = True
+                        pending = app_state.pending_spool_afc
+                        app_state.pending_spool_afc = None
 
             # Unload transition must clear independently of lock/spool-id
             # state: tag-only staged lanes (#109) have neither, so the
@@ -245,10 +250,14 @@ def _sync_lane_state_single(lane_name: str, data: dict) -> None:
                 unloaded = True
             app_state.lane_load_states[lane_name] = load_state
 
-        # Consume pending afc_stage data on load transition
+        # Consume pending afc_stage data on load transition — same id-match
+        # rule as the poll path: never eat a staged spool while the lane
+        # reports a different Spoolman id
         if newly_loaded and app_state.pending_spool_afc:
-            pending = app_state.pending_spool_afc
-            app_state.pending_spool_afc = None
+            staged_id = app_state.pending_spool_afc.get("spoolman_id")
+            if staged_id is None or spool_id is None or staged_id == spool_id:
+                pending = app_state.pending_spool_afc
+                app_state.pending_spool_afc = None
 
         # Update lane status if present in delta
         status = data.get("status")

--- a/middleware/afc_status.py
+++ b/middleware/afc_status.py
@@ -149,7 +149,10 @@ def _sync_lane_state(data: dict) -> None:
             if lane_name == "system" or not isinstance(lane_data, dict):
                 continue
 
-            spool_id       = lane_data.get("spool_id")
+            # AFC reports 0 for "no spool" — normalize once so the lock/
+            # clear/swap/consumption logic below all see one empty value
+            # (the websocket path already treats 0 as removal)
+            spool_id       = lane_data.get("spool_id") or None
             status         = lane_data.get("status")
             lane_is_loaded = lane_data.get("load", False)
 
@@ -195,8 +198,7 @@ def _sync_lane_state(data: dict) -> None:
                 # consumes anything (SET_NEXT_SPOOL_ID may land after load).
                 if lane_is_loaded and not was_loaded and app_state.pending_spool_afc:
                     staged_id = app_state.pending_spool_afc.get("spoolman_id")
-                    lane_id = spool_id or None  # AFC uses 0 for "no spool"
-                    if lane_id is None or staged_id == lane_id:
+                    if spool_id is None or staged_id == spool_id:
                         newly_loaded = True
                         pending = app_state.pending_spool_afc
                         app_state.pending_spool_afc = None

--- a/middleware/mqtt_handler.py
+++ b/middleware/mqtt_handler.py
@@ -73,21 +73,12 @@ def _record_spool_tracking(
     density: float | None = None,
     tag_format: str | None = None,
 ) -> None:
-    """Store initial weight, UID, device, filament properties, and tag format for UPDATE_TAG deduction tracking."""
-    if not target or not uid or remaining is None:
+    """Record the UPDATE_TAG deduction baseline (via tracking_store) and run
+    the scan-time low-spool check."""
+    from tracking_store import record_tracking
+    if not record_tracking(target, uid, device_id, remaining,
+                           diameter_mm, density, tag_format):
         return
-    with app_state.state_lock:
-        app_state.active_spool_tracking[target] = app_state.ActiveSpool(
-            uid=uid,
-            device_id=device_id or "",
-            weight_g=remaining,
-            diameter_mm=diameter_mm or 1.75,
-            density=density or 1.24,
-            tag_format=tag_format or "unknown",
-        )
-    # Persist so the deduction baseline survives restarts (#91)
-    from tracking_store import save_tracking
-    save_tracking()
 
     # Check low-spool threshold at scan time — if a new spool has plenty of
     # filament, this also clears any latched low-spool state from the same
@@ -164,17 +155,12 @@ def _handle_uid_only_tag(client: mqtt.Client, scanner_cfg: dict, uid: str, topic
 
     # Shared scanners — cache for later assignment, don't activate yet
     if action in ("toolhead_stage", "afc_stage"):
-        pending = {
-            "color_hex": color_hex,
-            "material": material,
-            "remaining_g": remaining,
-            "spoolman_id": spool_id,
-        }
-        with app_state.state_lock:
-            if action == "afc_stage":
-                app_state.pending_spool_afc = pending
-            else:
-                app_state.pending_spool_toolhead = pending
+        from activation import _cache_pending_spool
+        _cache_pending_spool(
+            "afc" if action == "afc_stage" else "toolhead",
+            color_hex, material, remaining, spool_id,
+            uid=uid, device_id=device_id or "", tag_format="uid_only",
+        )
         logger.info(f"[{action}] Staged spool {spool_id} ({name}) for assignment")
         # Observer channels (MQTT event stream) still see staged scans even
         # though no printer command fires yet (#93)

--- a/middleware/rest_api.py
+++ b/middleware/rest_api.py
@@ -24,7 +24,7 @@ from pydantic import BaseModel
 
 import app_state
 from adapters.dispatcher import detect_and_parse
-from activation import _activate_from_scan
+from activation import _activate_from_scan, _cache_pending_spool
 from moonraker_client import send_gcode
 from mqtt_handler import _record_spool_tracking, _get_scanner_target
 from config import CONFIG_PATH
@@ -198,19 +198,22 @@ def mobile_scan(req: MobileScanRequest) -> ApiResponse:
 
     # toolhead_stage: cache as pending, phone picks toolhead next
     if action == "toolhead_stage":
-        with app_state.state_lock:
-            replaced = app_state.pending_spool_toolhead is not None
-            app_state.pending_spool_toolhead = {
-                "color_hex": scan.color_hex or "FFFFFF",
-                "material": scan.material_name or scan.material_type or "Unknown",
-                "remaining_g": scan.remaining_weight_g,
-                "spoolman_id": scan.scanner_spoolman_id,
-                "uid": scan.uid,
-                "nozzle_temp_min": scan.nozzle_temp_min_c,
-                "nozzle_temp_max": scan.nozzle_temp_max_c,
-                "bed_temp_min": scan.bed_temp_min_c,
-                "bed_temp_max": scan.bed_temp_max_c,
-            }
+        replaced = _cache_pending_spool(
+            "toolhead",
+            scan.color_hex or "FFFFFF",
+            scan.material_name or scan.material_type or "Unknown",
+            scan.remaining_weight_g,
+            scan.scanner_spoolman_id,
+            scan.nozzle_temp_min_c,
+            scan.nozzle_temp_max_c,
+            scan.bed_temp_min_c,
+            scan.bed_temp_max_c,
+            uid=scan.uid,
+            device_id="",
+            diameter_mm=scan.diameter_mm,
+            density=scan.density,
+            tag_format=req.tag_format,
+        )
 
         msg = (
             "Previous pending spool replaced — select a toolhead to assign"

--- a/middleware/rest_api.py
+++ b/middleware/rest_api.py
@@ -212,7 +212,7 @@ def mobile_scan(req: MobileScanRequest) -> ApiResponse:
             device_id="",
             diameter_mm=scan.diameter_mm,
             density=scan.density,
-            tag_format=req.tag_format,
+            tag_format=req.tag_format or scan.source,
         )
 
         msg = (

--- a/middleware/tests/test_activation.py
+++ b/middleware/tests/test_activation.py
@@ -262,6 +262,48 @@ class TestPendingSlotIsolation(unittest.TestCase):
                          app_state.pending_spool_toolhead)
 
 
+class TestStagedCarriesTrackingFields(unittest.TestCase):
+    """Staged scans carry uid + filament props into the pending slot so the
+    consumer can record a deduction baseline on assignment (#109). The uid is
+    stored as-sent — /api/status echoes this dict to the shipped mobile app."""
+
+    def setUp(self):
+        _setup_app_state()
+
+    def test_rich_scan_fields_land_in_pending_slot(self):
+        from activation import _route_staged
+        from publishers.base import Action
+        from state.models import ScanEvent
+        scan = ScanEvent(
+            source="spoolsense_scanner", target_id="T0", scanned_at="now",
+            uid="AABB11", present=True, tag_data_valid=True,
+            diameter_mm=1.75, density=1.24,
+            raw={"tag_format": "openprinttag"},
+        )
+        event = MagicMock(nozzle_temp_min=None, nozzle_temp_max=None,
+                          bed_temp_min=None, bed_temp_max=None)
+        with patch("activation.notify_observers"):
+            _route_staged(Action.TOOLHEAD_STAGE, True, "FF0000", "PLA", 500.0,
+                          42, event, scan, "f3d360")
+        pending = app_state.pending_spool_toolhead
+        self.assertEqual(pending["uid"], "AABB11")
+        self.assertEqual(pending["device_id"], "f3d360")
+        self.assertEqual(pending["diameter_mm"], 1.75)
+        self.assertEqual(pending["tag_format"], "openprinttag")
+
+    def test_no_scan_defaults_are_harmless(self):
+        from activation import _route_staged
+        from publishers.base import Action
+        event = MagicMock(nozzle_temp_min=None, nozzle_temp_max=None,
+                          bed_temp_min=None, bed_temp_max=None)
+        with patch("activation.notify_observers"):
+            _route_staged(Action.AFC_STAGE, True, "FF0000", "PLA", 500.0,
+                          42, event)
+        pending = app_state.pending_spool_afc
+        self.assertIsNone(pending["uid"])
+        self.assertEqual(pending["tag_format"], "unknown")
+
+
 class TestBuildSpoolEventScannerId(unittest.TestCase):
     """scanner_id must carry the source scanner so event-stream (#93)
     consumers can tell scanners apart — regression for the live finding

--- a/middleware/tests/test_activation.py
+++ b/middleware/tests/test_activation.py
@@ -291,6 +291,26 @@ class TestStagedCarriesTrackingFields(unittest.TestCase):
         self.assertEqual(pending["diameter_mm"], 1.75)
         self.assertEqual(pending["tag_format"], "openprinttag")
 
+    def test_opentag3d_format_derived_from_source(self):
+        # Direct OpenTag3D payloads have no tag_format key — the parser puts
+        # the format in scan.source; storing "unknown" would make
+        # _is_writable_tag silently skip every deduction after assignment
+        from activation import _route_staged
+        from publishers.base import Action
+        from state.models import ScanEvent
+        scan = ScanEvent(
+            source="opentag3d", target_id="T0", scanned_at="now",
+            uid="AABB11", present=True, tag_data_valid=True,
+            raw={"opentag_version": 1},
+        )
+        event = MagicMock(nozzle_temp_min=None, nozzle_temp_max=None,
+                          bed_temp_min=None, bed_temp_max=None)
+        with patch("activation.notify_observers"):
+            _route_staged(Action.TOOLHEAD_STAGE, True, "FF0000", "PLA", 500.0,
+                          42, event, scan, "f3d360")
+        self.assertEqual(app_state.pending_spool_toolhead["tag_format"],
+                         "opentag3d")
+
     def test_no_scan_defaults_are_harmless(self):
         from activation import _route_staged
         from publishers.base import Action

--- a/middleware/tests/test_activation.py
+++ b/middleware/tests/test_activation.py
@@ -291,6 +291,24 @@ class TestStagedCarriesTrackingFields(unittest.TestCase):
         self.assertEqual(pending["diameter_mm"], 1.75)
         self.assertEqual(pending["tag_format"], "openprinttag")
 
+    def test_mobile_marker_not_stored_as_tracking_device(self):
+        # device_id="mobile" is REST event attribution — if it lands in the
+        # tracking record, UPDATE_TAG publishes deductions to a nonexistent
+        # MQTT scanner instead of the mobile REST store
+        from activation import _route_staged
+        from publishers.base import Action
+        from state.models import ScanEvent
+        scan = ScanEvent(
+            source="opentag3d", target_id="mobile", scanned_at="now",
+            uid="AABB11", present=True, tag_data_valid=True,
+        )
+        event = MagicMock(nozzle_temp_min=None, nozzle_temp_max=None,
+                          bed_temp_min=None, bed_temp_max=None)
+        with patch("activation.notify_observers"):
+            _route_staged(Action.AFC_STAGE, True, "FF0000", "PLA", 500.0,
+                          42, event, scan, "mobile")
+        self.assertEqual(app_state.pending_spool_afc["device_id"], "")
+
     def test_opentag3d_format_derived_from_source(self):
         # Direct OpenTag3D payloads have no tag_format key — the parser puts
         # the format in scan.source; storing "unknown" would make

--- a/middleware/tests/test_afc_status.py
+++ b/middleware/tests/test_afc_status.py
@@ -248,6 +248,32 @@ class TestLaneLoadRecordsTracking(unittest.TestCase):
             _sync_lane_state_single("lane1", {"load": False})
         self.assertNotIn("lane1", app_state.active_spool_tracking)
 
+    def test_poll_mismatched_spool_id_leaves_pending_staged(self):
+        # Spool A staged, but the lane loads spool B (assigned externally) —
+        # A must stay staged and B's lane must not get A's data or baseline
+        app_state.lane_load_states["lane1"] = False
+        staged = {
+            "color_hex": "FF0000", "material": "PLA", "remaining_g": 250.0,
+            "spoolman_id": 42, "uid": "AABBCC", "tag_format": "openprinttag",
+        }
+        app_state.pending_spool_afc = staged
+        data = _make_afc_data(spool_id=99, load=True)
+        with patch("afc_status.threading.Timer"):
+            with patch("afc_status.publish_lock"):
+                _sync_lane_state(data)
+        self.assertIs(app_state.pending_spool_afc, staged)
+        self.assertNotIn("lane1", app_state.active_spool_tracking)
+
+    def test_ws_mismatched_spool_id_leaves_pending_staged(self):
+        app_state.lane_load_states["lane1"] = False
+        staged = {"color_hex": "FF0000", "material": "PLA",
+                  "remaining_g": 250.0, "spoolman_id": 42, "uid": "AABBCC"}
+        app_state.pending_spool_afc = staged
+        with patch("afc_status.threading.Timer"):
+            with patch("afc_status.publish_lock"):
+                _sync_lane_state_single("lane1", {"spool_id": 99, "load": True})
+        self.assertIs(app_state.pending_spool_afc, staged)
+
     def test_poll_spoolman_backed_load_consumes_pending(self):
         # SET_NEXT_SPOOL_ID lands before the poll sees load=true, so the
         # same poll reports BOTH — staged data must still be consumed and

--- a/middleware/tests/test_afc_status.py
+++ b/middleware/tests/test_afc_status.py
@@ -331,6 +331,20 @@ class TestLaneLoadRecordsTracking(unittest.TestCase):
                 _sync_lane_state_single("lane1", {"load": True})
         self.assertIsNone(app_state.pending_spool_afc)
 
+    def test_ws_zero_spool_id_load_consumes_tag_only_staged(self):
+        # AFC reports spool_id 0 for "no spool" — a tag-only staged spool
+        # must still be consumed when the lane loads with a zero id
+        app_state.lane_load_states["lane1"] = False
+        staged = {"color_hex": "FF0000", "material": "PLA",
+                  "remaining_g": 250.0, "spoolman_id": None, "uid": "AABBCC",
+                  "tag_format": "openprinttag"}
+        app_state.pending_spool_afc = staged
+        with patch("afc_status.threading.Timer"):
+            with patch("afc_status.publish_lock"):
+                _sync_lane_state_single("lane1", {"spool_id": 0, "load": True})
+        self.assertIsNone(app_state.pending_spool_afc)
+        self.assertIn("lane1", app_state.active_spool_tracking)
+
     def test_poll_spoolman_backed_load_consumes_pending(self):
         # SET_NEXT_SPOOL_ID lands before the poll sees load=true, so the
         # same poll reports BOTH — staged data must still be consumed and

--- a/middleware/tests/test_afc_status.py
+++ b/middleware/tests/test_afc_status.py
@@ -248,6 +248,26 @@ class TestLaneLoadRecordsTracking(unittest.TestCase):
             _sync_lane_state_single("lane1", {"load": False})
         self.assertNotIn("lane1", app_state.active_spool_tracking)
 
+    def test_poll_spoolman_backed_load_consumes_pending(self):
+        # SET_NEXT_SPOOL_ID lands before the poll sees load=true, so the
+        # same poll reports BOTH — staged data must still be consumed and
+        # the baseline recorded, not left for a later lane to steal
+        app_state.lane_load_states["lane1"] = False
+        app_state.pending_spool_afc = {
+            "color_hex": "FF0000", "material": "PLA", "remaining_g": 250.0,
+            "spoolman_id": 42, "uid": "AABBCC", "device_id": "4d9620",
+            "tag_format": "openprinttag",
+        }
+        data = _make_afc_data(spool_id=42, load=True)
+        with patch("afc_status.threading.Timer"):
+            with patch("afc_status.publish_lock"):
+                _sync_lane_state(data)
+        self.assertIsNone(app_state.pending_spool_afc)
+        rec = app_state.active_spool_tracking.get("lane1")
+        self.assertIsNotNone(rec)
+        self.assertEqual(rec.uid, "aabbcc")
+        self.assertEqual(app_state.active_spools.get("lane1"), 42)
+
 
 class TestSwapClearsTracking(unittest.TestCase):
     """An externally-driven spool swap (Mainsail SET_SPOOL_ID, no scan) must

--- a/middleware/tests/test_afc_status.py
+++ b/middleware/tests/test_afc_status.py
@@ -178,6 +178,47 @@ class TestSyncLaneState(unittest.TestCase):
         assert app_state.active_spools.get("lane1") == 7
 
 
+class TestLaneLoadRecordsTracking(unittest.TestCase):
+    """An afc_stage scan consumed on lane load records a deduction baseline
+    for that lane — previously only dedicated afc_lane scans got one (#109)."""
+
+    def setUp(self):
+        _reset_app_state()
+
+    def _load_lane_with_pending(self, pending):
+        app_state.lane_load_states["lane1"] = False
+        app_state.pending_spool_afc = pending
+        data = _make_afc_data(spool_id=None, load=True)
+        with patch("afc_status.threading.Timer"):
+            with patch("afc_status.publish_lock"):
+                _sync_lane_state(data)
+
+    def test_staged_scan_with_uid_records_baseline(self):
+        self._load_lane_with_pending({
+            "color_hex": "FF0000", "material": "PLA", "remaining_g": 250.0,
+            "spoolman_id": None, "uid": "AABBCC", "device_id": "4d9620",
+            "diameter_mm": 1.75, "density": 1.24, "tag_format": "openprinttag",
+        })
+        rec = app_state.active_spool_tracking.get("lane1")
+        self.assertIsNotNone(rec)
+        self.assertEqual(rec.uid, "aabbcc")
+        self.assertEqual(rec.weight_g, 250.0)
+
+    def test_staged_scan_without_uid_records_nothing(self):
+        self._load_lane_with_pending({
+            "color_hex": "FF0000", "material": "PLA", "remaining_g": 250.0,
+            "spoolman_id": None,
+        })
+        self.assertNotIn("lane1", app_state.active_spool_tracking)
+
+    def test_staged_scan_without_weight_records_nothing(self):
+        self._load_lane_with_pending({
+            "color_hex": "FF0000", "material": "PLA", "remaining_g": None,
+            "spoolman_id": 5, "uid": "AABBCC",
+        })
+        self.assertNotIn("lane1", app_state.active_spool_tracking)
+
+
 class TestSwapClearsTracking(unittest.TestCase):
     """An externally-driven spool swap (Mainsail SET_SPOOL_ID, no scan) must
     drop the lane's deduction baseline — it describes the removed spool. A

--- a/middleware/tests/test_afc_status.py
+++ b/middleware/tests/test_afc_status.py
@@ -218,6 +218,36 @@ class TestLaneLoadRecordsTracking(unittest.TestCase):
         })
         self.assertNotIn("lane1", app_state.active_spool_tracking)
 
+    def test_unrecordable_pending_clears_previous_baseline(self):
+        # A new spool loaded but with no baseline data — the OLD spool's
+        # record must not survive to receive its deductions
+        app_state.active_spool_tracking["lane1"] = app_state.ActiveSpool(
+            uid="oldspool", weight_g=400.0)
+        self._load_lane_with_pending({
+            "color_hex": "FF0000", "material": "PLA", "remaining_g": None,
+            "spoolman_id": None,
+        })
+        self.assertNotIn("lane1", app_state.active_spool_tracking)
+
+    def test_poll_unload_clears_tag_only_baseline(self):
+        # Tag-only staged lanes never lock and have no spool_id, so the
+        # action-based clear can't fire — the load transition must clear
+        app_state.lane_load_states["lane1"] = True
+        app_state.active_spool_tracking["lane1"] = app_state.ActiveSpool(
+            uid="aabbcc", weight_g=250.0)
+        data = _make_afc_data(spool_id=None, load=False)
+        with patch("afc_status.publish_lock"):
+            _sync_lane_state(data)
+        self.assertNotIn("lane1", app_state.active_spool_tracking)
+
+    def test_ws_unload_clears_tag_only_baseline(self):
+        app_state.lane_load_states["lane1"] = True
+        app_state.active_spool_tracking["lane1"] = app_state.ActiveSpool(
+            uid="aabbcc", weight_g=250.0)
+        with patch("afc_status.publish_lock"):
+            _sync_lane_state_single("lane1", {"load": False})
+        self.assertNotIn("lane1", app_state.active_spool_tracking)
+
 
 class TestSwapClearsTracking(unittest.TestCase):
     """An externally-driven spool swap (Mainsail SET_SPOOL_ID, no scan) must

--- a/middleware/tests/test_afc_status.py
+++ b/middleware/tests/test_afc_status.py
@@ -331,6 +331,31 @@ class TestLaneLoadRecordsTracking(unittest.TestCase):
                 _sync_lane_state_single("lane1", {"load": True})
         self.assertIsNone(app_state.pending_spool_afc)
 
+    def test_poll_zero_spool_id_treated_as_empty(self):
+        # AFC reports 0 for "no spool" — polling must not lock an empty
+        # lane, and a locked lane reporting 0 must clear (parity with the
+        # websocket path, which always treated 0 as removal)
+        app_state.lane_locks["lane1"] = True
+        app_state.active_spools["lane1"] = 42
+        data = _make_afc_data(spool_id=0, load=False)
+        with patch("afc_status.publish_lock") as mock_lock:
+            _sync_lane_state(data)
+            mock_lock.assert_called_once_with("lane1", "clear")
+        self.assertIsNone(app_state.active_spools.get("lane1"))
+
+    def test_poll_zero_spool_id_load_consumes_tag_only_staged(self):
+        app_state.lane_load_states["lane1"] = False
+        staged = {"color_hex": "FF0000", "material": "PLA",
+                  "remaining_g": 250.0, "spoolman_id": None, "uid": "AABBCC",
+                  "tag_format": "openprinttag"}
+        app_state.pending_spool_afc = staged
+        data = _make_afc_data(spool_id=0, load=True)
+        with patch("afc_status.threading.Timer"):
+            with patch("afc_status.publish_lock"):
+                _sync_lane_state(data)
+        self.assertIsNone(app_state.pending_spool_afc)
+        self.assertIn("lane1", app_state.active_spool_tracking)
+
     def test_ws_zero_spool_id_load_consumes_tag_only_staged(self):
         # AFC reports spool_id 0 for "no spool" — a tag-only staged spool
         # must still be consumed when the lane loads with a zero id

--- a/middleware/tests/test_afc_status.py
+++ b/middleware/tests/test_afc_status.py
@@ -300,6 +300,37 @@ class TestLaneLoadRecordsTracking(unittest.TestCase):
         self.assertIsNone(app_state.pending_spool_afc)
         self.assertIn("lane1", app_state.active_spool_tracking)
 
+    def test_poll_tag_only_staged_not_claimed_by_spoolman_lane(self):
+        # Tag-only spool staged; a lane loads an externally-assigned
+        # Spoolman spool — the staged record must not be claimed by it
+        app_state.lane_load_states["lane1"] = False
+        staged = {"color_hex": "FF0000", "material": "PLA",
+                  "remaining_g": 250.0, "spoolman_id": None, "uid": "AABBCC"}
+        app_state.pending_spool_afc = staged
+        data = _make_afc_data(spool_id=99, load=True)
+        with patch("afc_status.threading.Timer"):
+            with patch("afc_status.publish_lock"):
+                _sync_lane_state(data)
+        self.assertIs(app_state.pending_spool_afc, staged)
+
+    def test_ws_explicit_null_clears_cached_id_then_staged_consumes(self):
+        # Removal delta {"spool_id": null} must clear the cached id, so a
+        # later load-only delta can consume freshly staged data instead of
+        # being blocked by a stale id forever
+        app_state.lane_load_states["lane1"] = True
+        app_state.active_spools["lane1"] = 99
+        with patch("afc_status.publish_lock"):
+            _sync_lane_state_single("lane1", {"spool_id": None, "load": False})
+        self.assertIsNone(app_state.active_spools.get("lane1"))
+        staged = {"color_hex": "FF0000", "material": "PLA",
+                  "remaining_g": 250.0, "spoolman_id": 42, "uid": "AABBCC",
+                  "tag_format": "openprinttag"}
+        app_state.pending_spool_afc = staged
+        with patch("afc_status.threading.Timer"):
+            with patch("afc_status.publish_lock"):
+                _sync_lane_state_single("lane1", {"load": True})
+        self.assertIsNone(app_state.pending_spool_afc)
+
     def test_poll_spoolman_backed_load_consumes_pending(self):
         # SET_NEXT_SPOOL_ID lands before the poll sees load=true, so the
         # same poll reports BOTH — staged data must still be consumed and

--- a/middleware/tests/test_afc_status.py
+++ b/middleware/tests/test_afc_status.py
@@ -274,6 +274,32 @@ class TestLaneLoadRecordsTracking(unittest.TestCase):
                 _sync_lane_state_single("lane1", {"spool_id": 99, "load": True})
         self.assertIs(app_state.pending_spool_afc, staged)
 
+    def test_ws_load_only_delta_respects_cached_spool_id(self):
+        # Partial delta {"load": true} omits spool_id (= unchanged) — the
+        # lane's CACHED id (99) must block consuming staged spool 42
+        app_state.lane_load_states["lane1"] = False
+        app_state.active_spools["lane1"] = 99
+        staged = {"color_hex": "FF0000", "material": "PLA",
+                  "remaining_g": 250.0, "spoolman_id": 42, "uid": "AABBCC"}
+        app_state.pending_spool_afc = staged
+        with patch("afc_status.threading.Timer"):
+            with patch("afc_status.publish_lock"):
+                _sync_lane_state_single("lane1", {"load": True})
+        self.assertIs(app_state.pending_spool_afc, staged)
+
+    def test_ws_load_only_delta_consumes_when_cached_id_matches(self):
+        app_state.lane_load_states["lane1"] = False
+        app_state.active_spools["lane1"] = 42
+        staged = {"color_hex": "FF0000", "material": "PLA",
+                  "remaining_g": 250.0, "spoolman_id": 42, "uid": "AABBCC",
+                  "tag_format": "openprinttag"}
+        app_state.pending_spool_afc = staged
+        with patch("afc_status.threading.Timer"):
+            with patch("afc_status.publish_lock"):
+                _sync_lane_state_single("lane1", {"load": True})
+        self.assertIsNone(app_state.pending_spool_afc)
+        self.assertIn("lane1", app_state.active_spool_tracking)
+
     def test_poll_spoolman_backed_load_consumes_pending(self):
         # SET_NEXT_SPOOL_ID lands before the poll sees load=true, so the
         # same poll reports BOTH — staged data must still be consumed and

--- a/middleware/tests/test_rest_api.py
+++ b/middleware/tests/test_rest_api.py
@@ -182,6 +182,15 @@ class TestMobileScan(unittest.TestCase):
         # Pending spool was stored in app_state
         self.assertIsNotNone(app_state.pending_spool_toolhead)
 
+    def test_toolhead_stage_pending_uid_stored_as_sent(self):
+        # Frozen iOS contract: /api/status echoes the pending dict and the
+        # shipped app reads the uid back — it must keep the case the app sent
+        _reset_app_state(mobile_enabled=True, mobile_action="toolhead_stage")
+        scan = _make_scan_event(uid="AABBCCDD")
+        with patch("rest_api.detect_and_parse", return_value=scan):
+            self._post({"uid": "AABBCCDD", "present": True, "tag_data_valid": True})
+        self.assertEqual(app_state.pending_spool_toolhead["uid"], "AABBCCDD")
+
     def test_toolhead_stage_replaced_flag_set_on_second_scan(self):
         _reset_app_state(mobile_enabled=True, mobile_action="toolhead_stage")
         # Pre-populate a pending spool to simulate scanning twice

--- a/middleware/tests/test_toolchanger_status.py
+++ b/middleware/tests/test_toolchanger_status.py
@@ -17,7 +17,11 @@ sys.modules.setdefault("watchdog.observers", MagicMock())
 sys.modules.setdefault("watchdog.events", MagicMock())
 
 import app_state  # noqa: E402
-from toolchanger_status import _fetch_pending_tool, _assign_spool_to_tool  # noqa: E402
+from toolchanger_status import (  # noqa: E402
+    _fetch_pending_tool,
+    _assign_spool_to_tool,
+    _process_pending_tool,
+)
 
 
 def _reset_app_state(moonraker_url="http://moonraker:7125"):
@@ -28,6 +32,7 @@ def _reset_app_state(moonraker_url="http://moonraker:7125"):
     }
     app_state.lane_locks = {}
     app_state.active_spools = {}
+    app_state.active_spool_tracking = {}
     app_state.pending_spool_afc = None
     app_state.pending_spool_toolhead = None
     app_state.state_lock = threading.Lock()
@@ -248,6 +253,115 @@ class TestAssignSpoolToTool(unittest.TestCase):
             if "json" in c[1] and c[1]["json"].get("namespace") == "lane_data"
         ]
         assert len(lane_data_calls) == 0
+
+
+class TestProcessPendingTool(unittest.TestCase):
+    """A failed ASSIGN_SPOOL must not eat the staged spool (#108): the slot is
+    restored on failure unless a newer scan already took it."""
+
+    def setUp(self):
+        _reset_app_state()
+
+    @patch("toolchanger_status._assign_spool_to_tool", return_value=False)
+    def test_failed_assignment_restores_pending_spool(self, mock_assign):
+        pending = {"spoolman_id": 7, "color_hex": "FF0000", "material": "PLA",
+                   "remaining_g": 300.0}
+        app_state.pending_spool_toolhead = pending
+
+        _process_pending_tool("T0", "Macro assign")
+
+        mock_assign.assert_called_once_with("T0", pending)
+        self.assertIs(app_state.pending_spool_toolhead, pending)
+
+    @patch("toolchanger_status._assign_spool_to_tool")
+    def test_failed_assignment_does_not_overwrite_newer_scan(self, mock_assign):
+        old = {"spoolman_id": 7, "color_hex": "FF0000", "material": "PLA",
+               "remaining_g": 300.0}
+        new = {"spoolman_id": 9, "color_hex": "00FF00", "material": "PETG",
+               "remaining_g": 800.0}
+        app_state.pending_spool_toolhead = old
+
+        def assign_and_stage_newer(tool_name, pending):
+            # A scan lands while the (slow) assign network call is running
+            app_state.pending_spool_toolhead = new
+            return False
+
+        mock_assign.side_effect = assign_and_stage_newer
+        _process_pending_tool("T0", "Macro assign")
+
+        self.assertIs(app_state.pending_spool_toolhead, new)
+
+    @patch("toolchanger_status._assign_spool_to_tool", return_value=True)
+    def test_successful_assignment_leaves_slot_empty(self, mock_assign):
+        app_state.pending_spool_toolhead = {"spoolman_id": 7, "color_hex": "FF0000",
+                                            "material": "PLA", "remaining_g": 300.0}
+
+        _process_pending_tool("T0", "Macro assign WS")
+
+        self.assertIsNone(app_state.pending_spool_toolhead)
+
+    @patch("toolchanger_status._assign_spool_to_tool")
+    def test_no_pending_spool_does_not_assign(self, mock_assign):
+        _process_pending_tool("T0", "Macro assign")
+        mock_assign.assert_not_called()
+
+
+class TestAssignRecordsTracking(unittest.TestCase):
+    """A staged scan consumed by ASSIGN_SPOOL records a deduction baseline —
+    previously only dedicated toolhead/afc_lane scans got one (#109)."""
+
+    def setUp(self):
+        _reset_app_state()
+
+    @patch("requests.post")
+    def test_success_records_baseline_with_lowercased_uid(self, mock_post):
+        mock_post.return_value = MagicMock(raise_for_status=lambda: None)
+        pending = {"spoolman_id": 10, "color_hex": "FF0000", "material": "PLA",
+                   "remaining_g": 300.0, "uid": "AABB11", "device_id": "f3d360",
+                   "diameter_mm": 1.75, "density": 1.24,
+                   "tag_format": "openprinttag"}
+
+        result = _assign_spool_to_tool("T0", pending)
+
+        self.assertTrue(result)
+        rec = app_state.active_spool_tracking.get("T0")
+        self.assertIsNotNone(rec)
+        self.assertEqual(rec.uid, "aabb11")
+        self.assertEqual(rec.weight_g, 300.0)
+        self.assertEqual(rec.tag_format, "openprinttag")
+
+    @patch("requests.post")
+    def test_no_uid_records_nothing(self, mock_post):
+        mock_post.return_value = MagicMock(raise_for_status=lambda: None)
+        pending = {"spoolman_id": 10, "color_hex": "FF0000", "material": "PLA",
+                   "remaining_g": 300.0}
+
+        _assign_spool_to_tool("T0", pending)
+
+        self.assertNotIn("T0", app_state.active_spool_tracking)
+
+    @patch("requests.post")
+    def test_no_weight_records_nothing(self, mock_post):
+        # A baseline without a weight can't drive a deduction — skip it
+        mock_post.return_value = MagicMock(raise_for_status=lambda: None)
+        pending = {"spoolman_id": 10, "color_hex": "FF0000", "material": "PLA",
+                   "remaining_g": None, "uid": "AABB11"}
+
+        _assign_spool_to_tool("T0", pending)
+
+        self.assertNotIn("T0", app_state.active_spool_tracking)
+
+    @patch("requests.post")
+    def test_failed_activation_records_nothing(self, mock_post):
+        import requests as req
+        mock_post.side_effect = req.ConnectionError("refused")
+        pending = {"spoolman_id": 10, "color_hex": "FF0000", "material": "PLA",
+                   "remaining_g": 300.0, "uid": "AABB11"}
+
+        result = _assign_spool_to_tool("T0", pending)
+
+        self.assertFalse(result)
+        self.assertNotIn("T0", app_state.active_spool_tracking)
 
 
 class TestLaneDataTemps(unittest.TestCase):

--- a/middleware/tests/test_toolchanger_status.py
+++ b/middleware/tests/test_toolchanger_status.py
@@ -352,6 +352,21 @@ class TestAssignRecordsTracking(unittest.TestCase):
         self.assertNotIn("T0", app_state.active_spool_tracking)
 
     @patch("requests.post")
+    def test_unrecordable_assignment_clears_previous_baseline(self, mock_post):
+        # Spool B assigned with no weight while spool A's baseline is on the
+        # tool — B's usage must not be deducted from A's uid
+        mock_post.return_value = MagicMock(raise_for_status=lambda: None)
+        app_state.active_spool_tracking["T0"] = app_state.ActiveSpool(
+            uid="spool_a", weight_g=400.0)
+        pending = {"spoolman_id": 10, "color_hex": "FF0000", "material": "PLA",
+                   "remaining_g": None, "uid": "SPOOLB"}
+
+        result = _assign_spool_to_tool("T0", pending)
+
+        self.assertTrue(result)
+        self.assertNotIn("T0", app_state.active_spool_tracking)
+
+    @patch("requests.post")
     def test_failed_activation_records_nothing(self, mock_post):
         import requests as req
         mock_post.side_effect = req.ConnectionError("refused")

--- a/middleware/tests/test_tracking_store.py
+++ b/middleware/tests/test_tracking_store.py
@@ -16,7 +16,7 @@ sys.modules.setdefault("paho.mqtt", MagicMock())
 sys.modules.setdefault("paho.mqtt.client", MagicMock())
 
 import app_state  # noqa: E402
-from tracking_store import load_tracking, save_tracking  # noqa: E402
+from tracking_store import load_tracking, record_tracking, save_tracking  # noqa: E402
 
 
 class TestTrackingStore(unittest.TestCase):
@@ -74,6 +74,47 @@ class TestTrackingStore(unittest.TestCase):
     def test_save_never_raises(self):
         app_state.TRACKING_FILE = "/nonexistent-root-dir/tracking.json"
         save_tracking()  # must not raise
+
+
+class TestRecordTracking(unittest.TestCase):
+    """record_tracking is the single write path for deduction baselines —
+    it lowercases the uid, requires a weight, and persists (#109)."""
+
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".json", delete=False)
+        self.tmp.close()
+        os.unlink(self.tmp.name)
+        app_state.TRACKING_FILE = self.tmp.name
+        app_state.state_lock = threading.Lock()
+        app_state.active_spool_tracking = {}
+
+    def tearDown(self):
+        if os.path.exists(self.tmp.name):
+            os.unlink(self.tmp.name)
+
+    def test_records_lowercased_uid_and_persists(self):
+        ok = record_tracking("T0", "AABB11", "f3d360", 300.0, 1.75, 1.24, "openprinttag")
+        self.assertTrue(ok)
+        self.assertEqual(app_state.active_spool_tracking["T0"].uid, "aabb11")
+        with open(self.tmp.name) as f:
+            self.assertIn("aabb11", json.load(f)["T0"]["uid"])
+
+    def test_missing_weight_rejected(self):
+        self.assertFalse(record_tracking("T0", "aabb11", "", None))
+        self.assertNotIn("T0", app_state.active_spool_tracking)
+        self.assertFalse(os.path.exists(self.tmp.name))
+
+    def test_missing_uid_or_target_rejected(self):
+        self.assertFalse(record_tracking("T0", "", "", 300.0))
+        self.assertFalse(record_tracking("", "aabb11", "", 300.0))
+        self.assertEqual(app_state.active_spool_tracking, {})
+
+    def test_defaults_applied(self):
+        record_tracking("lane1", "aabb11", "", 250.0)
+        rec = app_state.active_spool_tracking["lane1"]
+        self.assertEqual(rec.diameter_mm, 1.75)
+        self.assertEqual(rec.density, 1.24)
+        self.assertEqual(rec.tag_format, "unknown")
 
 
 class TestClearTracking(unittest.TestCase):

--- a/middleware/toolchanger_status.py
+++ b/middleware/toolchanger_status.py
@@ -181,13 +181,19 @@ def _assign_spool_to_tool(tool_name: str, pending: dict) -> bool:
                                 color_hex, material, remaining_g, temps=pending)
 
     # Deduction baseline for UPDATE_TAG (#109) — staged scans carry the uid;
-    # without this, spools assigned via ASSIGN_SPOOL never get a baseline
+    # without this, spools assigned via ASSIGN_SPOOL never get a baseline.
+    # When the new spool can't be recorded (no uid or unknown weight), the
+    # previous spool's baseline must still die — a successful assignment
+    # means it no longer describes what's mounted.
     uid = pending.get("uid")
     if uid and remaining_g is not None:
         from tracking_store import record_tracking
         record_tracking(macro, uid, pending.get("device_id", ""), remaining_g,
                         pending.get("diameter_mm"), pending.get("density"),
                         pending.get("tag_format"))
+    else:
+        from tracking_store import clear_tracking
+        clear_tracking(macro)
     return True
 
 

--- a/middleware/toolchanger_status.py
+++ b/middleware/toolchanger_status.py
@@ -131,11 +131,15 @@ def _publish_tool_lane_data(moonraker: str, macro: str, tool_number_str: str,
         logger.exception(f"[toolhead_stage] Failed to publish lane_data for {macro}")
 
 
-def _assign_spool_to_tool(tool_name: str, pending: dict) -> None:
-    """Pushes cached spool data to the specified tool via Klipper gcode commands."""
+def _assign_spool_to_tool(tool_name: str, pending: dict) -> bool:
+    """Pushes cached spool data to the specified tool via Klipper gcode commands.
+
+    Returns False on hard failure (no Moonraker, Spoolman activation failed)
+    so the caller can restore the pending spool; cosmetic failures (color
+    gcode) are logged and do not fail the assignment."""
     moonraker = app_state.cfg.get("moonraker_url", "")
     if not moonraker:
-        return
+        return False
 
     macro = tool_name.upper()
     match = _TOOL_PATTERN.match(macro)
@@ -149,7 +153,7 @@ def _assign_spool_to_tool(tool_name: str, pending: dict) -> None:
     # Spoolman path — activate, set gcode var, persist, with rollback on failure
     if spoolman_id is not None:
         if not _activate_spoolman(moonraker, macro, tool_number_str, spoolman_id):
-            return
+            return False
 
     # Color — always set from tag data regardless of Spoolman
     spool_color = display_spoolcolor(color_hex)
@@ -175,6 +179,49 @@ def _assign_spool_to_tool(tool_name: str, pending: dict) -> None:
     if app_state.cfg.get("publish_lane_data", False):
         _publish_tool_lane_data(moonraker, macro, tool_number_str, spoolman_id,
                                 color_hex, material, remaining_g, temps=pending)
+
+    # Deduction baseline for UPDATE_TAG (#109) — staged scans carry the uid;
+    # without this, spools assigned via ASSIGN_SPOOL never get a baseline
+    uid = pending.get("uid")
+    if uid and remaining_g is not None:
+        from tracking_store import record_tracking
+        record_tracking(macro, uid, pending.get("device_id", ""), remaining_g,
+                        pending.get("diameter_mm"), pending.get("density"),
+                        pending.get("tag_format"))
+    return True
+
+
+def _process_pending_tool(tool_name: str, source: str) -> None:
+    """Claim the staged spool and assign it, restoring it on a failed assign.
+
+    The slot is cleared before the network calls so a concurrent scan can
+    stage freely; on failure the claimed spool is put back only if no newer
+    scan has taken the slot in the meantime (#108)."""
+    with app_state.state_lock:
+        pending = app_state.pending_spool_toolhead
+        app_state.pending_spool_toolhead = None
+
+    if not pending:
+        logger.warning(
+            f"{source}: {tool_name} requested but no spool scanned yet — "
+            "scan a tag first, then run ASSIGN_SPOOL"
+        )
+        return
+
+    logger.info(f"{source}: assigning cached spool data to {tool_name}")
+    if _assign_spool_to_tool(tool_name, pending):
+        return
+
+    with app_state.state_lock:
+        if app_state.pending_spool_toolhead is None:
+            app_state.pending_spool_toolhead = pending
+            restored = True
+        else:
+            restored = False
+    if restored:
+        logger.warning(f"{source}: assignment to {tool_name} failed — pending spool restored, rescan not needed")
+    else:
+        logger.warning(f"{source}: assignment to {tool_name} failed; a newer scan already replaced the pending spool")
 
 
 def _fetch_pending_tool() -> str | None:
@@ -231,19 +278,7 @@ class ToolchangerStatusSync:
         tool_name = pending_tool.strip()
         logger.info(f"Macro assign WS: tool {tool_name} requested")
 
-        pending: dict | None = None
-        with app_state.state_lock:
-            if app_state.pending_spool_toolhead:
-                pending = app_state.pending_spool_toolhead
-                app_state.pending_spool_toolhead = None
-
-        if pending:
-            logger.info(f"Macro assign WS: assigning cached spool data to {tool_name}")
-            _assign_spool_to_tool(tool_name, pending)
-        else:
-            logger.warning(
-                f"Macro assign WS: {tool_name} requested but no spool scanned yet"
-            )
+        _process_pending_tool(tool_name, "Macro assign WS")
 
         _clear_pending_tool()
 
@@ -304,23 +339,7 @@ class ToolchangerStatusSync:
                     tool_name = pending_tool.strip()
                     logger.info(f"Macro assign: tool {tool_name} requested")
 
-                    # Check for pending spool data
-                    pending: dict | None = None
-                    with app_state.state_lock:
-                        if app_state.pending_spool_toolhead:
-                            pending = app_state.pending_spool_toolhead
-                            app_state.pending_spool_toolhead = None
-
-                    if pending:
-                        logger.info(
-                            f"Macro assign: assigning cached spool data to {tool_name}"
-                        )
-                        _assign_spool_to_tool(tool_name, pending)
-                    else:
-                        logger.warning(
-                            f"Macro assign: {tool_name} requested but no spool scanned yet — "
-                            "scan a tag first, then run ASSIGN_SPOOL"
-                        )
+                    _process_pending_tool(tool_name, "Macro assign")
 
                     # Clear the macro variable
                     _clear_pending_tool()

--- a/middleware/tracking_store.py
+++ b/middleware/tracking_store.py
@@ -23,6 +23,37 @@ import app_state
 logger = logging.getLogger(__name__)
 
 
+def record_tracking(
+    target: str,
+    uid: str,
+    device_id: str = "",
+    remaining: float | None = None,
+    diameter_mm: float | None = None,
+    density: float | None = None,
+    tag_format: str | None = None,
+) -> bool:
+    """Record the deduction baseline for the spool mounted on *target* and
+    persist it. Requires a uid and a known weight — a baseline without a
+    weight can't drive a deduction, so nothing useful would be stored.
+
+    The uid is stored lowercased: tracking records are matched against
+    scanner/mobile uids that arrive in either case."""
+    if not target or not uid or remaining is None:
+        return False
+
+    with app_state.state_lock:
+        app_state.active_spool_tracking[target] = app_state.ActiveSpool(
+            uid=uid.lower(),
+            device_id=device_id or "",
+            weight_g=remaining,
+            diameter_mm=diameter_mm or 1.75,
+            density=density or 1.24,
+            tag_format=tag_format or "unknown",
+        )
+    save_tracking()
+    return True
+
+
 def load_tracking() -> None:
     """Load persisted tracking records into app_state at startup."""
     if not os.path.exists(app_state.TRACKING_FILE):


### PR DESCRIPTION
Hardens the staged (shared-scanner) assignment flow and closes two gaps in deduction tracking.

## Changes

**Failed ASSIGN_SPOOL no longer loses the staged spool (#108)** — both assign paths (websocket and polling, now deduplicated into one helper) cleared `pending_spool_toolhead` before the network calls, so a failed assignment forced a rescan. On failure the spool is restored, unless a newer scan already took the slot.

**Staged scans record a deduction baseline (#109)** — staged scans (MQTT rich and uid-only, plus mobile) now carry uid, device_id, diameter, density, and tag_format into the pending slot, and the consumers record a baseline when the slot is consumed: ASSIGN_SPOOL for `toolhead_stage`, lane load for `afc_stage`. Previously only dedicated `toolhead`/`afc_lane` scans got a baseline, so UPDATE_TAG never deducted for staged assignments. The write path is consolidated in `tracking_store.record_tracking`. The pending dict keeps the uid exactly as sent, since `/api/status` echoes it to the shipped mobile app.

**AFC staged-consumption semantics tightened** — recording baselines on lane load exposed several pre-existing and new edge cases in how staged data is consumed, now all fixed and regression-tested:
- Spoolman-backed loads in polling mode report `load=true` and the spool id in the same poll; consumption keyed off id-absence never fired
- A lane loading a different Spoolman spool no longer eats the staged one; matching honors partial websocket deltas (absent key = unchanged, explicit null/0 = removed) and AFC's `0` = no spool
- Unload transitions clear baselines independently of lock/spool-id state, covering tag-only lanes that have neither
- A successful assignment that can't record a baseline (no uid or unknown weight) clears the previous spool's record instead of leaving it to receive the new spool's deductions
- Mobile staged scans keep the empty-string tracking device id, so their deductions stay on the REST store the app polls instead of a nonexistent MQTT scanner topic
- Tag formats for direct OpenTag3D/OpenPrintTag payloads derive from the parser source, so staged deductions aren't rejected as unwritable

**Docs** — new Bondtech INDX section in `docs/klipper-setup.md` (#91): macro requirements, shared-scanner workflow, slicer-metadata deduction, and active-tool sync.

## Testing

- 598 tests passing (32 new: restore-on-failure, baseline recording on both consumers, every consumption edge case above); flake8 clean
- Reviewed until clean

Closes #108
Closes #109


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Bondtech INDX setup guidance, including shared-scanner workflows, tool assignment, spool metadata, and active-spool synchronization.
  - Added support for richer scan metadata, including spool identifiers, device information, filament dimensions, density, and tag format.
  - Added automatic tracking baselines for assigned or activated spools.

- **Bug Fixes**
  - Improved staged-spool assignment across polling and websocket updates.
  - Prevented stale or mismatched staged data from being applied to tools.
  - Preserved newer scans when an assignment fails and improved handling of unloaded lanes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->