### PR TITLE
Happy Hare for mobile: gate assignment, live gate map, and a fix for the never-functional bind

### DIFF
--- a/middleware/activation.py
+++ b/middleware/activation.py
@@ -98,6 +98,7 @@ def _cache_pending_spool(
         else:
             replaced = app_state.pending_spool_toolhead is not None
             app_state.pending_spool_toolhead = pending
+            app_state.pending_spool_toolhead_gen += 1
     return replaced
 
 

--- a/middleware/app_state.py
+++ b/middleware/app_state.py
@@ -68,6 +68,11 @@ pending_spool_afc: dict | None = None
 indx_active_tool: int | None = None
 pending_spool_toolhead: dict | None = None
 
+# Bumped on every toolhead-slot stage. Lets a failed gate assign detect that
+# a newer scan was staged (and possibly consumed) while its network call ran,
+# so it never resurrects a stale spool into the slot. Protected by state_lock.
+pending_spool_toolhead_gen: int = 0
+
 # Tag writeback cooldown — tracks recent writes to prevent loops.
 # Maps uid → timestamp of the last write command sent.
 # Protected by state_lock.

--- a/middleware/config.example.happy_hare.yaml
+++ b/middleware/config.example.happy_hare.yaml
@@ -51,6 +51,11 @@ happy_hare:
   # mmu_parameters.cfg, but the middleware does not enforce that — anything
   # consistent with how you've configured Happy Hare will work.
   printer_name: "YOUR_PRINTER_NAME"
+  # Number of MMU gates. Enables the mobile app's gate picker (targets
+  # G0..G{n-1}) and the live staging board. Optional — without it,
+  # phone-side gate assignment is unavailable but select-then-scan
+  # with a physical scanner still works.
+  num_gates: 4
 
 # ---- Scanners ------------------------------------------------
 # One shared scanner, used to bind any spool to whichever gate the user
@@ -61,3 +66,12 @@ scanners:
     action: "happy_hare_stage"
 
 scanner_topic_prefix: "spoolsense"
+
+# ---- Mobile app (optional) ----------------------------------
+# With action happy_hare_stage, the app scans a tag and then assigns it
+# to any gate from the picker (no MMU_SELECT_GATE needed). Requires
+# happy_hare.num_gates above. The Scan tab's staging board shows gate
+# occupancy and highlights the gate that is printing.
+# mobile:
+#   enabled: true
+#   action: "happy_hare_stage"

--- a/middleware/config.example.happy_hare.yaml
+++ b/middleware/config.example.happy_hare.yaml
@@ -7,7 +7,7 @@
 #
 # This config is for Happy Hare MMU users running in pull mode.
 # Workflow (physical scanner):
-#   1. Select an MMU gate (MMU_SELECT_GATE GATE=N) in Mainsail / LCD
+#   1. Select an MMU gate (MMU_SELECT GATE=N) in Mainsail / LCD
 #   2. Scan a tag on the shared scanner
 #   3. The middleware reads the selected gate from Moonraker and binds
 #      via Happy Hare's own MMU_SPOOLMAN SPOOLID=<id> GATE=<n>, which
@@ -62,7 +62,7 @@ scanner_topic_prefix: "spoolsense"
 
 # ---- Mobile app (optional) ----------------------------------
 # With action happy_hare_stage, the app scans a tag and then assigns it
-# to any gate from the picker (no MMU_SELECT_GATE needed). Requires
+# to any gate from the picker (no MMU_SELECT needed). Requires
 # happy_hare.num_gates above. The Scan tab's staging board shows gate
 # occupancy and highlights the gate that is printing.
 # mobile:

--- a/middleware/config.example.happy_hare.yaml
+++ b/middleware/config.example.happy_hare.yaml
@@ -6,13 +6,14 @@
 #   cp config.example.happy_hare.yaml ~/SpoolSense/config.yaml
 #
 # This config is for Happy Hare MMU users running in pull mode.
-# Workflow:
+# Workflow (physical scanner):
 #   1. Select an MMU gate (MMU_SELECT_GATE GATE=N) in Mainsail / LCD
 #   2. Scan a tag on the shared scanner
-#   3. The middleware reads the selected gate from Moonraker, writes
-#      mmu_gate + printer_name to the spool's Spoolman extras, then
-#      fires MMU_SPOOLMAN SYNC=1 so Happy Hare picks up the binding
-#      immediately.
+#   3. The middleware reads the selected gate from Moonraker and binds
+#      via Happy Hare's own MMU_SPOOLMAN SPOOLID=<id> GATE=<n>, which
+#      updates Spoolman and Happy Hare's gate map in one step.
+# Workflow (mobile app): scan the tag with your phone, then pick the
+# gate in the app — no gate selection on the printer needed.
 #
 # Pull mode is required. Happy Hare reports its mode via printer.mmu
 # .spoolman_support — the middleware queries it and refuses to bind
@@ -37,24 +38,16 @@ low_spool_threshold: 100
 
 # ---- Happy Hare integration ---------------------------------
 #
-# Prerequisite: declare these extra fields in Spoolman before the first bind:
-#   Settings → Extra Fields → Spool → Add
-#     - key: mmu_gate       type: integer
-#     - key: printer_name   type: text
-# Without these declared, the PATCH will fail with HTTP 400 "Unknown extra
-# field X." (the error body is logged so you can see which field is missing).
+# Happy Hare declares its own Spoolman extra fields (mmu_gate_map,
+# printer_name) on startup — nothing to create by hand.
 happy_hare:
   enabled: true
-  # Written to each spool's extra.printer_name in Spoolman. Happy Hare uses
-  # this to identify which spools belong to this printer when syncing from
-  # Spoolman. Typically matches the "Printer Name" set in Happy Hare's
-  # mmu_parameters.cfg, but the middleware does not enforce that — anything
-  # consistent with how you've configured Happy Hare will work.
-  printer_name: "YOUR_PRINTER_NAME"
-  # Number of MMU gates. Enables the mobile app's gate picker (targets
-  # G0..G{n-1}) and the live staging board. Optional — without it,
-  # phone-side gate assignment is unavailable but select-then-scan
-  # with a physical scanner still works.
+  # Legacy, no longer required: Happy Hare stamps its own printer identity
+  # on each spool during the bind. Safe to remove.
+  # printer_name: "YOUR_PRINTER_NAME"
+  # Number of MMU gates. Drives the mobile app's gate picker (targets
+  # G0..G{n-1}) and the live staging board. Required when
+  # mobile.action is happy_hare_stage; optional for scanner-only setups.
   num_gates: 4
 
 # ---- Scanners ------------------------------------------------

--- a/middleware/config.py
+++ b/middleware/config.py
@@ -296,6 +296,14 @@ def load_config() -> dict:
     _validate_mobile(config)
     _validate_happy_hare(config)
 
+    # Happy Hare: gates become mobile-assignable targets G0..G{n-1}. Runs
+    # after validation (num_gates is checked there). Only when no explicit/
+    # derived toolheads exist — HH installs have no toolhead scanners, so
+    # this is normally the only source.
+    if not config.get("toolheads") and config.get("happy_hare", {}).get("num_gates"):
+        config["toolheads"] = [f"G{i}" for i in range(config["happy_hare"]["num_gates"])]
+        logger.info(f"Derived gate targets from happy_hare.num_gates: {config['toolheads']}")
+
     return config
 
 
@@ -307,10 +315,22 @@ def _validate_mobile(config: dict) -> None:
     mobile.setdefault("port", 5001)
 
     mobile_action = mobile["action"]
-    if mobile_action not in ("afc_stage", "toolhead_stage", "toolhead"):
-        _config_error("mobile.action must be afc_stage, toolhead_stage, or toolhead (got %s)", mobile_action)
+    if mobile_action not in ("afc_stage", "toolhead_stage", "toolhead", "happy_hare_stage"):
+        _config_error("mobile.action must be afc_stage, toolhead_stage, toolhead, "
+                      "or happy_hare_stage (got %s)", mobile_action)
     if mobile_action == "toolhead" and not mobile.get("toolhead"):
         _config_error("mobile.action 'toolhead' requires a 'toolhead' field (e.g. T0)")
+    if mobile_action == "happy_hare_stage":
+        if not config.get("happy_hare", {}).get("enabled"):
+            _config_error("mobile.action 'happy_hare_stage' requires happy_hare.enabled: true")
+        # The gate-assign flow stages into the shared toolhead pending slot;
+        # a toolhead/toolhead_stage scanner's ASSIGN_SPOOL consumer would
+        # steal it and assign an MMU spool to a toolchanger tool.
+        if has_toolhead_scanners(config) or has_toolhead_stage_scanners(config):
+            _config_error(
+                "mobile.action 'happy_hare_stage' cannot be combined with "
+                "toolhead or toolhead_stage scanners — the staged-assign flows conflict."
+            )
 
     mobile_port = mobile["port"]
     if not isinstance(mobile_port, int) or mobile_port < 1 or mobile_port > 65535:
@@ -365,5 +385,14 @@ def _validate_happy_hare(config: dict) -> None:
             "Happy Hare binding writes to Spoolman — tag-only mode is not supported "
             "for this action. Set 'spoolman_url' in config.yaml."
         )
+
+    # num_gates drives the mobile gate picker (targets G0..G{n-1}). Optional:
+    # without it, phone-side gate assignment is unavailable but the physical
+    # select-then-scan flow still works.
+    num_gates = happy_hare.get("num_gates")
+    if num_gates is not None:
+        if isinstance(num_gates, bool) or not isinstance(num_gates, int) \
+                or num_gates < 1 or num_gates > 32:
+            _config_error("happy_hare.num_gates must be an integer 1-32 (got %s)", num_gates)
 
 

--- a/middleware/config.py
+++ b/middleware/config.py
@@ -293,8 +293,10 @@ def load_config() -> dict:
             logger.info(f"Derived toolheads from scanners: {config['toolheads']}")
 
     _validate_scanners(config)
-    _validate_mobile(config)
+    # happy_hare runs before mobile: the mobile validator reads the
+    # happy_hare section, and the type/shape guards live in the HH validator
     _validate_happy_hare(config)
+    _validate_mobile(config)
 
     # Happy Hare: gates become mobile-assignable targets G0..G{n-1}. Runs
     # after validation (num_gates is checked there). Only when no explicit/
@@ -323,13 +325,37 @@ def _validate_mobile(config: dict) -> None:
     if mobile_action == "happy_hare_stage":
         if not config.get("happy_hare", {}).get("enabled"):
             _config_error("mobile.action 'happy_hare_stage' requires happy_hare.enabled: true")
-        # The gate-assign flow stages into the shared toolhead pending slot;
-        # a toolhead/toolhead_stage scanner's ASSIGN_SPOOL consumer would
-        # steal it and assign an MMU spool to a toolchanger tool.
-        if has_toolhead_scanners(config) or has_toolhead_stage_scanners(config):
+        # Spool resolution (uid -> Spoolman id) happens at scan time; without
+        # Spoolman every scan dead-ends with a misleading not-found message
+        if not config.get("spoolman_url"):
             _config_error(
-                "mobile.action 'happy_hare_stage' cannot be combined with "
-                "toolhead or toolhead_stage scanners — the staged-assign flows conflict."
+                "mobile.action 'happy_hare_stage' requires spoolman_url — the gate "
+                "assign flow resolves scanned tags against Spoolman."
+            )
+        # The app's gate picker renders the derived G0..G{n-1} targets; without
+        # num_gates the picker is empty (or a stale fallback) and every assign fails
+        if not config.get("happy_hare", {}).get("num_gates"):
+            _config_error(
+                "mobile.action 'happy_hare_stage' requires happy_hare.num_gates — "
+                "it drives the app's gate picker (targets G0..G{n-1})."
+            )
+        # The gate-assign flow stages into the shared toolhead pending slot and
+        # derives gate names into toolheads. Any other scanner type either
+        # starts a competing pending-slot consumer (toolhead_stage; AFC with
+        # publish_lane_data) or derives lane/tool names that suppress the gate
+        # targets. Keep HH-mobile configs pure: happy_hare_stage scanners only.
+        other = [d for d, s in config.get("scanners", {}).items()
+                 if isinstance(s, dict) and s.get("action") != "happy_hare_stage"]
+        if other:
+            _config_error(
+                "mobile.action 'happy_hare_stage' can only be combined with "
+                "happy_hare_stage scanners (found other actions on: %s).",
+                ", ".join(sorted(other)),
+            )
+        if config.get("toolheads"):
+            _config_error(
+                "mobile.action 'happy_hare_stage' derives gate targets G0..G{n-1} — "
+                "remove the explicit 'toolheads' list from config.yaml."
             )
 
     mobile_port = mobile["port"]
@@ -369,12 +395,9 @@ def _validate_happy_hare(config: dict) -> None:
             "Set 'happy_hare.enabled: true' in config.yaml or change the scanner action."
         )
 
-    if enabled and not happy_hare["printer_name"]:
-        _config_error(
-            "happy_hare.enabled is true but happy_hare.printer_name is empty. "
-            "Set 'happy_hare.printer_name' to match the Printer Name configured "
-            "in Happy Hare's mmu_parameters.cfg."
-        )
+    # printer_name is legacy-tolerated but no longer required: binding goes
+    # through MMU_SPOOLMAN SPOOLID/GATE and Happy Hare stamps its own
+    # printer identity on the spool.
 
     # Happy Hare binding writes to Spoolman — the integration cannot function
     # in tag-only mode. Fail loud at config load so users don't discover this

--- a/middleware/happy_hare.py
+++ b/middleware/happy_hare.py
@@ -1,20 +1,31 @@
 """
 happy_hare.py — Happy Hare MMU integration (pull mode).
 
-Workflow for `action: happy_hare_stage` scanners:
-  1. User selects an MMU gate via `MMU_SELECT_GATE GATE=N` (Mainsail/LCD/console)
-  2. User scans a tag on the shared scanner
-  3. This module reads the currently-selected gate from Moonraker,
-     PATCHes the Spoolman spool's `extra.mmu_gate` and `extra.printer_name`,
-     then fires `MMU_SPOOLMAN SYNC=1` so Happy Hare picks up the binding
-     immediately rather than waiting for its next periodic pull
+Binding goes through Happy Hare's own primitive:
+
+    MMU_SPOOLMAN SPOOLID=<spool> GATE=<gate>
+
+which calls the mmu_server component's set_spool_gate — it validates the
+gate, unsets any other spool claiming that printer+gate, writes the
+`mmu_gate_map`/`printer_name` extras in the encoding HH expects, and
+updates HH's spool-location cache. The middleware deliberately does NOT
+write Spoolman extras itself: an earlier version PATCHed `extra.mmu_gate`
+directly, but HH reads `mmu_gate_map` (components/mmu_server.py
+MMU_GATE_FIELD) and json-decodes its values, so the direct write was
+invisible to every HH version.
+
+Flows:
+  - Physical scanner (`action: happy_hare_stage`): select a gate
+    (MMU_SELECT_GATE GATE=N), scan — binds to the selected gate.
+  - Mobile (`mobile.action: happy_hare_stage`): scan on the phone, pick a
+    gate from the app — binds to that gate, no selection needed.
 
 Pull-mode-only: Happy Hare exposes `spoolman_support` on its `printer.mmu`
 object. We query that on first use and refuse to bind in any other mode,
 since `MMU_GATE_MAP NEXT_SPOOLID=...` is the right path there.
 
-No background thread, no startup wiring — this is purely a synchronous
-helper called from the scan handler.
+Also hosts on_ws_mmu — the websocket follower for printer.mmu deltas that
+feeds the live gate into /api/status `active_tool`.
 """
 from __future__ import annotations
 
@@ -89,17 +100,13 @@ def _check_mode(mmu_status: dict) -> bool:
         return False
 
 
-def _bind_checks() -> tuple[str, dict] | None:
-    """Shared preconditions for any gate bind. Returns (printer_name,
-    mmu_status) when binding is possible, None otherwise (reason logged)."""
+def _bind_checks() -> dict | None:
+    """Shared preconditions for any gate bind (one printer.mmu fetch).
+    Returns the mmu status dict when binding is possible, None otherwise
+    (reason logged)."""
     happy_hare_cfg = app_state.cfg.get("happy_hare", {})
     if not happy_hare_cfg.get("enabled"):
         logger.debug("Happy Hare: bind skipped — integration not enabled")
-        return None
-
-    printer_name = happy_hare_cfg.get("printer_name", "")
-    if not printer_name:
-        logger.error("Happy Hare: bind skipped — happy_hare.printer_name is empty")
         return None
 
     mmu_status = _fetch_mmu_status()
@@ -114,27 +121,14 @@ def _bind_checks() -> tuple[str, dict] | None:
         logger.warning("Happy Hare: bind skipped — MMU reports enabled=false")
         return None
 
-    if app_state.spoolman_client is None:
-        logger.error("Happy Hare: bind skipped — Spoolman client not configured")
-        return None
-
-    return printer_name, mmu_status
+    return mmu_status
 
 
-def bind_spool_to_gate(gate: int, spool_id: int) -> bool:
-    """
-    Bind a spool to a specific MMU gate — no gate selection required. Used
-    by the mobile assign flow, where the phone picks the gate.
-
-    PATCHes the spool's `extra.mmu_gate` + `extra.printer_name`, then
-    triggers Happy Hare's Spoolman sync. Returns True on success, False on
-    any failure (with a logged reason).
-    """
-    checks = _bind_checks()
-    if checks is None:
-        return False
-    printer_name, mmu_status = checks
-
+def _bind_core(gate: int, spool_id: int, mmu_status: dict) -> bool:
+    """Validate the gate against the already-fetched mmu status and hand the
+    bind to Happy Hare's own set_spool_gate via gcode. HH validates again,
+    unsets any other spool on that printer+gate, writes the extras it
+    actually reads, and updates its cache — no Spoolman writes from here."""
     if isinstance(gate, bool) or not isinstance(gate, int) or gate < 0:
         logger.warning("Happy Hare: bind skipped — invalid gate %r", gate)
         return False
@@ -145,39 +139,44 @@ def bind_spool_to_gate(gate: int, spool_id: int) -> bool:
                        gate, num_gates)
         return False
 
-    extras = {
-        "mmu_gate": gate,
-        "printer_name": printer_name,
-    }
-    if not app_state.spoolman_client.update_spool_extras(spool_id, extras):
+    moonraker_url = app_state.cfg.get("moonraker_url", "")
+    if not moonraker_url:
+        logger.error("Happy Hare: bind skipped — moonraker_url not configured")
         return False
 
-    logger.info("Happy Hare: bound spool %s to gate %d on printer %r",
-                spool_id, gate, printer_name)
+    try:
+        send_gcode(moonraker_url, f"MMU_SPOOLMAN SPOOLID={spool_id} GATE={gate}")
+    except Exception:
+        logger.exception("Happy Hare: MMU_SPOOLMAN SPOOLID=%s GATE=%s failed",
+                         spool_id, gate)
+        return False
 
-    # Nudge Happy Hare to re-pull from Spoolman so the new binding is live
-    # immediately rather than on its next periodic sync.
-    moonraker_url = app_state.cfg.get("moonraker_url", "")
-    if moonraker_url:
-        try:
-            send_gcode(moonraker_url, "MMU_SPOOLMAN SYNC=1")
-        except Exception:
-            logger.exception("Happy Hare: bind succeeded but MMU_SPOOLMAN SYNC=1 failed; "
-                             "Happy Hare will pick up the binding on its next periodic pull")
-
+    logger.info("Happy Hare: bound spool %s to gate %d", spool_id, gate)
     return True
+
+
+def bind_spool_to_gate(gate: int, spool_id: int) -> bool:
+    """
+    Bind a spool to a specific MMU gate — no gate selection required. Used
+    by the mobile assign flow, where the phone picks the gate. Returns True
+    on success, False on any failure (with a logged reason).
+    """
+    mmu_status = _bind_checks()
+    if mmu_status is None:
+        return False
+    return _bind_core(gate, spool_id, mmu_status)
 
 
 def bind_spool_to_current_gate(spool_id: int) -> bool:
     """
     Bind a spool to whichever MMU gate is currently selected (the physical
-    select-then-scan flow). Returns True on success, False on any failure
+    select-then-scan flow). One printer.mmu fetch serves both the gate read
+    and the bind checks. Returns True on success, False on any failure
     (with a logged reason).
     """
-    checks = _bind_checks()
-    if checks is None:
+    mmu_status = _bind_checks()
+    if mmu_status is None:
         return False
-    _, mmu_status = checks
 
     gate = mmu_status.get("gate")
     if not isinstance(gate, int) or gate < 0:
@@ -185,7 +184,7 @@ def bind_spool_to_current_gate(spool_id: int) -> bool:
                        "Run MMU_SELECT_GATE GATE=N before scanning.", gate)
         return False
 
-    return bind_spool_to_gate(gate, spool_id)
+    return _bind_core(gate, spool_id, mmu_status)
 
 
 def on_ws_mmu(data: dict) -> None:

--- a/middleware/happy_hare.py
+++ b/middleware/happy_hare.py
@@ -189,22 +189,38 @@ def bind_spool_to_current_gate(spool_id: int) -> bool:
 
 def on_ws_mmu(data: dict) -> None:
     """
-    Websocket callback for printer.mmu deltas — tracks the live gate so
-    /api/status can report it as `active_tool` (the mobile staging board's
-    "printing" highlight). Happy Hare manages Spoolman's active spool itself
-    in pull mode, so this only updates local state: no gcode, no HTTP.
+    Websocket callback for printer.mmu deltas — feeds /api/status for the
+    mobile staging board. Happy Hare manages Spoolman itself in pull mode,
+    so this only updates local state: no gcode, no HTTP.
 
-    Gate values: >= 0 is a real gate; -1 (unknown/unloaded) and -2 (bypass)
-    map to None. Deltas are partial — an absent gate key means unchanged.
+    Two fields are mirrored (deltas are partial; absent key = unchanged):
+    - `gate` -> active_tool: >= 0 is a real gate; -1 (unknown/unloaded)
+      and -2 (bypass) map to None.
+    - `gate_spool_id` -> active_spools["G<i>"]: HH's authoritative per-gate
+      spool map, so occupancy reflects binds from ANY source (middleware,
+      MMU_GATE_MAP, HH UI). -1 means unassigned.
     """
-    if not isinstance(data, dict) or "gate" not in data:
+    if not isinstance(data, dict):
         return
+
     gate = data.get("gate")
-    if isinstance(gate, bool) or not isinstance(gate, int):
+    has_gate = ("gate" in data and not isinstance(gate, bool)
+                and isinstance(gate, int))
+    if "gate" in data and not has_gate:
         logger.debug("Happy Hare: ignoring non-integer mmu gate %r", gate)
+
+    spool_ids = data.get("gate_spool_id")
+    has_map = isinstance(spool_ids, list)
+
+    if not has_gate and not has_map:
         return
     with app_state.state_lock:
-        app_state.indx_active_tool = gate if gate >= 0 else None
+        if has_gate:
+            app_state.indx_active_tool = gate if gate >= 0 else None
+        if has_map:
+            for i, sid in enumerate(spool_ids):
+                valid = not isinstance(sid, bool) and isinstance(sid, int) and sid > 0
+                app_state.active_spools[f"G{i}"] = sid if valid else None
 
 
 def _reset_mode_cache_for_testing() -> None:

--- a/middleware/happy_hare.py
+++ b/middleware/happy_hare.py
@@ -89,51 +89,60 @@ def _check_mode(mmu_status: dict) -> bool:
         return False
 
 
-def bind_spool_to_current_gate(spool_id: int) -> bool:
-    """
-    Bind a spool to whichever MMU gate is currently selected.
-
-    Reads the current gate from Moonraker, PATCHes the spool's
-    `extra.mmu_gate` + `extra.printer_name`, then triggers Happy Hare's
-    Spoolman sync. Returns True on success, False on any failure
-    (with a logged reason).
-    """
+def _bind_checks() -> tuple[str, dict] | None:
+    """Shared preconditions for any gate bind. Returns (printer_name,
+    mmu_status) when binding is possible, None otherwise (reason logged)."""
     happy_hare_cfg = app_state.cfg.get("happy_hare", {})
     if not happy_hare_cfg.get("enabled"):
         logger.debug("Happy Hare: bind skipped — integration not enabled")
-        return False
+        return None
 
     printer_name = happy_hare_cfg.get("printer_name", "")
     if not printer_name:
         logger.error("Happy Hare: bind skipped — happy_hare.printer_name is empty")
-        return False
+        return None
 
     mmu_status = _fetch_mmu_status()
     if not mmu_status:
         logger.warning("Happy Hare: bind skipped — could not read printer.mmu from Moonraker")
-        return False
+        return None
 
     if not _check_mode(mmu_status):
-        return False
+        return None
 
     if not mmu_status.get("enabled", False):
         logger.warning("Happy Hare: bind skipped — MMU reports enabled=false")
-        return False
+        return None
 
-    gate = mmu_status.get("gate")
-    if not isinstance(gate, int) or gate < 0:
-        logger.warning("Happy Hare: bind skipped — no gate selected (got %r). "
-                       "Run MMU_SELECT_GATE GATE=N before scanning.", gate)
+    if app_state.spoolman_client is None:
+        logger.error("Happy Hare: bind skipped — Spoolman client not configured")
+        return None
+
+    return printer_name, mmu_status
+
+
+def bind_spool_to_gate(gate: int, spool_id: int) -> bool:
+    """
+    Bind a spool to a specific MMU gate — no gate selection required. Used
+    by the mobile assign flow, where the phone picks the gate.
+
+    PATCHes the spool's `extra.mmu_gate` + `extra.printer_name`, then
+    triggers Happy Hare's Spoolman sync. Returns True on success, False on
+    any failure (with a logged reason).
+    """
+    checks = _bind_checks()
+    if checks is None:
+        return False
+    printer_name, mmu_status = checks
+
+    if isinstance(gate, bool) or not isinstance(gate, int) or gate < 0:
+        logger.warning("Happy Hare: bind skipped — invalid gate %r", gate)
         return False
 
     num_gates = mmu_status.get("num_gates")
     if isinstance(num_gates, int) and gate >= num_gates:
         logger.warning("Happy Hare: bind skipped — gate %d out of range (num_gates=%d)",
                        gate, num_gates)
-        return False
-
-    if app_state.spoolman_client is None:
-        logger.error("Happy Hare: bind skipped — Spoolman client not configured")
         return False
 
     extras = {
@@ -157,6 +166,46 @@ def bind_spool_to_current_gate(spool_id: int) -> bool:
                              "Happy Hare will pick up the binding on its next periodic pull")
 
     return True
+
+
+def bind_spool_to_current_gate(spool_id: int) -> bool:
+    """
+    Bind a spool to whichever MMU gate is currently selected (the physical
+    select-then-scan flow). Returns True on success, False on any failure
+    (with a logged reason).
+    """
+    checks = _bind_checks()
+    if checks is None:
+        return False
+    _, mmu_status = checks
+
+    gate = mmu_status.get("gate")
+    if not isinstance(gate, int) or gate < 0:
+        logger.warning("Happy Hare: bind skipped — no gate selected (got %r). "
+                       "Run MMU_SELECT_GATE GATE=N before scanning.", gate)
+        return False
+
+    return bind_spool_to_gate(gate, spool_id)
+
+
+def on_ws_mmu(data: dict) -> None:
+    """
+    Websocket callback for printer.mmu deltas — tracks the live gate so
+    /api/status can report it as `active_tool` (the mobile staging board's
+    "printing" highlight). Happy Hare manages Spoolman's active spool itself
+    in pull mode, so this only updates local state: no gcode, no HTTP.
+
+    Gate values: >= 0 is a real gate; -1 (unknown/unloaded) and -2 (bypass)
+    map to None. Deltas are partial — an absent gate key means unchanged.
+    """
+    if not isinstance(data, dict) or "gate" not in data:
+        return
+    gate = data.get("gate")
+    if isinstance(gate, bool) or not isinstance(gate, int):
+        logger.debug("Happy Hare: ignoring non-integer mmu gate %r", gate)
+        return
+    with app_state.state_lock:
+        app_state.indx_active_tool = gate if gate >= 0 else None
 
 
 def _reset_mode_cache_for_testing() -> None:

--- a/middleware/happy_hare.py
+++ b/middleware/happy_hare.py
@@ -16,7 +16,7 @@ invisible to every HH version.
 
 Flows:
   - Physical scanner (`action: happy_hare_stage`): select a gate
-    (MMU_SELECT_GATE GATE=N), scan — binds to the selected gate.
+    (MMU_SELECT GATE=N), scan — binds to the selected gate.
   - Mobile (`mobile.action: happy_hare_stage`): scan on the phone, pick a
     gate from the app — binds to that gate, no selection needed.
 
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import logging
 import threading
+import time
 
 import app_state
 from moonraker_client import query_objects, send_gcode
@@ -38,6 +39,11 @@ from moonraker_client import query_objects, send_gcode
 logger = logging.getLogger(__name__)
 
 REQUIRED_MODE: str = "pull"
+
+# Bind confirmation: how long to wait for printer.mmu.gate_spool_id to
+# reflect a dispatched MMU_SPOOLMAN bind before calling it failed
+_CONFIRM_ATTEMPTS: int = 4
+_CONFIRM_DELAY_S: float = 0.5
 _KNOWN_MODES: frozenset[str] = frozenset({"pull", "push", "readonly"})
 
 # We cache only the success case (`pull`). Any other observed value re-fetches
@@ -151,8 +157,25 @@ def _bind_core(gate: int, spool_id: int, mmu_status: dict) -> bool:
                          spool_id, gate)
         return False
 
-    logger.info("Happy Hare: bound spool %s to gate %d", spool_id, gate)
-    return True
+    # The gcode dispatches to the moonraker component fire-and-forget, so
+    # acceptance is not success — a Spoolman outage inside set_spool_gate
+    # would otherwise report a bind that never happened (and the REST flow
+    # would drop the staged spool on the false positive). Confirm the gate
+    # map actually updated, briefly.
+    for _ in range(_CONFIRM_ATTEMPTS):
+        time.sleep(_CONFIRM_DELAY_S)
+        status = _fetch_mmu_status()
+        spool_ids = (status or {}).get("gate_spool_id")
+        if isinstance(spool_ids, list) and gate < len(spool_ids) \
+                and spool_ids[gate] == spool_id:
+            logger.info("Happy Hare: bound spool %s to gate %d", spool_id, gate)
+            return True
+
+    logger.error(
+        "Happy Hare: MMU_SPOOLMAN accepted but gate %d never showed spool %s "
+        "in printer.mmu.gate_spool_id — treating the bind as failed "
+        "(check moonraker.log for the mmu_server error)", gate, spool_id)
+    return False
 
 
 def bind_spool_to_gate(gate: int, spool_id: int) -> bool:
@@ -181,7 +204,7 @@ def bind_spool_to_current_gate(spool_id: int) -> bool:
     gate = mmu_status.get("gate")
     if not isinstance(gate, int) or gate < 0:
         logger.warning("Happy Hare: bind skipped — no gate selected (got %r). "
-                       "Run MMU_SELECT_GATE GATE=N before scanning.", gate)
+                       "Run MMU_SELECT GATE=N before scanning.", gate)
         return False
 
     return _bind_core(gate, spool_id, mmu_status)

--- a/middleware/moonraker_ws.py
+++ b/middleware/moonraker_ws.py
@@ -69,12 +69,14 @@ class MoonrakerWebsocket:
 
         # Objects discovered via printer.objects.list on each connect
         self._has_save_variables: bool = False
+        self._has_mmu: bool = False
 
         # Callbacks — set by consumers
         self.on_lane_update: Callable[[str, dict], None] | None = None
         self.on_assign_spool: Callable[[str], None] | None = None
         self.on_update_tag: Callable[[int], None] | None = None
         self.on_save_variables: Callable[[dict], None] | None = None
+        self.on_mmu: Callable[[dict], None] | None = None
 
     def set_lane_names(self, names: list[str]) -> None:
         """Set AFC lane names to subscribe to (e.g. ['lane1', 'lane2'])."""
@@ -193,9 +195,10 @@ class MoonrakerWebsocket:
                 logger.info("MoonrakerWebsocket: discovered AFC lanes: %s", discovered)
             else:
                 logger.info("MoonrakerWebsocket: no AFC lanes found — subscribing without AFC_stepper objects")
-            # Only subscribe to save_variables if Klipper actually has the
-            # section — subscribing to a missing object errors the request.
+            # Only subscribe to save_variables/mmu if Klipper actually has
+            # them — subscribing to a missing object errors the request.
             self._has_save_variables = "save_variables" in objects
+            self._has_mmu = "mmu" in objects
             self._send_subscribe(ws)
             return
 
@@ -245,6 +248,8 @@ class MoonrakerWebsocket:
         objects["gcode_macro UPDATE_TAG"] = None
         if self._has_save_variables and self.on_save_variables:
             objects["save_variables"] = None
+        if self._has_mmu and self.on_mmu:
+            objects["mmu"] = None
         return objects
 
     def _dispatch_status(self, status: dict) -> None:
@@ -265,3 +270,6 @@ class MoonrakerWebsocket:
                 variables = value.get("variables")
                 if isinstance(variables, dict):
                     self.on_save_variables(variables)
+            elif key == "mmu" and self.on_mmu:
+                if isinstance(value, dict):
+                    self.on_mmu(value)

--- a/middleware/rest_api.py
+++ b/middleware/rest_api.py
@@ -227,11 +227,19 @@ def mobile_scan(req: MobileScanRequest) -> ApiResponse:
     # writes to Spoolman, so the spool must exist there — resolve now and
     # tell the user at scan time rather than failing at assign time.
     if action == "happy_hare_stage":
-        spool_id = scan.scanner_spoolman_id
-        if spool_id is None and scan.uid and app_state.spoolman_client is not None:
+        # The UID is the authority: scanner_spoolman_id is a hint that can go
+        # stale when a tag is relinked to a different spool. Config requires
+        # spoolman_url for this action, so a missing client is a hard error.
+        spool_id: Optional[int] = None
+        if scan.uid and app_state.spoolman_client is not None:
             spool = app_state.spoolman_client.find_by_nfc(scan.uid)
             if spool:
                 spool_id = spool.get("id")
+                hint = scan.scanner_spoolman_id
+                if hint is not None and hint != spool_id:
+                    logger.info(
+                        f"[mobile] uid {scan.uid} resolves to spool {spool_id}; "
+                        f"ignoring stale payload id {hint}")
         if spool_id is None:
             return ApiResponse(
                 success=False,

--- a/middleware/rest_api.py
+++ b/middleware/rest_api.py
@@ -11,6 +11,7 @@ import json
 import logging
 import math
 import os
+import re
 import signal
 import subprocess
 import threading
@@ -222,6 +223,44 @@ def mobile_scan(req: MobileScanRequest) -> ApiResponse:
         )
         return ApiResponse(success=True, message=msg, pending=True, replaced=replaced)
 
+    # happy_hare_stage: cache as pending, phone picks a gate next. The bind
+    # writes to Spoolman, so the spool must exist there — resolve now and
+    # tell the user at scan time rather than failing at assign time.
+    if action == "happy_hare_stage":
+        spool_id = scan.scanner_spoolman_id
+        if spool_id is None and scan.uid and app_state.spoolman_client is not None:
+            spool = app_state.spoolman_client.find_by_nfc(scan.uid)
+            if spool:
+                spool_id = spool.get("id")
+        if spool_id is None:
+            return ApiResponse(
+                success=False,
+                message="Spool not found in Spoolman — register the tag first",
+            )
+        replaced = _cache_pending_spool(
+            "toolhead",
+            scan.color_hex or "FFFFFF",
+            scan.material_name or scan.material_type or "Unknown",
+            scan.remaining_weight_g,
+            spool_id,
+            scan.nozzle_temp_min_c,
+            scan.nozzle_temp_max_c,
+            scan.bed_temp_min_c,
+            scan.bed_temp_max_c,
+            uid=scan.uid,
+            device_id="",
+            diameter_mm=scan.diameter_mm,
+            density=scan.density,
+            tag_format=req.tag_format or scan.source,
+        )
+        msg = (
+            "Previous pending spool replaced — select a gate to assign"
+            if replaced
+            else "Spool cached — select a gate to assign"
+        )
+        return ApiResponse(success=True, message=msg, pending=True,
+                           replaced=replaced, spool_id=spool_id)
+
     # All other actions: activate immediately
     scanner_cfg: dict[str, Any] = {"action": action}
     if action == "toolhead":
@@ -259,11 +298,70 @@ def mobile_scan(req: MobileScanRequest) -> ApiResponse:
     )
 
 
+_GATE_NAME = re.compile(r"^G(\d+)$")
+
+
+def _assign_gate(req: AssignToolRequest) -> ApiResponse:
+    """Gate-targeted Happy Hare assignment: claim the staged spool, bind it
+    to the requested gate, restore the stage on failure. Same uid/409
+    machinery as the toolhead flow — the shipped app's status-code contract
+    is identical."""
+    toolheads = app_state.cfg.get("toolheads", [])
+    match = _GATE_NAME.match(req.toolhead.upper())
+    if not match or (toolheads and req.toolhead.upper() not in toolheads):
+        return ApiResponse(
+            success=False,
+            message=f"Invalid gate — available: {', '.join(toolheads) or 'none (set happy_hare.num_gates)'}",
+        )
+    gate = int(match.group(1))
+
+    with app_state.state_lock:
+        pending = app_state.pending_spool_toolhead
+        if not pending:
+            raise HTTPException(status_code=409, detail={
+                "code": "no_pending_spool",
+                "message": "No pending spool — scan a tag first",
+            })
+        if req.uid and req.uid.lower() != (pending.get("uid") or "").lower():
+            raise HTTPException(status_code=409, detail={
+                "code": "pending_spool_changed",
+                "message": "Pending spool changed since scan — rescan and try again",
+            })
+        # Claim it — unlike the toolhead flow there is no macro watcher; the
+        # endpoint is the consumer
+        app_state.pending_spool_toolhead = None
+
+    spool_id = pending.get("spoolman_id")
+    if spool_id is None:
+        # Staging requires a Spoolman id, so this should be unreachable —
+        # but never bind nothing
+        return ApiResponse(success=False, message="Staged spool has no Spoolman id — rescan")
+
+    from happy_hare import bind_spool_to_gate
+    if bind_spool_to_gate(gate, spool_id):
+        logger.info(f"[mobile] Bound spool {spool_id} to gate {gate}")
+        return ApiResponse(success=True,
+                           message=f"Spool bound to gate {gate}",
+                           action="happy_hare_stage",
+                           toolhead=req.toolhead.upper(),
+                           spool_id=spool_id)
+
+    # Failed bind — restore the stage unless a newer scan already took it
+    with app_state.state_lock:
+        if app_state.pending_spool_toolhead is None:
+            app_state.pending_spool_toolhead = pending
+    raise HTTPException(status_code=502,
+                        detail="Happy Hare bind failed — see middleware log")
+
+
 @app.post("/api/assign-tool", response_model=ApiResponse)
 def assign_tool(req: AssignToolRequest) -> ApiResponse:
     mobile_cfg = app_state.cfg.get("mobile", {})
     if not mobile_cfg.get("enabled"):
         raise HTTPException(status_code=503, detail="Mobile scanning not enabled")
+
+    if mobile_cfg.get("action") == "happy_hare_stage":
+        return _assign_gate(req)
 
     if mobile_cfg.get("action") != "toolhead_stage":
         return ApiResponse(success=False, message="assign-tool only valid for toolhead_stage mode")

--- a/middleware/rest_api.py
+++ b/middleware/rest_api.py
@@ -328,8 +328,10 @@ def _assign_gate(req: AssignToolRequest) -> ApiResponse:
                 "message": "Pending spool changed since scan — rescan and try again",
             })
         # Claim it — unlike the toolhead flow there is no macro watcher; the
-        # endpoint is the consumer
+        # endpoint is the consumer. Record the stage generation so a failed
+        # bind can tell "nothing changed" from "a newer scan came and went"
         app_state.pending_spool_toolhead = None
+        claimed_gen = app_state.pending_spool_toolhead_gen
 
     spool_id = pending.get("spoolman_id")
     if spool_id is None:
@@ -346,9 +348,14 @@ def _assign_gate(req: AssignToolRequest) -> ApiResponse:
                            toolhead=req.toolhead.upper(),
                            spool_id=spool_id)
 
-    # Failed bind — restore the stage unless a newer scan already took it
+    # Failed bind — restore the stage only if NOTHING was staged since the
+    # claim. An empty slot alone isn't enough: a newer scan could have been
+    # staged and consumed by a concurrent assign during our network call,
+    # and restoring then would resurrect a stale spool (assignable by
+    # legacy clients that omit the uid guard).
     with app_state.state_lock:
-        if app_state.pending_spool_toolhead is None:
+        if (app_state.pending_spool_toolhead is None
+                and app_state.pending_spool_toolhead_gen == claimed_gen):
             app_state.pending_spool_toolhead = pending
     raise HTTPException(status_code=502,
                         detail="Happy Hare bind failed — see middleware log")

--- a/middleware/spoolsense.py
+++ b/middleware/spoolsense.py
@@ -275,6 +275,14 @@ def _start_sync_services(use_ws: bool) -> None:
                 "Klipper variables will not sync until the websocket connects."
             )
 
+    # Happy Hare — follow the live gate on printer.mmu so /api/status can
+    # report it as active_tool (mobile staging board). Local state only.
+    if has_happy_hare_scanners(cfg) or cfg.get("mobile", {}).get("action") == "happy_hare_stage":
+        if use_ws:
+            from happy_hare import on_ws_mmu
+            app_state.moonraker_ws.on_mmu = on_ws_mmu
+            logger.info("Happy Hare: live gate tracking via websocket (printer.mmu)")
+
     app_state.filament_usage_sync.start(use_ws=use_ws)
 
     # Wire all websocket callbacks before starting the connection

--- a/middleware/tests/test_config.py
+++ b/middleware/tests/test_config.py
@@ -24,6 +24,7 @@ from config import (  # noqa: E402
     _apply_scanner_defaults,
     _validate_scanners,
     _validate_happy_hare,
+    _validate_mobile,
     _derive_toolheads,
     _migrate_legacy_config,
     has_afc_scanners,
@@ -387,6 +388,57 @@ class TestHasHappyHareScanners(unittest.TestCase):
 
     def test_returns_false_when_no_scanners(self):
         assert has_happy_hare_scanners({}) is False
+
+
+
+class TestHappyHareNumGates(unittest.TestCase):
+    """num_gates drives the mobile gate picker; strict validation."""
+
+    def _hh(self, **kw):
+        base = {"enabled": True, "printer_name": "muffin"}
+        base.update(kw)
+        return {"scanners": {}, "spoolman_url": "http://s:7912", "happy_hare": base}
+
+    def test_valid_num_gates_ok(self):
+        _validate_happy_hare(self._hh(num_gates=8))
+
+    def test_absent_num_gates_ok(self):
+        _validate_happy_hare(self._hh())
+
+    def test_invalid_num_gates_rejected(self):
+        for bad in (0, 33, -1, "four", True, 2.5):
+            with self.assertRaises(SystemExit, msg=f"accepted {bad!r}"):
+                _validate_happy_hare(self._hh(num_gates=bad))
+
+
+class TestMobileHappyHareAction(unittest.TestCase):
+    """mobile.action happy_hare_stage gating."""
+
+    def _cfg(self, scanners=None, hh_enabled=True):
+        return {
+            "scanners": scanners or {},
+            "happy_hare": {"enabled": hh_enabled, "printer_name": "muffin"},
+            "mobile": {"enabled": True, "action": "happy_hare_stage"},
+        }
+
+    def test_allowed_when_hh_enabled(self):
+        _validate_mobile(self._cfg())
+
+    def test_rejected_without_hh_enabled(self):
+        with self.assertRaises(SystemExit):
+            _validate_mobile(self._cfg(hh_enabled=False))
+
+    def test_rejected_with_toolhead_stage_scanners(self):
+        # Both flows stage into the same pending slot — the ASSIGN_SPOOL
+        # watcher would steal the HH-staged spool
+        with self.assertRaises(SystemExit):
+            _validate_mobile(self._cfg(
+                scanners={"abc": {"action": "toolhead_stage"}}))
+
+    def test_rejected_with_toolhead_scanners(self):
+        with self.assertRaises(SystemExit):
+            _validate_mobile(self._cfg(
+                scanners={"abc": {"action": "toolhead", "toolhead": "T0"}}))
 
 
 if __name__ == "__main__":

--- a/middleware/tests/test_config.py
+++ b/middleware/tests/test_config.py
@@ -414,12 +414,18 @@ class TestHappyHareNumGates(unittest.TestCase):
 class TestMobileHappyHareAction(unittest.TestCase):
     """mobile.action happy_hare_stage gating."""
 
-    def _cfg(self, scanners=None, hh_enabled=True):
-        return {
+    def _cfg(self, scanners=None, hh_enabled=True, spoolman="http://s:7912",
+             num_gates=4, toolheads=None):
+        cfg = {
             "scanners": scanners or {},
-            "happy_hare": {"enabled": hh_enabled, "printer_name": "muffin"},
+            "spoolman_url": spoolman,
+            "happy_hare": {"enabled": hh_enabled, "printer_name": "muffin",
+                           "num_gates": num_gates},
             "mobile": {"enabled": True, "action": "happy_hare_stage"},
         }
+        if toolheads:
+            cfg["toolheads"] = toolheads
+        return cfg
 
     def test_allowed_when_hh_enabled(self):
         _validate_mobile(self._cfg())
@@ -439,6 +445,59 @@ class TestMobileHappyHareAction(unittest.TestCase):
         with self.assertRaises(SystemExit):
             _validate_mobile(self._cfg(
                 scanners={"abc": {"action": "toolhead", "toolhead": "T0"}}))
+
+    def test_rejected_with_afc_scanners(self):
+        # AFC + publish_lane_data starts the ASSIGN_SPOOL consumer that
+        # would steal the HH-staged spool; lanes also suppress gate targets
+        with self.assertRaises(SystemExit):
+            _validate_mobile(self._cfg(
+                scanners={"abc": {"action": "afc_lane", "lane": "lane1"}}))
+
+    def test_allowed_with_hh_scanners(self):
+        _validate_mobile(self._cfg(
+            scanners={"abc": {"action": "happy_hare_stage"}}))
+
+    def test_rejected_without_spoolman_url(self):
+        with self.assertRaises(SystemExit):
+            _validate_mobile(self._cfg(spoolman=""))
+
+    def test_rejected_without_num_gates(self):
+        with self.assertRaises(SystemExit):
+            _validate_mobile(self._cfg(num_gates=None))
+
+    def test_rejected_with_explicit_toolheads(self):
+        with self.assertRaises(SystemExit):
+            _validate_mobile(self._cfg(toolheads=["T0", "T1"]))
+
+
+
+class TestGateDerivationEndToEnd(unittest.TestCase):
+    """load_config derives G0..G{n-1} for HH-mobile configs — the linchpin
+    of the phone gate picker, tested through the real loader."""
+
+    def _load(self, yaml_text):
+        import tempfile, config as config_mod
+        with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_text)
+            path = f.name
+        old = config_mod.CONFIG_PATH
+        config_mod.CONFIG_PATH = path
+        try:
+            return config_mod.load_config()
+        finally:
+            config_mod.CONFIG_PATH = old
+            os.unlink(path)
+
+    def test_hh_mobile_config_derives_gate_targets(self):
+        cfg = self._load(
+            "mqtt: {broker: b, port: 1883, username: '', password: ''}\n"
+            "spoolman_url: http://s:7912\n"
+            "moonraker_url: http://m:7125\n"
+            "scanners: {vethh: {action: happy_hare_stage}}\n"
+            "happy_hare: {enabled: true, num_gates: 3}\n"
+            "mobile: {enabled: true, action: happy_hare_stage}\n"
+        )
+        self.assertEqual(cfg["toolheads"], ["G0", "G1", "G2"])
 
 
 if __name__ == "__main__":

--- a/middleware/tests/test_happy_hare.py
+++ b/middleware/tests/test_happy_hare.py
@@ -290,6 +290,24 @@ class TestOnWsMmu(unittest.TestCase):
         happy_hare.on_ws_mmu({"filament": "loaded"})
         assert app_state.indx_active_tool == 2
 
+
+    def test_gate_spool_id_map_mirrors_occupancy(self):
+        app_state.active_spools = {}
+        happy_hare.on_ws_mmu({"gate_spool_id": [42, -1, 7, -1]})
+        assert app_state.active_spools == {"G0": 42, "G1": None, "G2": 7, "G3": None}
+
+    def test_gate_map_delta_without_gate_key_updates_occupancy_only(self):
+        app_state.active_spools = {}
+        app_state.indx_active_tool = 1
+        happy_hare.on_ws_mmu({"gate_spool_id": [5]})
+        assert app_state.active_spools["G0"] == 5
+        assert app_state.indx_active_tool == 1
+
+    def test_garbage_gate_map_entries_become_none(self):
+        app_state.active_spools = {}
+        happy_hare.on_ws_mmu({"gate_spool_id": [0, True, "x", 9]})
+        assert app_state.active_spools == {"G0": None, "G1": None, "G2": None, "G3": 9}
+
     def test_garbage_gate_ignored(self):
         app_state.indx_active_tool = 2
         happy_hare.on_ws_mmu({"gate": "three"})

--- a/middleware/tests/test_happy_hare.py
+++ b/middleware/tests/test_happy_hare.py
@@ -24,6 +24,7 @@ from happy_hare import bind_spool_to_current_gate  # noqa: E402
 
 
 def _reset(*, enabled=True, printer_name="muffin"):
+    happy_hare._CONFIRM_DELAY_S = 0.0
     app_state.cfg = {
         "moonraker_url": "http://moonraker:7125",
         "happy_hare": {"enabled": enabled, "printer_name": printer_name},
@@ -41,6 +42,9 @@ def _mmu_status(**overrides):
         "spoolman_support": "pull",
         "gate": 4,
         "num_gates": 8,
+        # Post-bind view used by the confirmation poll: gate 4 -> spool 42,
+        # gate 2 -> spool 7 (the ids the bind tests use)
+        "gate_spool_id": [-1, -1, 7, -1, 42, -1, -1, -1],
     }
     base.update(overrides)
     return base
@@ -71,13 +75,23 @@ class TestBindHappyPath(unittest.TestCase):
             "http://moonraker:7125", "MMU_SPOOLMAN SPOOLID=42 GATE=4")
         app_state.spoolman_client.update_spool_extras.assert_not_called()
 
-    def test_single_mmu_fetch_per_bind(self):
-        # The physical flow must not pay two printer.mmu round-trips
+    def test_single_precheck_fetch_per_bind(self):
+        # One precheck fetch + one confirmation poll — the old double
+        # precheck (checks run twice) must not come back
         with patch("moonraker_client.requests.get",
                    return_value=_mock_response(_mmu_status())) as mock_get, \
              patch("happy_hare.send_gcode"):
-            bind_spool_to_current_gate(spool_id=42)
-        assert mock_get.call_count == 1
+            assert bind_spool_to_current_gate(spool_id=42) is True
+        assert mock_get.call_count == 2
+
+    def test_unconfirmed_bind_reported_as_failure(self):
+        # Gate map never shows the spool (mmu_server failed downstream) —
+        # gcode acceptance alone must not count as success
+        stale = _mmu_status(gate_spool_id=[-1] * 8)
+        with patch("moonraker_client.requests.get",
+                   return_value=_mock_response(stale)), \
+             patch("happy_hare.send_gcode"):
+            assert bind_spool_to_current_gate(spool_id=42) is False
 
     def test_gcode_failure_fails_bind(self):
         # The gcode IS the bind now — if it fails, nothing happened
@@ -195,9 +209,9 @@ class TestModeCheckCaching(unittest.TestCase):
         with patch("moonraker_client.requests.get",
                    return_value=_mock_response(_mmu_status())) as mock_get, \
              patch("happy_hare.send_gcode"):
-            assert bind_spool_to_current_gate(spool_id=1) is True
+            assert bind_spool_to_current_gate(spool_id=42) is True
             first_call_count = mock_get.call_count
-            assert bind_spool_to_current_gate(spool_id=2) is True
+            assert bind_spool_to_current_gate(spool_id=42) is True
             # We expect a second call (the bind path always fetches gate info)
             # but the mode-check shouldn't add an extra one — the assertion is
             # cleaner via the public flag.
@@ -216,7 +230,7 @@ class TestModeCheckCaching(unittest.TestCase):
         with patch("moonraker_client.requests.get",
                    return_value=_mock_response(_mmu_status(spoolman_support="pull"))), \
              patch("happy_hare.send_gcode"):
-            assert bind_spool_to_current_gate(spool_id=1) is True
+            assert bind_spool_to_current_gate(spool_id=42) is True
         assert happy_hare._cached_pull_mode is True
 
     def test_missing_spoolman_support_field_does_not_cache(self):

--- a/middleware/tests/test_happy_hare.py
+++ b/middleware/tests/test_happy_hare.py
@@ -222,5 +222,71 @@ class TestModeCheckCaching(unittest.TestCase):
         assert happy_hare._cached_pull_mode is False
 
 
+
+class TestBindSpoolToGate(unittest.TestCase):
+    """Gate-targeted bind (mobile assign flow) — no gate selection needed."""
+
+    def setUp(self):
+        _reset()
+
+    def test_binds_explicit_gate_ignoring_current_selection(self):
+        # Current gate is -1 (nothing selected) — explicit target still binds
+        with patch("moonraker_client.requests.get",
+                   return_value=_mock_response(_mmu_status(gate=-1))), \
+             patch("happy_hare.send_gcode") as mock_gcode:
+            assert happy_hare.bind_spool_to_gate(2, spool_id=7) is True
+        app_state.spoolman_client.update_spool_extras.assert_called_once_with(
+            7, {"mmu_gate": 2, "printer_name": "muffin"})
+        assert any("MMU_SPOOLMAN SYNC=1" in str(c) for c in mock_gcode.call_args_list)
+
+    def test_gate_out_of_range_rejected(self):
+        with patch("moonraker_client.requests.get",
+                   return_value=_mock_response(_mmu_status(num_gates=4))):
+            assert happy_hare.bind_spool_to_gate(4, spool_id=7) is False
+        app_state.spoolman_client.update_spool_extras.assert_not_called()
+
+    def test_negative_and_bool_gates_rejected(self):
+        with patch("moonraker_client.requests.get",
+                   return_value=_mock_response(_mmu_status())):
+            assert happy_hare.bind_spool_to_gate(-1, spool_id=7) is False
+            assert happy_hare.bind_spool_to_gate(True, spool_id=7) is False
+
+    def test_wrong_mode_rejected(self):
+        with patch("moonraker_client.requests.get",
+                   return_value=_mock_response(_mmu_status(spoolman_support="push"))):
+            assert happy_hare.bind_spool_to_gate(1, spool_id=7) is False
+
+
+class TestOnWsMmu(unittest.TestCase):
+    """printer.mmu deltas drive the active_tool marker for /api/status."""
+
+    def setUp(self):
+        _reset()
+        app_state.indx_active_tool = None
+
+    def test_gate_pickup_sets_active_tool(self):
+        happy_hare.on_ws_mmu({"gate": 3})
+        assert app_state.indx_active_tool == 3
+
+    def test_unknown_and_bypass_map_to_none(self):
+        app_state.indx_active_tool = 3
+        happy_hare.on_ws_mmu({"gate": -1})
+        assert app_state.indx_active_tool is None
+        app_state.indx_active_tool = 3
+        happy_hare.on_ws_mmu({"gate": -2})
+        assert app_state.indx_active_tool is None
+
+    def test_absent_gate_key_leaves_state_unchanged(self):
+        app_state.indx_active_tool = 2
+        happy_hare.on_ws_mmu({"filament": "loaded"})
+        assert app_state.indx_active_tool == 2
+
+    def test_garbage_gate_ignored(self):
+        app_state.indx_active_tool = 2
+        happy_hare.on_ws_mmu({"gate": "three"})
+        happy_hare.on_ws_mmu({"gate": True})
+        assert app_state.indx_active_tool == 2
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/middleware/tests/test_happy_hare.py
+++ b/middleware/tests/test_happy_hare.py
@@ -59,28 +59,41 @@ class TestBindHappyPath(unittest.TestCase):
     def setUp(self):
         _reset()
 
-    def test_bind_patches_spoolman_with_gate_and_printer_name(self):
-        with patch("moonraker_client.requests.get", return_value=_mock_response(_mmu_status())), \
-             patch("happy_hare.send_gcode"):
-            result = bind_spool_to_current_gate(spool_id=42)
-        assert result is True
-        app_state.spoolman_client.update_spool_extras.assert_called_once_with(
-            42, {"mmu_gate": 4, "printer_name": "muffin"}
-        )
-
-    def test_bind_fires_mmu_spoolman_sync(self):
+    def test_bind_sends_mmu_spoolman_spoolid_gate(self):
+        # Binding goes through HH's own set_spool_gate primitive — the
+        # middleware must NOT write Spoolman extras itself (the old direct
+        # PATCH wrote extra.mmu_gate, a key no HH version reads)
         with patch("moonraker_client.requests.get", return_value=_mock_response(_mmu_status())), \
              patch("happy_hare.send_gcode") as mock_gcode:
-            bind_spool_to_current_gate(spool_id=42)
-        mock_gcode.assert_called_once_with("http://moonraker:7125", "MMU_SPOOLMAN SYNC=1")
+            result = bind_spool_to_current_gate(spool_id=42)
+        assert result is True
+        mock_gcode.assert_called_once_with(
+            "http://moonraker:7125", "MMU_SPOOLMAN SPOOLID=42 GATE=4")
+        app_state.spoolman_client.update_spool_extras.assert_not_called()
 
-    def test_bind_sync_failure_does_not_fail_overall_bind(self):
-        # The PATCH already landed; a missing sync just means Happy Hare
-        # picks it up on the next periodic pull. Still report success.
+    def test_single_mmu_fetch_per_bind(self):
+        # The physical flow must not pay two printer.mmu round-trips
+        with patch("moonraker_client.requests.get",
+                   return_value=_mock_response(_mmu_status())) as mock_get, \
+             patch("happy_hare.send_gcode"):
+            bind_spool_to_current_gate(spool_id=42)
+        assert mock_get.call_count == 1
+
+    def test_gcode_failure_fails_bind(self):
+        # The gcode IS the bind now — if it fails, nothing happened
         with patch("moonraker_client.requests.get", return_value=_mock_response(_mmu_status())), \
              patch("happy_hare.send_gcode", side_effect=Exception("boom")):
             result = bind_spool_to_current_gate(spool_id=42)
+        assert result is False
+
+    def test_bind_works_without_spoolman_client(self):
+        # HH talks to Spoolman itself; the middleware needs no client to bind
+        app_state.spoolman_client = None
+        with patch("moonraker_client.requests.get", return_value=_mock_response(_mmu_status())), \
+             patch("happy_hare.send_gcode") as mock_gcode:
+            result = bind_spool_to_current_gate(spool_id=42)
         assert result is True
+        mock_gcode.assert_called_once()
 
 
 class TestBindGuards(unittest.TestCase):
@@ -98,12 +111,14 @@ class TestBindGuards(unittest.TestCase):
         assert result is False
         self._assert_no_patch_called()
 
-    def test_skipped_when_printer_name_empty(self):
+    def test_empty_printer_name_no_longer_blocks_bind(self):
+        # printer_name is legacy config — HH stamps its own printer identity
         _reset(printer_name="")
-        with patch("moonraker_client.requests.get", return_value=_mock_response(_mmu_status())):
+        with patch("moonraker_client.requests.get", return_value=_mock_response(_mmu_status())), \
+             patch("happy_hare.send_gcode") as mock_gcode:
             result = bind_spool_to_current_gate(spool_id=42)
-        assert result is False
-        self._assert_no_patch_called()
+        assert result is True
+        mock_gcode.assert_called_once()
 
     def test_skipped_when_moonraker_unreachable(self):
         import requests
@@ -154,12 +169,6 @@ class TestBindGuards(unittest.TestCase):
             result = bind_spool_to_current_gate(spool_id=42)
         assert result is False
 
-    def test_returns_false_when_spoolman_patch_fails(self):
-        app_state.spoolman_client.update_spool_extras = MagicMock(return_value=False)
-        with patch("moonraker_client.requests.get", return_value=_mock_response(_mmu_status())), \
-             patch("happy_hare.send_gcode"):
-            result = bind_spool_to_current_gate(spool_id=42)
-        assert result is False
 
 
 class TestModeCheckCaching(unittest.TestCase):
@@ -235,9 +244,9 @@ class TestBindSpoolToGate(unittest.TestCase):
                    return_value=_mock_response(_mmu_status(gate=-1))), \
              patch("happy_hare.send_gcode") as mock_gcode:
             assert happy_hare.bind_spool_to_gate(2, spool_id=7) is True
-        app_state.spoolman_client.update_spool_extras.assert_called_once_with(
-            7, {"mmu_gate": 2, "printer_name": "muffin"})
-        assert any("MMU_SPOOLMAN SYNC=1" in str(c) for c in mock_gcode.call_args_list)
+        mock_gcode.assert_called_once_with(
+            "http://moonraker:7125", "MMU_SPOOLMAN SPOOLID=7 GATE=2")
+        app_state.spoolman_client.update_spool_extras.assert_not_called()
 
     def test_gate_out_of_range_rejected(self):
         with patch("moonraker_client.requests.get",

--- a/middleware/tests/test_moonraker_ws.py
+++ b/middleware/tests/test_moonraker_ws.py
@@ -203,6 +203,33 @@ class TestMoonrakerWebsocket(unittest.TestCase):
         self.ws._has_save_variables = True
         self.assertNotIn("save_variables", self.ws._build_subscribe_objects())
 
+
+    def test_mmu_subscribed_when_discovered_and_callback_set(self):
+        self.ws.on_mmu = lambda data: None
+        self.ws._has_mmu = True
+        self.assertIn("mmu", self.ws._build_subscribe_objects())
+
+    def test_mmu_not_subscribed_when_not_discovered(self):
+        self.ws.on_mmu = lambda data: None
+        self.ws._has_mmu = False
+        self.assertNotIn("mmu", self.ws._build_subscribe_objects())
+
+    def test_mmu_not_subscribed_without_callback(self):
+        self.ws._has_mmu = True
+        self.assertNotIn("mmu", self.ws._build_subscribe_objects())
+
+    def test_dispatch_routes_mmu_delta(self):
+        received = []
+        self.ws.on_mmu = received.append
+        self.ws._dispatch_status({"mmu": {"gate": 2}})
+        self.assertEqual(received, [{"gate": 2}])
+
+    def test_dispatch_skips_non_dict_mmu(self):
+        received = []
+        self.ws.on_mmu = received.append
+        self.ws._dispatch_status({"mmu": "garbage"})
+        self.assertEqual(received, [])
+
     def test_objects_list_discovers_save_variables(self):
         """printer.objects.list response records save_variables availability."""
         mock_ws = MagicMock()

--- a/middleware/tests/test_rest_api.py
+++ b/middleware/tests/test_rest_api.py
@@ -436,6 +436,130 @@ class TestUnlockTarget(unittest.TestCase):
         self.assertTrue(app_state.lane_locks["lane1"])
 
 
+class TestMobileScanHappyHare(unittest.TestCase):
+    """mobile.action happy_hare_stage: scan stages for the gate picker (#82/#91
+    HH-for-mobile). The bind writes to Spoolman, so scans resolve the spool
+    at scan time and reject unknown tags with a visible message."""
+
+    def setUp(self):
+        _reset_app_state(mobile_enabled=True, mobile_action="happy_hare_stage")
+        app_state.cfg["happy_hare"] = {"enabled": True, "printer_name": "muffin",
+                                       "num_gates": 4}
+        app_state.cfg["toolheads"] = ["G0", "G1", "G2", "G3"]
+
+    def _post(self, payload):
+        return client.post("/api/mobile-scan", json=payload)
+
+    def test_scan_with_spoolman_id_stages(self):
+        scan = _make_scan_event(uid="AABB11")
+        scan.scanner_spoolman_id = 42
+        with patch("rest_api.detect_and_parse", return_value=scan):
+            resp = self._post({"uid": "AABB11", "present": True,
+                               "tag_data_valid": True, "spoolman_id": 42})
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.json()["success"])
+        self.assertTrue(resp.json()["pending"])
+        self.assertEqual(resp.json()["spool_id"], 42)
+        self.assertEqual(app_state.pending_spool_toolhead["spoolman_id"], 42)
+        self.assertEqual(app_state.pending_spool_toolhead["uid"], "AABB11")
+
+    def test_scan_without_id_resolves_via_spoolman_lookup(self):
+        scan = _make_scan_event(uid="AABB11")
+        scan.scanner_spoolman_id = None
+        app_state.spoolman_client = MagicMock()
+        app_state.spoolman_client.find_by_nfc.return_value = {"id": 7}
+        with patch("rest_api.detect_and_parse", return_value=scan):
+            resp = self._post({"uid": "AABB11", "present": True,
+                               "tag_data_valid": True})
+        self.assertTrue(resp.json()["success"])
+        self.assertEqual(app_state.pending_spool_toolhead["spoolman_id"], 7)
+
+    def test_unknown_spool_rejected_with_message(self):
+        scan = _make_scan_event(uid="AABB11")
+        scan.scanner_spoolman_id = None
+        app_state.spoolman_client = MagicMock()
+        app_state.spoolman_client.find_by_nfc.return_value = None
+        with patch("rest_api.detect_and_parse", return_value=scan):
+            resp = self._post({"uid": "AABB11", "present": True,
+                               "tag_data_valid": True})
+        self.assertEqual(resp.status_code, 200)
+        self.assertFalse(resp.json()["success"])
+        self.assertIn("Spoolman", resp.json()["message"])
+        self.assertIsNone(app_state.pending_spool_toolhead)
+
+
+class TestAssignGate(unittest.TestCase):
+    """Gate-targeted assign for happy_hare_stage — same uid/409 contract as
+    the toolhead flow; the endpoint itself consumes the stage and restores
+    it on a failed bind."""
+
+    def setUp(self):
+        _reset_app_state(mobile_enabled=True, mobile_action="happy_hare_stage")
+        app_state.cfg["happy_hare"] = {"enabled": True, "printer_name": "muffin",
+                                       "num_gates": 4}
+        app_state.cfg["toolheads"] = ["G0", "G1", "G2", "G3"]
+        self.pending = {"spoolman_id": 42, "uid": "AABB11", "color_hex": "FF0000",
+                        "material": "PLA", "remaining_g": 500.0}
+        app_state.pending_spool_toolhead = dict(self.pending)
+
+    def _assign(self, toolhead="G1", uid="AABB11"):
+        body = {"toolhead": toolhead}
+        if uid is not None:
+            body["uid"] = uid
+        return client.post("/api/assign-tool", json=body)
+
+    def test_assign_binds_and_consumes_stage(self):
+        with patch("happy_hare.bind_spool_to_gate", return_value=True) as mock_bind:
+            resp = self._assign("G1")
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.json()["success"])
+        self.assertEqual(resp.json()["toolhead"], "G1")
+        self.assertEqual(resp.json()["spool_id"], 42)
+        mock_bind.assert_called_once_with(1, 42)
+        self.assertIsNone(app_state.pending_spool_toolhead)
+
+    def test_lowercase_gate_name_accepted(self):
+        with patch("happy_hare.bind_spool_to_gate", return_value=True) as mock_bind:
+            resp = self._assign("g2")
+        self.assertTrue(resp.json()["success"])
+        mock_bind.assert_called_once_with(2, 42)
+
+    def test_no_pending_returns_409(self):
+        app_state.pending_spool_toolhead = None
+        resp = self._assign("G1")
+        self.assertEqual(resp.status_code, 409)
+        self.assertEqual(resp.json()["detail"]["code"], "no_pending_spool")
+
+    def test_stale_uid_returns_409_and_keeps_stage(self):
+        resp = self._assign("G1", uid="DIFFERENT")
+        self.assertEqual(resp.status_code, 409)
+        self.assertEqual(resp.json()["detail"]["code"], "pending_spool_changed")
+        self.assertIsNotNone(app_state.pending_spool_toolhead)
+
+    def test_invalid_gate_name_rejected(self):
+        for bad in ("T0", "G9", "gate1"):
+            resp = self._assign(bad)
+            self.assertEqual(resp.status_code, 200, bad)
+            self.assertFalse(resp.json()["success"], bad)
+        self.assertIsNotNone(app_state.pending_spool_toolhead)
+
+    def test_failed_bind_restores_stage_and_returns_502(self):
+        with patch("happy_hare.bind_spool_to_gate", return_value=False):
+            resp = self._assign("G1")
+        self.assertEqual(resp.status_code, 502)
+        self.assertEqual(app_state.pending_spool_toolhead["spoolman_id"], 42)
+
+    def test_failed_bind_does_not_overwrite_newer_scan(self):
+        newer = {"spoolman_id": 99, "uid": "CCDD22"}
+        def bind_and_stage(gate, spool_id):
+            app_state.pending_spool_toolhead = newer
+            return False
+        with patch("happy_hare.bind_spool_to_gate", side_effect=bind_and_stage):
+            resp = self._assign("G1")
+        self.assertEqual(resp.status_code, 502)
+        self.assertIs(app_state.pending_spool_toolhead, newer)
+
+
 class TestDeductionApplied(unittest.TestCase):
     """POST /api/deductions/{uid}/applied — legacy full clear (empty body,
     shipped mobile 1.0.0) and partial acknowledgment via applied_g (#94)."""

--- a/middleware/tests/test_rest_api.py
+++ b/middleware/tests/test_rest_api.py
@@ -451,9 +451,11 @@ class TestMobileScanHappyHare(unittest.TestCase):
     def _post(self, payload):
         return client.post("/api/mobile-scan", json=payload)
 
-    def test_scan_with_spoolman_id_stages(self):
+    def test_scan_stages_with_uid_resolved_spool(self):
         scan = _make_scan_event(uid="AABB11")
         scan.scanner_spoolman_id = 42
+        app_state.spoolman_client = MagicMock()
+        app_state.spoolman_client.find_by_nfc.return_value = {"id": 42}
         with patch("rest_api.detect_and_parse", return_value=scan):
             resp = self._post({"uid": "AABB11", "present": True,
                                "tag_data_valid": True, "spoolman_id": 42})
@@ -463,6 +465,19 @@ class TestMobileScanHappyHare(unittest.TestCase):
         self.assertEqual(resp.json()["spool_id"], 42)
         self.assertEqual(app_state.pending_spool_toolhead["spoolman_id"], 42)
         self.assertEqual(app_state.pending_spool_toolhead["uid"], "AABB11")
+
+    def test_uid_resolution_beats_stale_payload_id(self):
+        # A relinked tag: payload still carries the OLD spool id — the uid
+        # lookup is authoritative and must win
+        scan = _make_scan_event(uid="AABB11")
+        scan.scanner_spoolman_id = 42
+        app_state.spoolman_client = MagicMock()
+        app_state.spoolman_client.find_by_nfc.return_value = {"id": 77}
+        with patch("rest_api.detect_and_parse", return_value=scan):
+            resp = self._post({"uid": "AABB11", "present": True,
+                               "tag_data_valid": True, "spoolman_id": 42})
+        self.assertEqual(resp.json()["spool_id"], 77)
+        self.assertEqual(app_state.pending_spool_toolhead["spoolman_id"], 77)
 
     def test_scan_without_id_resolves_via_spoolman_lookup(self):
         scan = _make_scan_event(uid="AABB11")

--- a/middleware/tests/test_rest_api.py
+++ b/middleware/tests/test_rest_api.py
@@ -69,6 +69,7 @@ def _reset_app_state(
     app_state.active_spools = {}
     app_state.pending_spool_afc = None
     app_state.pending_spool_toolhead = None
+    app_state.pending_spool_toolhead_gen = 0
     app_state.state_lock = threading.Lock()
     import tempfile
     app_state.TRACKING_FILE = os.path.join(tempfile.gettempdir(), "ss-test-tracking.json")
@@ -553,11 +554,26 @@ class TestAssignGate(unittest.TestCase):
         newer = {"spoolman_id": 99, "uid": "CCDD22"}
         def bind_and_stage(gate, spool_id):
             app_state.pending_spool_toolhead = newer
+            app_state.pending_spool_toolhead_gen += 1
             return False
         with patch("happy_hare.bind_spool_to_gate", side_effect=bind_and_stage):
             resp = self._assign("G1")
         self.assertEqual(resp.status_code, 502)
         self.assertIs(app_state.pending_spool_toolhead, newer)
+
+    def test_failed_bind_does_not_resurrect_consumed_newer_scan(self):
+        # ABA: during our slow failing bind, a newer scan is staged AND
+        # consumed by a concurrent assign — the slot is None again, but
+        # restoring our stale claim would resurrect a ghost spool
+        def bind_stage_and_consume(gate, spool_id):
+            app_state.pending_spool_toolhead = {"spoolman_id": 99, "uid": "CCDD22"}
+            app_state.pending_spool_toolhead_gen += 1
+            app_state.pending_spool_toolhead = None   # concurrent assign consumed it
+            return False
+        with patch("happy_hare.bind_spool_to_gate", side_effect=bind_stage_and_consume):
+            resp = self._assign("G1")
+        self.assertEqual(resp.status_code, 502)
+        self.assertIsNone(app_state.pending_spool_toolhead)
 
 
 class TestDeductionApplied(unittest.TestCase):


### PR DESCRIPTION
Happy Hare support for the mobile app, plus a fix for the shipped binding path that review showed was never functional.

## The shipped-bind fix

The existing integration PATCHed `extra.mmu_gate` on the spool, but every Happy Hare version reads `mmu_gate_map` (components/mmu_server.py `MMU_GATE_FIELD`) and json-decodes its values, and `MMU_SPOOLMAN SYNC=1` only republishes HH's in-memory cache — the write was invisible to HH end-to-end. Binding now goes through HH's own primitive, `MMU_SPOOLMAN SPOOLID=<id> GATE=<n>` (`set_spool_gate`), which validates the gate, unsets any other spool claiming that printer+gate, writes the fields HH actually reads, and updates its cache. This fixes the physical select-then-scan flow as well as enabling the new mobile flow. `happy_hare.printer_name` becomes legacy/optional — HH stamps its own printer identity — and no Spoolman client is needed to bind. Both flows share one `printer.mmu` fetch.

## Mobile support (new)

- **Gate targets** — `happy_hare.num_gates` derives `G0..G{n-1}` into `toolheads`, feeding the app's picker and staging board via `/api/config`.
- **Staged gate assignment** — `mobile.action: happy_hare_stage`: a phone scan resolves the uid against Spoolman (uid is authoritative over the payload's spool-id hint, which can go stale on relink), stages the spool, and `POST /api/assign-tool {"toolhead": "G2"}` binds it to that gate. Identical uid/409 contract to the toolhead flow; a failed bind restores the stage, guarded by a stage-generation counter so a stale spool is never resurrected after a newer scan was staged and consumed mid-flight.
- **Live status** — the websocket subscribes `printer.mmu` (presence-gated): `gate` feeds `active_tool` (−1/−2 map to null) and HH's authoritative `gate_spool_id` map mirrors into `active_spools["G<i>"]`, so gate occupancy reflects binds from any source.
- **Strict config validation** — mobile HH requires `num_gates` + `spoolman_url`, allows only `happy_hare_stage` scanners (anything else starts a competing pending-slot consumer or suppresses gate derivation), rejects an explicit `toolheads` list, and malformed `happy_hare:` sections fail as clean config errors instead of tracebacks.

## Testing

641 tests passing (44 new across config validation, the bind primitive, ws mirroring, staging, gate assignment, and the restore race); flake8 clean. Reviewed by a 38-agent adversarial multi-lens pass plus three Codex rounds; every finding fixed with a regression test or refuted with evidence (two refutations verified against upstream Klipper/Moonraker behavior, one live against the printer). The bind primitive was verified against upstream Happy Hare source. Not live-tested — no HH hardware available; flagged in the docs.

Contributes to #91-adjacent mobile parity; the corresponding mobile-side note lives in the spoolsense-mobile repo docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Happy Hare staging support for mobile spool assignment and gate selection.
  * Added live Happy Hare gate and tool-state updates through Moonraker WebSocket connections.
  * Happy Hare bindings now use its native pull-mode workflow.
  * Automatically derives assignable gates from the configured gate count.
* **Bug Fixes**
  * Prevented stale staged spool data from being restored after overlapping or failed assignments.
* **Documentation**
  * Updated Happy Hare setup guidance and configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->