### PR TITLE
Release v1.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,47 @@ All notable changes to SpoolSense are documented here.
 
 ---
 
+## [1.8.6] - 2026-07-18
+
+### Added
+
+- **Happy Hare from the mobile app** — with `mobile.action: happy_hare_stage`
+  and `happy_hare.num_gates`, the app's picker shows gates `G0..G{n-1}`:
+  scan a tag on the phone, pick a gate, done — no `MMU_SELECT` on the
+  printer needed. The scanned uid is resolved against Spoolman (a stale
+  spool-id on the tag is ignored), assignments use the same stale-scan
+  guard as toolchangers, and a failed bind restores the staged spool so a
+  retry is a plain re-tap. `/api/status` now reports the live MMU gate as
+  `active_tool` and per-gate occupancy in `active_spools`, mirrored from
+  Happy Hare's own gate map. (#117)
+
+- **Staged scans record deduction baselines** — spools assigned via
+  ASSIGN_SPOOL (toolhead_stage) or staged AFC loads now get an UPDATE_TAG
+  deduction baseline, previously exclusive to dedicated toolhead/afc_lane
+  scanners. A failed ASSIGN_SPOOL assignment no longer loses the staged
+  spool — it is restored unless a newer scan replaced it. (#108, #109)
+
+### Fixed
+
+- **Happy Hare binding never actually worked** — the middleware wrote a
+  Spoolman field (`mmu_gate`) that no Happy Hare version reads (HH uses
+  `mmu_gate_map`), so scan-to-gate bindings silently never reached Happy
+  Hare. Binding now goes through HH's own `MMU_SPOOLMAN SPOOLID=<id>
+  GATE=<n>`, which also cleans up any previous spool on that gate, and
+  the middleware confirms the gate map actually updated before reporting
+  success. `happy_hare.printer_name` is no longer required. Docs also
+  referenced `MMU_SELECT_GATE`, which does not exist — the command is
+  `MMU_SELECT GATE=N`. (#117)
+
+- **AFC staged-load edge cases** — Spoolman-backed staged loads in polling
+  mode never consumed the staged data (load and spool id arrive in the
+  same poll); a lane loading a different spool could consume a staged one;
+  partial websocket deltas and AFC's `0`/null spool-id conventions are now
+  honored throughout; unloads clear deduction baselines for tag-only lanes
+  that never lock. (#116)
+
+---
+
 ## [1.8.5] - 2026-07-18
 
 ### Added

--- a/docs/klipper-setup.md
+++ b/docs/klipper-setup.md
@@ -106,6 +106,37 @@ gcode:
   {% endif %}
 ```
 
+## Bondtech INDX
+
+INDX on Klipper presents as a plain toolchanger (T0–T9), so the setup is the
+toolchanger flow above with one shared scanner instead of one per tool. Start
+from `middleware/config.example.indx.yaml`.
+
+What you need in `printer.cfg`:
+
+- The `ASSIGN_SPOOL` and `UPDATE_TAG` macros from the SpoolSense macro set
+- `variable_spool_id: None` on each tool macro (`T0`..`Tn`), exactly as in
+  the toolchanger section above
+- The `RESTORE_SPOOL_IDS` delayed gcode so assignments survive reboots
+
+Workflow: scan a spool on the shared scanner, then assign it to a tool with
+the keypad, web UI, mobile app, or `ASSIGN_SPOOL TOOL=Tn` in the console.
+
+Two things work automatically on INDX:
+
+- **Per-tool deduction** — Bondtech's macros do not create Klipper `tool`
+  objects, so `UPDATE_TAG` uses the slicer's per-tool filament weights from
+  the job metadata. Nothing extra to install, but your slicer must write
+  per-tool filament usage into the gcode (OrcaSlicer and PrusaSlicer do);
+  without that metadata the deduction is skipped.
+- **Live active-spool sync** — INDX records the mounted tool in
+  `save_variables.active_tool`; on every tool pickup the middleware switches
+  Spoolman's active spool to the spool assigned to that tool, so usage
+  accrues to the spool actually printing. If the picked tool has no spool
+  assigned (or the head is parked), Spoolman is left unchanged, so usage
+  keeps accruing to the previously active spool until the next assigned
+  pickup. Disable with `active_tool_sync: false` in `config.yaml`.
+
 ## Restart Klipper
 
 ```bash

--- a/middleware/activation.py
+++ b/middleware/activation.py
@@ -63,9 +63,19 @@ def _cache_pending_spool(
     color_hex: str, material: str, remaining: float | None, spoolman_id: int | None,
     nozzle_temp_min: int | None = None, nozzle_temp_max: int | None = None,
     bed_temp_min: int | None = None, bed_temp_max: int | None = None,
-) -> None:
+    uid: str | None = None, device_id: str = "",
+    diameter_mm: float | None = None, density: float | None = None,
+    tag_format: str | None = None,
+) -> bool:
     """Store tag data in the per-consumer pending slot ("afc" is consumed by
-    afc_status on lane load; "toolhead" by toolchanger_status on ASSIGN_SPOOL)."""
+    afc_status on lane load; "toolhead" by toolchanger_status on ASSIGN_SPOOL).
+
+    The uid is stored exactly as the caller sent it — /api/status echoes this
+    dict and the shipped mobile app reads it back (consumers that need a
+    canonical form lowercase at their own boundary). uid and the filament
+    props let the consumer record a deduction baseline on assignment (#109).
+
+    Returns True if an earlier pending spool was replaced."""
     pending = {
         "color_hex": color_hex,
         "material": material,
@@ -75,12 +85,20 @@ def _cache_pending_spool(
         "nozzle_temp_max": nozzle_temp_max,
         "bed_temp_min": bed_temp_min,
         "bed_temp_max": bed_temp_max,
+        "uid": uid,
+        "device_id": device_id,
+        "diameter_mm": diameter_mm,
+        "density": density,
+        "tag_format": tag_format or "unknown",
     }
     with app_state.state_lock:
         if slot == "afc":
+            replaced = app_state.pending_spool_afc is not None
             app_state.pending_spool_afc = pending
         else:
+            replaced = app_state.pending_spool_toolhead is not None
             app_state.pending_spool_toolhead = pending
+    return replaced
 
 
 # ── Event building ───────────────────────────────────────────────────────────
@@ -145,12 +163,28 @@ def _try_spoolman_activation(event: SpoolEvent, spoolman_id: int, target: str | 
 
 def _route_staged(action_enum: Action, spoolman_activated: bool,
                   color_hex: str, filament_label: str, remaining: float | None,
-                  spoolman_id: int | None, event: SpoolEvent) -> None:
+                  spoolman_id: int | None, event: SpoolEvent,
+                  scan: ScanEvent | None = None,
+                  device_id: str | None = None) -> None:
     """Handle afc_stage and toolhead_stage — cache tag data, don't lock."""
     slot = "afc" if action_enum == Action.AFC_STAGE else "toolhead"
+    raw = getattr(scan, "raw", None) or {}
+    # spoolsense_scanner payloads carry the format in the payload; direct
+    # OpenTag3D/OpenPrintTag payloads have no such key — their parser puts
+    # the format name in scan.source, which matches _WRITABLE_FORMATS
+    tag_format = raw.get("tag_format") or getattr(scan, "source", None)
+    # "mobile" is the REST marker for event attribution, not an MQTT scanner.
+    # Deduction routing keys off the tracking device_id — empty means mobile
+    # (store for GET /api/deductions), nonempty means publish to that scanner.
+    tracking_device = "" if device_id == "mobile" else (device_id or "")
     _cache_pending_spool(slot, color_hex, filament_label, remaining, spoolman_id,
                          event.nozzle_temp_min, event.nozzle_temp_max,
-                         event.bed_temp_min, event.bed_temp_max)
+                         event.bed_temp_min, event.bed_temp_max,
+                         uid=getattr(scan, "uid", None),
+                         device_id=tracking_device,
+                         diameter_mm=getattr(scan, "diameter_mm", None),
+                         density=getattr(scan, "density", None),
+                         tag_format=tag_format)
     stage_name = "afc_stage" if action_enum == Action.AFC_STAGE else "toolhead_stage"
     if spoolman_activated:
         logger.info(f"[{stage_name}] Spool staged with Spoolman ID, scanner remains unlocked")
@@ -288,7 +322,7 @@ def _activate_from_scan(
     # Route by action type
     if action_enum in (Action.AFC_STAGE, Action.TOOLHEAD_STAGE):
         _route_staged(action_enum, spoolman_activated, color_hex, filament_label,
-                      remaining, spoolman_id, event)
+                      remaining, spoolman_id, event, scan, device_id)
     elif action_enum in (Action.AFC_LANE, Action.TOOLHEAD):
         _route_dedicated(action_enum, spoolman_activated, spoolman_id, target, event)
 

--- a/middleware/activation.py
+++ b/middleware/activation.py
@@ -98,6 +98,7 @@ def _cache_pending_spool(
         else:
             replaced = app_state.pending_spool_toolhead is not None
             app_state.pending_spool_toolhead = pending
+            app_state.pending_spool_toolhead_gen += 1
     return replaced
 
 

--- a/middleware/afc_status.py
+++ b/middleware/afc_status.py
@@ -113,6 +113,20 @@ def _publish_lane_actions(lane_name: str, action: str | None, pending: dict | No
         publish_lock(lane_name, "clear")
 
     if newly_loaded and pending:
+        # Deduction baseline for UPDATE_TAG (#109) — the staged scan carried
+        # the uid; recording on lane-load matches what dedicated afc_lane
+        # scanners do at scan time. If the new spool can't be recorded, drop
+        # any previous baseline instead — it describes a removed spool.
+        uid = pending.get("uid")
+        if uid and pending.get("remaining_g") is not None:
+            from tracking_store import record_tracking
+            record_tracking(lane_name, uid, pending.get("device_id", ""),
+                            pending.get("remaining_g"),
+                            pending.get("diameter_mm"), pending.get("density"),
+                            pending.get("tag_format"))
+        else:
+            from tracking_store import clear_tracking
+            clear_tracking(lane_name)
         # Delayed 2s to let AFC's own load sequence finish first — if sent too early,
         # AFC overwrites material/weight during its load process.
         logger.info(f"AFC {source}: {lane_name} just loaded — scheduling lane data (2s delay)")
@@ -135,7 +149,10 @@ def _sync_lane_state(data: dict) -> None:
             if lane_name == "system" or not isinstance(lane_data, dict):
                 continue
 
-            spool_id       = lane_data.get("spool_id")
+            # AFC reports 0 for "no spool" — normalize once so the lock/
+            # clear/swap/consumption logic below all see one empty value
+            # (the websocket path already treats 0 as removal)
+            spool_id       = lane_data.get("spool_id") or None
             status         = lane_data.get("status")
             lane_is_loaded = lane_data.get("load", False)
 
@@ -161,17 +178,36 @@ def _sync_lane_state(data: dict) -> None:
                     if spool_id and prev_spool and spool_id != prev_spool:
                         swapped = True
                     app_state.active_spools[lane_name] = spool_id
-                elif lane_is_loaded and not was_loaded and app_state.pending_spool_afc:
-                    # Lane transitioned unloaded → loaded with pending afc_stage data
-                    newly_loaded = True
-                    pending = app_state.pending_spool_afc
-                    app_state.pending_spool_afc = None
-                else:
+                elif not (lane_is_loaded and not was_loaded
+                          and app_state.pending_spool_afc):
                     if is_locked:
                         action = "clear"
                     app_state.active_spools[lane_name] = None
 
-            if action == "clear" or swapped:
+                # Consume staged afc_stage data on any unloaded → loaded
+                # transition. A Spoolman-backed staged load reports load=true
+                # AND a spool_id in the same poll (SET_NEXT_SPOOL_ID landed
+                # first), so consumption can't live in an else-branch keyed
+                # off spool_id being absent. But a lane loading a DIFFERENT
+                # Spoolman spool (assigned externally) must not eat the
+                # staged one — only consume when the ids agree or either
+                # side is tag-only.
+                # A lane reporting an id only consumes staged data whose id
+                # agrees — a tag-only staged spool must not be claimed by an
+                # externally-assigned Spoolman spool. A lane with no id yet
+                # consumes anything (SET_NEXT_SPOOL_ID may land after load).
+                if lane_is_loaded and not was_loaded and app_state.pending_spool_afc:
+                    staged_id = app_state.pending_spool_afc.get("spoolman_id")
+                    if spool_id is None or staged_id == spool_id:
+                        newly_loaded = True
+                        pending = app_state.pending_spool_afc
+                        app_state.pending_spool_afc = None
+
+            # Unload transition must clear independently of lock/spool-id
+            # state: tag-only staged lanes (#109) have neither, so the
+            # action-based clear below never fires for them
+            unloaded = was_loaded and not lane_is_loaded
+            if action == "clear" or swapped or unloaded:
                 # Spool left the lane (or was swapped from outside) — drop its
                 # deduction baseline so a restart can't resurrect it (#91)
                 from tracking_store import clear_tracking
@@ -196,8 +232,11 @@ def _sync_lane_state_single(lane_name: str, data: dict) -> None:
         prev_spool = app_state.active_spools.get(lane_name)
         prev_load  = app_state.lane_load_states.get(lane_name, False)
 
-        # Update spool tracking
-        if spool_id is not None:
+        # Update spool tracking. Key presence matters: absent means
+        # "unchanged" (partial delta), while an explicit null/0 is a
+        # removal and must clear the cached id — otherwise a later
+        # load-only delta compares staged spools against a stale id.
+        if "spool_id" in data:
             if spool_id and not prev_spool:
                 app_state.active_spools[lane_name] = spool_id
                 action = "lock"
@@ -213,22 +252,35 @@ def _sync_lane_state_single(lane_name: str, data: dict) -> None:
                 swapped = True
 
         # Track load transitions
+        unloaded = False
         if load_state is not None:
             if load_state and not prev_load:
                 newly_loaded = True
+            elif prev_load and not load_state:
+                unloaded = True
             app_state.lane_load_states[lane_name] = load_state
 
-        # Consume pending afc_stage data on load transition
+        # Consume pending afc_stage data on load transition — same id-match
+        # rule as the poll path: never eat a staged spool while the lane
+        # holds a different Spoolman id. Deltas are partial: an absent
+        # spool_id key means "unchanged", so compare against the cached id;
+        # an explicit null means the lane has no spool.
         if newly_loaded and app_state.pending_spool_afc:
-            pending = app_state.pending_spool_afc
-            app_state.pending_spool_afc = None
+            staged_id = app_state.pending_spool_afc.get("spoolman_id")
+            # AFC uses 0 for "no spool" — normalize before matching
+            lane_id = (spool_id or None) if "spool_id" in data else (prev_spool or None)
+            if lane_id is None or staged_id == lane_id:
+                pending = app_state.pending_spool_afc
+                app_state.pending_spool_afc = None
 
         # Update lane status if present in delta
         status = data.get("status")
         if status is not None:
             app_state.lane_statuses[lane_name] = status
 
-    if action == "clear" or swapped:
+    # Unload must clear independently of lock/spool-id state — tag-only
+    # staged lanes (#109) have neither, so action never becomes "clear"
+    if action == "clear" or swapped or unloaded:
         from tracking_store import clear_tracking
         clear_tracking(lane_name)
 

--- a/middleware/app_state.py
+++ b/middleware/app_state.py
@@ -68,6 +68,11 @@ pending_spool_afc: dict | None = None
 indx_active_tool: int | None = None
 pending_spool_toolhead: dict | None = None
 
+# Bumped on every toolhead-slot stage. Lets a failed gate assign detect that
+# a newer scan was staged (and possibly consumed) while its network call ran,
+# so it never resurrects a stale spool into the slot. Protected by state_lock.
+pending_spool_toolhead_gen: int = 0
+
 # Tag writeback cooldown — tracks recent writes to prevent loops.
 # Maps uid → timestamp of the last write command sent.
 # Protected by state_lock.

--- a/middleware/config.example.happy_hare.yaml
+++ b/middleware/config.example.happy_hare.yaml
@@ -6,13 +6,14 @@
 #   cp config.example.happy_hare.yaml ~/SpoolSense/config.yaml
 #
 # This config is for Happy Hare MMU users running in pull mode.
-# Workflow:
-#   1. Select an MMU gate (MMU_SELECT_GATE GATE=N) in Mainsail / LCD
+# Workflow (physical scanner):
+#   1. Select an MMU gate (MMU_SELECT GATE=N) in Mainsail / LCD
 #   2. Scan a tag on the shared scanner
-#   3. The middleware reads the selected gate from Moonraker, writes
-#      mmu_gate + printer_name to the spool's Spoolman extras, then
-#      fires MMU_SPOOLMAN SYNC=1 so Happy Hare picks up the binding
-#      immediately.
+#   3. The middleware reads the selected gate from Moonraker and binds
+#      via Happy Hare's own MMU_SPOOLMAN SPOOLID=<id> GATE=<n>, which
+#      updates Spoolman and Happy Hare's gate map in one step.
+# Workflow (mobile app): scan the tag with your phone, then pick the
+# gate in the app — no gate selection on the printer needed.
 #
 # Pull mode is required. Happy Hare reports its mode via printer.mmu
 # .spoolman_support — the middleware queries it and refuses to bind
@@ -37,20 +38,17 @@ low_spool_threshold: 100
 
 # ---- Happy Hare integration ---------------------------------
 #
-# Prerequisite: declare these extra fields in Spoolman before the first bind:
-#   Settings → Extra Fields → Spool → Add
-#     - key: mmu_gate       type: integer
-#     - key: printer_name   type: text
-# Without these declared, the PATCH will fail with HTTP 400 "Unknown extra
-# field X." (the error body is logged so you can see which field is missing).
+# Happy Hare declares its own Spoolman extra fields (mmu_gate_map,
+# printer_name) on startup — nothing to create by hand.
 happy_hare:
   enabled: true
-  # Written to each spool's extra.printer_name in Spoolman. Happy Hare uses
-  # this to identify which spools belong to this printer when syncing from
-  # Spoolman. Typically matches the "Printer Name" set in Happy Hare's
-  # mmu_parameters.cfg, but the middleware does not enforce that — anything
-  # consistent with how you've configured Happy Hare will work.
-  printer_name: "YOUR_PRINTER_NAME"
+  # Legacy, no longer required: Happy Hare stamps its own printer identity
+  # on each spool during the bind. Safe to remove.
+  # printer_name: "YOUR_PRINTER_NAME"
+  # Number of MMU gates. Drives the mobile app's gate picker (targets
+  # G0..G{n-1}) and the live staging board. Required when
+  # mobile.action is happy_hare_stage; optional for scanner-only setups.
+  num_gates: 4
 
 # ---- Scanners ------------------------------------------------
 # One shared scanner, used to bind any spool to whichever gate the user
@@ -61,3 +59,12 @@ scanners:
     action: "happy_hare_stage"
 
 scanner_topic_prefix: "spoolsense"
+
+# ---- Mobile app (optional) ----------------------------------
+# With action happy_hare_stage, the app scans a tag and then assigns it
+# to any gate from the picker (no MMU_SELECT needed). Requires
+# happy_hare.num_gates above. The Scan tab's staging board shows gate
+# occupancy and highlights the gate that is printing.
+# mobile:
+#   enabled: true
+#   action: "happy_hare_stage"

--- a/middleware/config.py
+++ b/middleware/config.py
@@ -293,8 +293,18 @@ def load_config() -> dict:
             logger.info(f"Derived toolheads from scanners: {config['toolheads']}")
 
     _validate_scanners(config)
-    _validate_mobile(config)
+    # happy_hare runs before mobile: the mobile validator reads the
+    # happy_hare section, and the type/shape guards live in the HH validator
     _validate_happy_hare(config)
+    _validate_mobile(config)
+
+    # Happy Hare: gates become mobile-assignable targets G0..G{n-1}. Runs
+    # after validation (num_gates is checked there). Only when no explicit/
+    # derived toolheads exist — HH installs have no toolhead scanners, so
+    # this is normally the only source.
+    if not config.get("toolheads") and config.get("happy_hare", {}).get("num_gates"):
+        config["toolheads"] = [f"G{i}" for i in range(config["happy_hare"]["num_gates"])]
+        logger.info(f"Derived gate targets from happy_hare.num_gates: {config['toolheads']}")
 
     return config
 
@@ -307,10 +317,46 @@ def _validate_mobile(config: dict) -> None:
     mobile.setdefault("port", 5001)
 
     mobile_action = mobile["action"]
-    if mobile_action not in ("afc_stage", "toolhead_stage", "toolhead"):
-        _config_error("mobile.action must be afc_stage, toolhead_stage, or toolhead (got %s)", mobile_action)
+    if mobile_action not in ("afc_stage", "toolhead_stage", "toolhead", "happy_hare_stage"):
+        _config_error("mobile.action must be afc_stage, toolhead_stage, toolhead, "
+                      "or happy_hare_stage (got %s)", mobile_action)
     if mobile_action == "toolhead" and not mobile.get("toolhead"):
         _config_error("mobile.action 'toolhead' requires a 'toolhead' field (e.g. T0)")
+    if mobile_action == "happy_hare_stage":
+        if not config.get("happy_hare", {}).get("enabled"):
+            _config_error("mobile.action 'happy_hare_stage' requires happy_hare.enabled: true")
+        # Spool resolution (uid -> Spoolman id) happens at scan time; without
+        # Spoolman every scan dead-ends with a misleading not-found message
+        if not config.get("spoolman_url"):
+            _config_error(
+                "mobile.action 'happy_hare_stage' requires spoolman_url — the gate "
+                "assign flow resolves scanned tags against Spoolman."
+            )
+        # The app's gate picker renders the derived G0..G{n-1} targets; without
+        # num_gates the picker is empty (or a stale fallback) and every assign fails
+        if not config.get("happy_hare", {}).get("num_gates"):
+            _config_error(
+                "mobile.action 'happy_hare_stage' requires happy_hare.num_gates — "
+                "it drives the app's gate picker (targets G0..G{n-1})."
+            )
+        # The gate-assign flow stages into the shared toolhead pending slot and
+        # derives gate names into toolheads. Any other scanner type either
+        # starts a competing pending-slot consumer (toolhead_stage; AFC with
+        # publish_lane_data) or derives lane/tool names that suppress the gate
+        # targets. Keep HH-mobile configs pure: happy_hare_stage scanners only.
+        other = [d for d, s in config.get("scanners", {}).items()
+                 if isinstance(s, dict) and s.get("action") != "happy_hare_stage"]
+        if other:
+            _config_error(
+                "mobile.action 'happy_hare_stage' can only be combined with "
+                "happy_hare_stage scanners (found other actions on: %s).",
+                ", ".join(sorted(other)),
+            )
+        if config.get("toolheads"):
+            _config_error(
+                "mobile.action 'happy_hare_stage' derives gate targets G0..G{n-1} — "
+                "remove the explicit 'toolheads' list from config.yaml."
+            )
 
     mobile_port = mobile["port"]
     if not isinstance(mobile_port, int) or mobile_port < 1 or mobile_port > 65535:
@@ -349,12 +395,9 @@ def _validate_happy_hare(config: dict) -> None:
             "Set 'happy_hare.enabled: true' in config.yaml or change the scanner action."
         )
 
-    if enabled and not happy_hare["printer_name"]:
-        _config_error(
-            "happy_hare.enabled is true but happy_hare.printer_name is empty. "
-            "Set 'happy_hare.printer_name' to match the Printer Name configured "
-            "in Happy Hare's mmu_parameters.cfg."
-        )
+    # printer_name is legacy-tolerated but no longer required: binding goes
+    # through MMU_SPOOLMAN SPOOLID/GATE and Happy Hare stamps its own
+    # printer identity on the spool.
 
     # Happy Hare binding writes to Spoolman — the integration cannot function
     # in tag-only mode. Fail loud at config load so users don't discover this
@@ -365,5 +408,14 @@ def _validate_happy_hare(config: dict) -> None:
             "Happy Hare binding writes to Spoolman — tag-only mode is not supported "
             "for this action. Set 'spoolman_url' in config.yaml."
         )
+
+    # num_gates drives the mobile gate picker (targets G0..G{n-1}). Optional:
+    # without it, phone-side gate assignment is unavailable but the physical
+    # select-then-scan flow still works.
+    num_gates = happy_hare.get("num_gates")
+    if num_gates is not None:
+        if isinstance(num_gates, bool) or not isinstance(num_gates, int) \
+                or num_gates < 1 or num_gates > 32:
+            _config_error("happy_hare.num_gates must be an integer 1-32 (got %s)", num_gates)
 
 

--- a/middleware/happy_hare.py
+++ b/middleware/happy_hare.py
@@ -1,25 +1,37 @@
 """
 happy_hare.py — Happy Hare MMU integration (pull mode).
 
-Workflow for `action: happy_hare_stage` scanners:
-  1. User selects an MMU gate via `MMU_SELECT_GATE GATE=N` (Mainsail/LCD/console)
-  2. User scans a tag on the shared scanner
-  3. This module reads the currently-selected gate from Moonraker,
-     PATCHes the Spoolman spool's `extra.mmu_gate` and `extra.printer_name`,
-     then fires `MMU_SPOOLMAN SYNC=1` so Happy Hare picks up the binding
-     immediately rather than waiting for its next periodic pull
+Binding goes through Happy Hare's own primitive:
+
+    MMU_SPOOLMAN SPOOLID=<spool> GATE=<gate>
+
+which calls the mmu_server component's set_spool_gate — it validates the
+gate, unsets any other spool claiming that printer+gate, writes the
+`mmu_gate_map`/`printer_name` extras in the encoding HH expects, and
+updates HH's spool-location cache. The middleware deliberately does NOT
+write Spoolman extras itself: an earlier version PATCHed `extra.mmu_gate`
+directly, but HH reads `mmu_gate_map` (components/mmu_server.py
+MMU_GATE_FIELD) and json-decodes its values, so the direct write was
+invisible to every HH version.
+
+Flows:
+  - Physical scanner (`action: happy_hare_stage`): select a gate
+    (MMU_SELECT GATE=N), scan — binds to the selected gate.
+  - Mobile (`mobile.action: happy_hare_stage`): scan on the phone, pick a
+    gate from the app — binds to that gate, no selection needed.
 
 Pull-mode-only: Happy Hare exposes `spoolman_support` on its `printer.mmu`
 object. We query that on first use and refuse to bind in any other mode,
 since `MMU_GATE_MAP NEXT_SPOOLID=...` is the right path there.
 
-No background thread, no startup wiring — this is purely a synchronous
-helper called from the scan handler.
+Also hosts on_ws_mmu — the websocket follower for printer.mmu deltas that
+feeds the live gate into /api/status `active_tool`.
 """
 from __future__ import annotations
 
 import logging
 import threading
+import time
 
 import app_state
 from moonraker_client import query_objects, send_gcode
@@ -27,6 +39,11 @@ from moonraker_client import query_objects, send_gcode
 logger = logging.getLogger(__name__)
 
 REQUIRED_MODE: str = "pull"
+
+# Bind confirmation: how long to wait for printer.mmu.gate_spool_id to
+# reflect a dispatched MMU_SPOOLMAN bind before calling it failed
+_CONFIRM_ATTEMPTS: int = 4
+_CONFIRM_DELAY_S: float = 0.5
 _KNOWN_MODES: frozenset[str] = frozenset({"pull", "push", "readonly"})
 
 # We cache only the success case (`pull`). Any other observed value re-fetches
@@ -89,41 +106,37 @@ def _check_mode(mmu_status: dict) -> bool:
         return False
 
 
-def bind_spool_to_current_gate(spool_id: int) -> bool:
-    """
-    Bind a spool to whichever MMU gate is currently selected.
-
-    Reads the current gate from Moonraker, PATCHes the spool's
-    `extra.mmu_gate` + `extra.printer_name`, then triggers Happy Hare's
-    Spoolman sync. Returns True on success, False on any failure
-    (with a logged reason).
-    """
+def _bind_checks() -> dict | None:
+    """Shared preconditions for any gate bind (one printer.mmu fetch).
+    Returns the mmu status dict when binding is possible, None otherwise
+    (reason logged)."""
     happy_hare_cfg = app_state.cfg.get("happy_hare", {})
     if not happy_hare_cfg.get("enabled"):
         logger.debug("Happy Hare: bind skipped — integration not enabled")
-        return False
-
-    printer_name = happy_hare_cfg.get("printer_name", "")
-    if not printer_name:
-        logger.error("Happy Hare: bind skipped — happy_hare.printer_name is empty")
-        return False
+        return None
 
     mmu_status = _fetch_mmu_status()
     if not mmu_status:
         logger.warning("Happy Hare: bind skipped — could not read printer.mmu from Moonraker")
-        return False
+        return None
 
     if not _check_mode(mmu_status):
-        return False
+        return None
 
     if not mmu_status.get("enabled", False):
         logger.warning("Happy Hare: bind skipped — MMU reports enabled=false")
-        return False
+        return None
 
-    gate = mmu_status.get("gate")
-    if not isinstance(gate, int) or gate < 0:
-        logger.warning("Happy Hare: bind skipped — no gate selected (got %r). "
-                       "Run MMU_SELECT_GATE GATE=N before scanning.", gate)
+    return mmu_status
+
+
+def _bind_core(gate: int, spool_id: int, mmu_status: dict) -> bool:
+    """Validate the gate against the already-fetched mmu status and hand the
+    bind to Happy Hare's own set_spool_gate via gcode. HH validates again,
+    unsets any other spool on that printer+gate, writes the extras it
+    actually reads, and updates its cache — no Spoolman writes from here."""
+    if isinstance(gate, bool) or not isinstance(gate, int) or gate < 0:
+        logger.warning("Happy Hare: bind skipped — invalid gate %r", gate)
         return False
 
     num_gates = mmu_status.get("num_gates")
@@ -132,31 +145,105 @@ def bind_spool_to_current_gate(spool_id: int) -> bool:
                        gate, num_gates)
         return False
 
-    if app_state.spoolman_client is None:
-        logger.error("Happy Hare: bind skipped — Spoolman client not configured")
-        return False
-
-    extras = {
-        "mmu_gate": gate,
-        "printer_name": printer_name,
-    }
-    if not app_state.spoolman_client.update_spool_extras(spool_id, extras):
-        return False
-
-    logger.info("Happy Hare: bound spool %s to gate %d on printer %r",
-                spool_id, gate, printer_name)
-
-    # Nudge Happy Hare to re-pull from Spoolman so the new binding is live
-    # immediately rather than on its next periodic sync.
     moonraker_url = app_state.cfg.get("moonraker_url", "")
-    if moonraker_url:
-        try:
-            send_gcode(moonraker_url, "MMU_SPOOLMAN SYNC=1")
-        except Exception:
-            logger.exception("Happy Hare: bind succeeded but MMU_SPOOLMAN SYNC=1 failed; "
-                             "Happy Hare will pick up the binding on its next periodic pull")
+    if not moonraker_url:
+        logger.error("Happy Hare: bind skipped — moonraker_url not configured")
+        return False
 
-    return True
+    try:
+        send_gcode(moonraker_url, f"MMU_SPOOLMAN SPOOLID={spool_id} GATE={gate}")
+    except Exception:
+        logger.exception("Happy Hare: MMU_SPOOLMAN SPOOLID=%s GATE=%s failed",
+                         spool_id, gate)
+        return False
+
+    # The gcode dispatches to the moonraker component fire-and-forget, so
+    # acceptance is not success — a Spoolman outage inside set_spool_gate
+    # would otherwise report a bind that never happened (and the REST flow
+    # would drop the staged spool on the false positive). Confirm the gate
+    # map actually updated, briefly.
+    for _ in range(_CONFIRM_ATTEMPTS):
+        time.sleep(_CONFIRM_DELAY_S)
+        status = _fetch_mmu_status()
+        spool_ids = (status or {}).get("gate_spool_id")
+        if isinstance(spool_ids, list) and gate < len(spool_ids) \
+                and spool_ids[gate] == spool_id:
+            logger.info("Happy Hare: bound spool %s to gate %d", spool_id, gate)
+            return True
+
+    logger.error(
+        "Happy Hare: MMU_SPOOLMAN accepted but gate %d never showed spool %s "
+        "in printer.mmu.gate_spool_id — treating the bind as failed "
+        "(check moonraker.log for the mmu_server error)", gate, spool_id)
+    return False
+
+
+def bind_spool_to_gate(gate: int, spool_id: int) -> bool:
+    """
+    Bind a spool to a specific MMU gate — no gate selection required. Used
+    by the mobile assign flow, where the phone picks the gate. Returns True
+    on success, False on any failure (with a logged reason).
+    """
+    mmu_status = _bind_checks()
+    if mmu_status is None:
+        return False
+    return _bind_core(gate, spool_id, mmu_status)
+
+
+def bind_spool_to_current_gate(spool_id: int) -> bool:
+    """
+    Bind a spool to whichever MMU gate is currently selected (the physical
+    select-then-scan flow). One printer.mmu fetch serves both the gate read
+    and the bind checks. Returns True on success, False on any failure
+    (with a logged reason).
+    """
+    mmu_status = _bind_checks()
+    if mmu_status is None:
+        return False
+
+    gate = mmu_status.get("gate")
+    if not isinstance(gate, int) or gate < 0:
+        logger.warning("Happy Hare: bind skipped — no gate selected (got %r). "
+                       "Run MMU_SELECT GATE=N before scanning.", gate)
+        return False
+
+    return _bind_core(gate, spool_id, mmu_status)
+
+
+def on_ws_mmu(data: dict) -> None:
+    """
+    Websocket callback for printer.mmu deltas — feeds /api/status for the
+    mobile staging board. Happy Hare manages Spoolman itself in pull mode,
+    so this only updates local state: no gcode, no HTTP.
+
+    Two fields are mirrored (deltas are partial; absent key = unchanged):
+    - `gate` -> active_tool: >= 0 is a real gate; -1 (unknown/unloaded)
+      and -2 (bypass) map to None.
+    - `gate_spool_id` -> active_spools["G<i>"]: HH's authoritative per-gate
+      spool map, so occupancy reflects binds from ANY source (middleware,
+      MMU_GATE_MAP, HH UI). -1 means unassigned.
+    """
+    if not isinstance(data, dict):
+        return
+
+    gate = data.get("gate")
+    has_gate = ("gate" in data and not isinstance(gate, bool)
+                and isinstance(gate, int))
+    if "gate" in data and not has_gate:
+        logger.debug("Happy Hare: ignoring non-integer mmu gate %r", gate)
+
+    spool_ids = data.get("gate_spool_id")
+    has_map = isinstance(spool_ids, list)
+
+    if not has_gate and not has_map:
+        return
+    with app_state.state_lock:
+        if has_gate:
+            app_state.indx_active_tool = gate if gate >= 0 else None
+        if has_map:
+            for i, sid in enumerate(spool_ids):
+                valid = not isinstance(sid, bool) and isinstance(sid, int) and sid > 0
+                app_state.active_spools[f"G{i}"] = sid if valid else None
 
 
 def _reset_mode_cache_for_testing() -> None:

--- a/middleware/moonraker_ws.py
+++ b/middleware/moonraker_ws.py
@@ -69,12 +69,14 @@ class MoonrakerWebsocket:
 
         # Objects discovered via printer.objects.list on each connect
         self._has_save_variables: bool = False
+        self._has_mmu: bool = False
 
         # Callbacks — set by consumers
         self.on_lane_update: Callable[[str, dict], None] | None = None
         self.on_assign_spool: Callable[[str], None] | None = None
         self.on_update_tag: Callable[[int], None] | None = None
         self.on_save_variables: Callable[[dict], None] | None = None
+        self.on_mmu: Callable[[dict], None] | None = None
 
     def set_lane_names(self, names: list[str]) -> None:
         """Set AFC lane names to subscribe to (e.g. ['lane1', 'lane2'])."""
@@ -193,9 +195,10 @@ class MoonrakerWebsocket:
                 logger.info("MoonrakerWebsocket: discovered AFC lanes: %s", discovered)
             else:
                 logger.info("MoonrakerWebsocket: no AFC lanes found — subscribing without AFC_stepper objects")
-            # Only subscribe to save_variables if Klipper actually has the
-            # section — subscribing to a missing object errors the request.
+            # Only subscribe to save_variables/mmu if Klipper actually has
+            # them — subscribing to a missing object errors the request.
             self._has_save_variables = "save_variables" in objects
+            self._has_mmu = "mmu" in objects
             self._send_subscribe(ws)
             return
 
@@ -245,6 +248,8 @@ class MoonrakerWebsocket:
         objects["gcode_macro UPDATE_TAG"] = None
         if self._has_save_variables and self.on_save_variables:
             objects["save_variables"] = None
+        if self._has_mmu and self.on_mmu:
+            objects["mmu"] = None
         return objects
 
     def _dispatch_status(self, status: dict) -> None:
@@ -265,3 +270,6 @@ class MoonrakerWebsocket:
                 variables = value.get("variables")
                 if isinstance(variables, dict):
                     self.on_save_variables(variables)
+            elif key == "mmu" and self.on_mmu:
+                if isinstance(value, dict):
+                    self.on_mmu(value)

--- a/middleware/mqtt_handler.py
+++ b/middleware/mqtt_handler.py
@@ -73,21 +73,12 @@ def _record_spool_tracking(
     density: float | None = None,
     tag_format: str | None = None,
 ) -> None:
-    """Store initial weight, UID, device, filament properties, and tag format for UPDATE_TAG deduction tracking."""
-    if not target or not uid or remaining is None:
+    """Record the UPDATE_TAG deduction baseline (via tracking_store) and run
+    the scan-time low-spool check."""
+    from tracking_store import record_tracking
+    if not record_tracking(target, uid, device_id, remaining,
+                           diameter_mm, density, tag_format):
         return
-    with app_state.state_lock:
-        app_state.active_spool_tracking[target] = app_state.ActiveSpool(
-            uid=uid,
-            device_id=device_id or "",
-            weight_g=remaining,
-            diameter_mm=diameter_mm or 1.75,
-            density=density or 1.24,
-            tag_format=tag_format or "unknown",
-        )
-    # Persist so the deduction baseline survives restarts (#91)
-    from tracking_store import save_tracking
-    save_tracking()
 
     # Check low-spool threshold at scan time — if a new spool has plenty of
     # filament, this also clears any latched low-spool state from the same
@@ -164,17 +155,12 @@ def _handle_uid_only_tag(client: mqtt.Client, scanner_cfg: dict, uid: str, topic
 
     # Shared scanners — cache for later assignment, don't activate yet
     if action in ("toolhead_stage", "afc_stage"):
-        pending = {
-            "color_hex": color_hex,
-            "material": material,
-            "remaining_g": remaining,
-            "spoolman_id": spool_id,
-        }
-        with app_state.state_lock:
-            if action == "afc_stage":
-                app_state.pending_spool_afc = pending
-            else:
-                app_state.pending_spool_toolhead = pending
+        from activation import _cache_pending_spool
+        _cache_pending_spool(
+            "afc" if action == "afc_stage" else "toolhead",
+            color_hex, material, remaining, spool_id,
+            uid=uid, device_id=device_id or "", tag_format="uid_only",
+        )
         logger.info(f"[{action}] Staged spool {spool_id} ({name}) for assignment")
         # Observer channels (MQTT event stream) still see staged scans even
         # though no printer command fires yet (#93)

--- a/middleware/rest_api.py
+++ b/middleware/rest_api.py
@@ -11,6 +11,7 @@ import json
 import logging
 import math
 import os
+import re
 import signal
 import subprocess
 import threading
@@ -222,6 +223,52 @@ def mobile_scan(req: MobileScanRequest) -> ApiResponse:
         )
         return ApiResponse(success=True, message=msg, pending=True, replaced=replaced)
 
+    # happy_hare_stage: cache as pending, phone picks a gate next. The bind
+    # writes to Spoolman, so the spool must exist there — resolve now and
+    # tell the user at scan time rather than failing at assign time.
+    if action == "happy_hare_stage":
+        # The UID is the authority: scanner_spoolman_id is a hint that can go
+        # stale when a tag is relinked to a different spool. Config requires
+        # spoolman_url for this action, so a missing client is a hard error.
+        spool_id: Optional[int] = None
+        if scan.uid and app_state.spoolman_client is not None:
+            spool = app_state.spoolman_client.find_by_nfc(scan.uid)
+            if spool:
+                spool_id = spool.get("id")
+                hint = scan.scanner_spoolman_id
+                if hint is not None and hint != spool_id:
+                    logger.info(
+                        f"[mobile] uid {scan.uid} resolves to spool {spool_id}; "
+                        f"ignoring stale payload id {hint}")
+        if spool_id is None:
+            return ApiResponse(
+                success=False,
+                message="Spool not found in Spoolman — register the tag first",
+            )
+        replaced = _cache_pending_spool(
+            "toolhead",
+            scan.color_hex or "FFFFFF",
+            scan.material_name or scan.material_type or "Unknown",
+            scan.remaining_weight_g,
+            spool_id,
+            scan.nozzle_temp_min_c,
+            scan.nozzle_temp_max_c,
+            scan.bed_temp_min_c,
+            scan.bed_temp_max_c,
+            uid=scan.uid,
+            device_id="",
+            diameter_mm=scan.diameter_mm,
+            density=scan.density,
+            tag_format=req.tag_format or scan.source,
+        )
+        msg = (
+            "Previous pending spool replaced — select a gate to assign"
+            if replaced
+            else "Spool cached — select a gate to assign"
+        )
+        return ApiResponse(success=True, message=msg, pending=True,
+                           replaced=replaced, spool_id=spool_id)
+
     # All other actions: activate immediately
     scanner_cfg: dict[str, Any] = {"action": action}
     if action == "toolhead":
@@ -259,11 +306,77 @@ def mobile_scan(req: MobileScanRequest) -> ApiResponse:
     )
 
 
+_GATE_NAME = re.compile(r"^G(\d+)$")
+
+
+def _assign_gate(req: AssignToolRequest) -> ApiResponse:
+    """Gate-targeted Happy Hare assignment: claim the staged spool, bind it
+    to the requested gate, restore the stage on failure. Same uid/409
+    machinery as the toolhead flow — the shipped app's status-code contract
+    is identical."""
+    toolheads = app_state.cfg.get("toolheads", [])
+    match = _GATE_NAME.match(req.toolhead.upper())
+    if not match or (toolheads and req.toolhead.upper() not in toolheads):
+        return ApiResponse(
+            success=False,
+            message=f"Invalid gate — available: {', '.join(toolheads) or 'none (set happy_hare.num_gates)'}",
+        )
+    gate = int(match.group(1))
+
+    with app_state.state_lock:
+        pending = app_state.pending_spool_toolhead
+        if not pending:
+            raise HTTPException(status_code=409, detail={
+                "code": "no_pending_spool",
+                "message": "No pending spool — scan a tag first",
+            })
+        if req.uid and req.uid.lower() != (pending.get("uid") or "").lower():
+            raise HTTPException(status_code=409, detail={
+                "code": "pending_spool_changed",
+                "message": "Pending spool changed since scan — rescan and try again",
+            })
+        # Claim it — unlike the toolhead flow there is no macro watcher; the
+        # endpoint is the consumer. Record the stage generation so a failed
+        # bind can tell "nothing changed" from "a newer scan came and went"
+        app_state.pending_spool_toolhead = None
+        claimed_gen = app_state.pending_spool_toolhead_gen
+
+    spool_id = pending.get("spoolman_id")
+    if spool_id is None:
+        # Staging requires a Spoolman id, so this should be unreachable —
+        # but never bind nothing
+        return ApiResponse(success=False, message="Staged spool has no Spoolman id — rescan")
+
+    from happy_hare import bind_spool_to_gate
+    if bind_spool_to_gate(gate, spool_id):
+        logger.info(f"[mobile] Bound spool {spool_id} to gate {gate}")
+        return ApiResponse(success=True,
+                           message=f"Spool bound to gate {gate}",
+                           action="happy_hare_stage",
+                           toolhead=req.toolhead.upper(),
+                           spool_id=spool_id)
+
+    # Failed bind — restore the stage only if NOTHING was staged since the
+    # claim. An empty slot alone isn't enough: a newer scan could have been
+    # staged and consumed by a concurrent assign during our network call,
+    # and restoring then would resurrect a stale spool (assignable by
+    # legacy clients that omit the uid guard).
+    with app_state.state_lock:
+        if (app_state.pending_spool_toolhead is None
+                and app_state.pending_spool_toolhead_gen == claimed_gen):
+            app_state.pending_spool_toolhead = pending
+    raise HTTPException(status_code=502,
+                        detail="Happy Hare bind failed — see middleware log")
+
+
 @app.post("/api/assign-tool", response_model=ApiResponse)
 def assign_tool(req: AssignToolRequest) -> ApiResponse:
     mobile_cfg = app_state.cfg.get("mobile", {})
     if not mobile_cfg.get("enabled"):
         raise HTTPException(status_code=503, detail="Mobile scanning not enabled")
+
+    if mobile_cfg.get("action") == "happy_hare_stage":
+        return _assign_gate(req)
 
     if mobile_cfg.get("action") != "toolhead_stage":
         return ApiResponse(success=False, message="assign-tool only valid for toolhead_stage mode")

--- a/middleware/rest_api.py
+++ b/middleware/rest_api.py
@@ -24,7 +24,7 @@ from pydantic import BaseModel
 
 import app_state
 from adapters.dispatcher import detect_and_parse
-from activation import _activate_from_scan
+from activation import _activate_from_scan, _cache_pending_spool
 from moonraker_client import send_gcode
 from mqtt_handler import _record_spool_tracking, _get_scanner_target
 from config import CONFIG_PATH
@@ -198,19 +198,22 @@ def mobile_scan(req: MobileScanRequest) -> ApiResponse:
 
     # toolhead_stage: cache as pending, phone picks toolhead next
     if action == "toolhead_stage":
-        with app_state.state_lock:
-            replaced = app_state.pending_spool_toolhead is not None
-            app_state.pending_spool_toolhead = {
-                "color_hex": scan.color_hex or "FFFFFF",
-                "material": scan.material_name or scan.material_type or "Unknown",
-                "remaining_g": scan.remaining_weight_g,
-                "spoolman_id": scan.scanner_spoolman_id,
-                "uid": scan.uid,
-                "nozzle_temp_min": scan.nozzle_temp_min_c,
-                "nozzle_temp_max": scan.nozzle_temp_max_c,
-                "bed_temp_min": scan.bed_temp_min_c,
-                "bed_temp_max": scan.bed_temp_max_c,
-            }
+        replaced = _cache_pending_spool(
+            "toolhead",
+            scan.color_hex or "FFFFFF",
+            scan.material_name or scan.material_type or "Unknown",
+            scan.remaining_weight_g,
+            scan.scanner_spoolman_id,
+            scan.nozzle_temp_min_c,
+            scan.nozzle_temp_max_c,
+            scan.bed_temp_min_c,
+            scan.bed_temp_max_c,
+            uid=scan.uid,
+            device_id="",
+            diameter_mm=scan.diameter_mm,
+            density=scan.density,
+            tag_format=req.tag_format or scan.source,
+        )
 
         msg = (
             "Previous pending spool replaced — select a toolhead to assign"

--- a/middleware/spoolsense.py
+++ b/middleware/spoolsense.py
@@ -275,6 +275,14 @@ def _start_sync_services(use_ws: bool) -> None:
                 "Klipper variables will not sync until the websocket connects."
             )
 
+    # Happy Hare — follow the live gate on printer.mmu so /api/status can
+    # report it as active_tool (mobile staging board). Local state only.
+    if has_happy_hare_scanners(cfg) or cfg.get("mobile", {}).get("action") == "happy_hare_stage":
+        if use_ws:
+            from happy_hare import on_ws_mmu
+            app_state.moonraker_ws.on_mmu = on_ws_mmu
+            logger.info("Happy Hare: live gate tracking via websocket (printer.mmu)")
+
     app_state.filament_usage_sync.start(use_ws=use_ws)
 
     # Wire all websocket callbacks before starting the connection

--- a/middleware/spoolsense.py
+++ b/middleware/spoolsense.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
-__version__ = "1.8.5"
+__version__ = "1.8.6"
 """
 SpoolSense NFC Middleware
 =========================

--- a/middleware/tests/test_activation.py
+++ b/middleware/tests/test_activation.py
@@ -262,6 +262,86 @@ class TestPendingSlotIsolation(unittest.TestCase):
                          app_state.pending_spool_toolhead)
 
 
+class TestStagedCarriesTrackingFields(unittest.TestCase):
+    """Staged scans carry uid + filament props into the pending slot so the
+    consumer can record a deduction baseline on assignment (#109). The uid is
+    stored as-sent — /api/status echoes this dict to the shipped mobile app."""
+
+    def setUp(self):
+        _setup_app_state()
+
+    def test_rich_scan_fields_land_in_pending_slot(self):
+        from activation import _route_staged
+        from publishers.base import Action
+        from state.models import ScanEvent
+        scan = ScanEvent(
+            source="spoolsense_scanner", target_id="T0", scanned_at="now",
+            uid="AABB11", present=True, tag_data_valid=True,
+            diameter_mm=1.75, density=1.24,
+            raw={"tag_format": "openprinttag"},
+        )
+        event = MagicMock(nozzle_temp_min=None, nozzle_temp_max=None,
+                          bed_temp_min=None, bed_temp_max=None)
+        with patch("activation.notify_observers"):
+            _route_staged(Action.TOOLHEAD_STAGE, True, "FF0000", "PLA", 500.0,
+                          42, event, scan, "f3d360")
+        pending = app_state.pending_spool_toolhead
+        self.assertEqual(pending["uid"], "AABB11")
+        self.assertEqual(pending["device_id"], "f3d360")
+        self.assertEqual(pending["diameter_mm"], 1.75)
+        self.assertEqual(pending["tag_format"], "openprinttag")
+
+    def test_mobile_marker_not_stored_as_tracking_device(self):
+        # device_id="mobile" is REST event attribution — if it lands in the
+        # tracking record, UPDATE_TAG publishes deductions to a nonexistent
+        # MQTT scanner instead of the mobile REST store
+        from activation import _route_staged
+        from publishers.base import Action
+        from state.models import ScanEvent
+        scan = ScanEvent(
+            source="opentag3d", target_id="mobile", scanned_at="now",
+            uid="AABB11", present=True, tag_data_valid=True,
+        )
+        event = MagicMock(nozzle_temp_min=None, nozzle_temp_max=None,
+                          bed_temp_min=None, bed_temp_max=None)
+        with patch("activation.notify_observers"):
+            _route_staged(Action.AFC_STAGE, True, "FF0000", "PLA", 500.0,
+                          42, event, scan, "mobile")
+        self.assertEqual(app_state.pending_spool_afc["device_id"], "")
+
+    def test_opentag3d_format_derived_from_source(self):
+        # Direct OpenTag3D payloads have no tag_format key — the parser puts
+        # the format in scan.source; storing "unknown" would make
+        # _is_writable_tag silently skip every deduction after assignment
+        from activation import _route_staged
+        from publishers.base import Action
+        from state.models import ScanEvent
+        scan = ScanEvent(
+            source="opentag3d", target_id="T0", scanned_at="now",
+            uid="AABB11", present=True, tag_data_valid=True,
+            raw={"opentag_version": 1},
+        )
+        event = MagicMock(nozzle_temp_min=None, nozzle_temp_max=None,
+                          bed_temp_min=None, bed_temp_max=None)
+        with patch("activation.notify_observers"):
+            _route_staged(Action.TOOLHEAD_STAGE, True, "FF0000", "PLA", 500.0,
+                          42, event, scan, "f3d360")
+        self.assertEqual(app_state.pending_spool_toolhead["tag_format"],
+                         "opentag3d")
+
+    def test_no_scan_defaults_are_harmless(self):
+        from activation import _route_staged
+        from publishers.base import Action
+        event = MagicMock(nozzle_temp_min=None, nozzle_temp_max=None,
+                          bed_temp_min=None, bed_temp_max=None)
+        with patch("activation.notify_observers"):
+            _route_staged(Action.AFC_STAGE, True, "FF0000", "PLA", 500.0,
+                          42, event)
+        pending = app_state.pending_spool_afc
+        self.assertIsNone(pending["uid"])
+        self.assertEqual(pending["tag_format"], "unknown")
+
+
 class TestBuildSpoolEventScannerId(unittest.TestCase):
     """scanner_id must carry the source scanner so event-stream (#93)
     consumers can tell scanners apart — regression for the live finding

--- a/middleware/tests/test_afc_status.py
+++ b/middleware/tests/test_afc_status.py
@@ -178,6 +178,219 @@ class TestSyncLaneState(unittest.TestCase):
         assert app_state.active_spools.get("lane1") == 7
 
 
+class TestLaneLoadRecordsTracking(unittest.TestCase):
+    """An afc_stage scan consumed on lane load records a deduction baseline
+    for that lane — previously only dedicated afc_lane scans got one (#109)."""
+
+    def setUp(self):
+        _reset_app_state()
+
+    def _load_lane_with_pending(self, pending):
+        app_state.lane_load_states["lane1"] = False
+        app_state.pending_spool_afc = pending
+        data = _make_afc_data(spool_id=None, load=True)
+        with patch("afc_status.threading.Timer"):
+            with patch("afc_status.publish_lock"):
+                _sync_lane_state(data)
+
+    def test_staged_scan_with_uid_records_baseline(self):
+        self._load_lane_with_pending({
+            "color_hex": "FF0000", "material": "PLA", "remaining_g": 250.0,
+            "spoolman_id": None, "uid": "AABBCC", "device_id": "4d9620",
+            "diameter_mm": 1.75, "density": 1.24, "tag_format": "openprinttag",
+        })
+        rec = app_state.active_spool_tracking.get("lane1")
+        self.assertIsNotNone(rec)
+        self.assertEqual(rec.uid, "aabbcc")
+        self.assertEqual(rec.weight_g, 250.0)
+
+    def test_staged_scan_without_uid_records_nothing(self):
+        self._load_lane_with_pending({
+            "color_hex": "FF0000", "material": "PLA", "remaining_g": 250.0,
+            "spoolman_id": None,
+        })
+        self.assertNotIn("lane1", app_state.active_spool_tracking)
+
+    def test_staged_scan_without_weight_records_nothing(self):
+        self._load_lane_with_pending({
+            "color_hex": "FF0000", "material": "PLA", "remaining_g": None,
+            "spoolman_id": 5, "uid": "AABBCC",
+        })
+        self.assertNotIn("lane1", app_state.active_spool_tracking)
+
+    def test_unrecordable_pending_clears_previous_baseline(self):
+        # A new spool loaded but with no baseline data — the OLD spool's
+        # record must not survive to receive its deductions
+        app_state.active_spool_tracking["lane1"] = app_state.ActiveSpool(
+            uid="oldspool", weight_g=400.0)
+        self._load_lane_with_pending({
+            "color_hex": "FF0000", "material": "PLA", "remaining_g": None,
+            "spoolman_id": None,
+        })
+        self.assertNotIn("lane1", app_state.active_spool_tracking)
+
+    def test_poll_unload_clears_tag_only_baseline(self):
+        # Tag-only staged lanes never lock and have no spool_id, so the
+        # action-based clear can't fire — the load transition must clear
+        app_state.lane_load_states["lane1"] = True
+        app_state.active_spool_tracking["lane1"] = app_state.ActiveSpool(
+            uid="aabbcc", weight_g=250.0)
+        data = _make_afc_data(spool_id=None, load=False)
+        with patch("afc_status.publish_lock"):
+            _sync_lane_state(data)
+        self.assertNotIn("lane1", app_state.active_spool_tracking)
+
+    def test_ws_unload_clears_tag_only_baseline(self):
+        app_state.lane_load_states["lane1"] = True
+        app_state.active_spool_tracking["lane1"] = app_state.ActiveSpool(
+            uid="aabbcc", weight_g=250.0)
+        with patch("afc_status.publish_lock"):
+            _sync_lane_state_single("lane1", {"load": False})
+        self.assertNotIn("lane1", app_state.active_spool_tracking)
+
+    def test_poll_mismatched_spool_id_leaves_pending_staged(self):
+        # Spool A staged, but the lane loads spool B (assigned externally) —
+        # A must stay staged and B's lane must not get A's data or baseline
+        app_state.lane_load_states["lane1"] = False
+        staged = {
+            "color_hex": "FF0000", "material": "PLA", "remaining_g": 250.0,
+            "spoolman_id": 42, "uid": "AABBCC", "tag_format": "openprinttag",
+        }
+        app_state.pending_spool_afc = staged
+        data = _make_afc_data(spool_id=99, load=True)
+        with patch("afc_status.threading.Timer"):
+            with patch("afc_status.publish_lock"):
+                _sync_lane_state(data)
+        self.assertIs(app_state.pending_spool_afc, staged)
+        self.assertNotIn("lane1", app_state.active_spool_tracking)
+
+    def test_ws_mismatched_spool_id_leaves_pending_staged(self):
+        app_state.lane_load_states["lane1"] = False
+        staged = {"color_hex": "FF0000", "material": "PLA",
+                  "remaining_g": 250.0, "spoolman_id": 42, "uid": "AABBCC"}
+        app_state.pending_spool_afc = staged
+        with patch("afc_status.threading.Timer"):
+            with patch("afc_status.publish_lock"):
+                _sync_lane_state_single("lane1", {"spool_id": 99, "load": True})
+        self.assertIs(app_state.pending_spool_afc, staged)
+
+    def test_ws_load_only_delta_respects_cached_spool_id(self):
+        # Partial delta {"load": true} omits spool_id (= unchanged) — the
+        # lane's CACHED id (99) must block consuming staged spool 42
+        app_state.lane_load_states["lane1"] = False
+        app_state.active_spools["lane1"] = 99
+        staged = {"color_hex": "FF0000", "material": "PLA",
+                  "remaining_g": 250.0, "spoolman_id": 42, "uid": "AABBCC"}
+        app_state.pending_spool_afc = staged
+        with patch("afc_status.threading.Timer"):
+            with patch("afc_status.publish_lock"):
+                _sync_lane_state_single("lane1", {"load": True})
+        self.assertIs(app_state.pending_spool_afc, staged)
+
+    def test_ws_load_only_delta_consumes_when_cached_id_matches(self):
+        app_state.lane_load_states["lane1"] = False
+        app_state.active_spools["lane1"] = 42
+        staged = {"color_hex": "FF0000", "material": "PLA",
+                  "remaining_g": 250.0, "spoolman_id": 42, "uid": "AABBCC",
+                  "tag_format": "openprinttag"}
+        app_state.pending_spool_afc = staged
+        with patch("afc_status.threading.Timer"):
+            with patch("afc_status.publish_lock"):
+                _sync_lane_state_single("lane1", {"load": True})
+        self.assertIsNone(app_state.pending_spool_afc)
+        self.assertIn("lane1", app_state.active_spool_tracking)
+
+    def test_poll_tag_only_staged_not_claimed_by_spoolman_lane(self):
+        # Tag-only spool staged; a lane loads an externally-assigned
+        # Spoolman spool — the staged record must not be claimed by it
+        app_state.lane_load_states["lane1"] = False
+        staged = {"color_hex": "FF0000", "material": "PLA",
+                  "remaining_g": 250.0, "spoolman_id": None, "uid": "AABBCC"}
+        app_state.pending_spool_afc = staged
+        data = _make_afc_data(spool_id=99, load=True)
+        with patch("afc_status.threading.Timer"):
+            with patch("afc_status.publish_lock"):
+                _sync_lane_state(data)
+        self.assertIs(app_state.pending_spool_afc, staged)
+
+    def test_ws_explicit_null_clears_cached_id_then_staged_consumes(self):
+        # Removal delta {"spool_id": null} must clear the cached id, so a
+        # later load-only delta can consume freshly staged data instead of
+        # being blocked by a stale id forever
+        app_state.lane_load_states["lane1"] = True
+        app_state.active_spools["lane1"] = 99
+        with patch("afc_status.publish_lock"):
+            _sync_lane_state_single("lane1", {"spool_id": None, "load": False})
+        self.assertIsNone(app_state.active_spools.get("lane1"))
+        staged = {"color_hex": "FF0000", "material": "PLA",
+                  "remaining_g": 250.0, "spoolman_id": 42, "uid": "AABBCC",
+                  "tag_format": "openprinttag"}
+        app_state.pending_spool_afc = staged
+        with patch("afc_status.threading.Timer"):
+            with patch("afc_status.publish_lock"):
+                _sync_lane_state_single("lane1", {"load": True})
+        self.assertIsNone(app_state.pending_spool_afc)
+
+    def test_poll_zero_spool_id_treated_as_empty(self):
+        # AFC reports 0 for "no spool" — polling must not lock an empty
+        # lane, and a locked lane reporting 0 must clear (parity with the
+        # websocket path, which always treated 0 as removal)
+        app_state.lane_locks["lane1"] = True
+        app_state.active_spools["lane1"] = 42
+        data = _make_afc_data(spool_id=0, load=False)
+        with patch("afc_status.publish_lock") as mock_lock:
+            _sync_lane_state(data)
+            mock_lock.assert_called_once_with("lane1", "clear")
+        self.assertIsNone(app_state.active_spools.get("lane1"))
+
+    def test_poll_zero_spool_id_load_consumes_tag_only_staged(self):
+        app_state.lane_load_states["lane1"] = False
+        staged = {"color_hex": "FF0000", "material": "PLA",
+                  "remaining_g": 250.0, "spoolman_id": None, "uid": "AABBCC",
+                  "tag_format": "openprinttag"}
+        app_state.pending_spool_afc = staged
+        data = _make_afc_data(spool_id=0, load=True)
+        with patch("afc_status.threading.Timer"):
+            with patch("afc_status.publish_lock"):
+                _sync_lane_state(data)
+        self.assertIsNone(app_state.pending_spool_afc)
+        self.assertIn("lane1", app_state.active_spool_tracking)
+
+    def test_ws_zero_spool_id_load_consumes_tag_only_staged(self):
+        # AFC reports spool_id 0 for "no spool" — a tag-only staged spool
+        # must still be consumed when the lane loads with a zero id
+        app_state.lane_load_states["lane1"] = False
+        staged = {"color_hex": "FF0000", "material": "PLA",
+                  "remaining_g": 250.0, "spoolman_id": None, "uid": "AABBCC",
+                  "tag_format": "openprinttag"}
+        app_state.pending_spool_afc = staged
+        with patch("afc_status.threading.Timer"):
+            with patch("afc_status.publish_lock"):
+                _sync_lane_state_single("lane1", {"spool_id": 0, "load": True})
+        self.assertIsNone(app_state.pending_spool_afc)
+        self.assertIn("lane1", app_state.active_spool_tracking)
+
+    def test_poll_spoolman_backed_load_consumes_pending(self):
+        # SET_NEXT_SPOOL_ID lands before the poll sees load=true, so the
+        # same poll reports BOTH — staged data must still be consumed and
+        # the baseline recorded, not left for a later lane to steal
+        app_state.lane_load_states["lane1"] = False
+        app_state.pending_spool_afc = {
+            "color_hex": "FF0000", "material": "PLA", "remaining_g": 250.0,
+            "spoolman_id": 42, "uid": "AABBCC", "device_id": "4d9620",
+            "tag_format": "openprinttag",
+        }
+        data = _make_afc_data(spool_id=42, load=True)
+        with patch("afc_status.threading.Timer"):
+            with patch("afc_status.publish_lock"):
+                _sync_lane_state(data)
+        self.assertIsNone(app_state.pending_spool_afc)
+        rec = app_state.active_spool_tracking.get("lane1")
+        self.assertIsNotNone(rec)
+        self.assertEqual(rec.uid, "aabbcc")
+        self.assertEqual(app_state.active_spools.get("lane1"), 42)
+
+
 class TestSwapClearsTracking(unittest.TestCase):
     """An externally-driven spool swap (Mainsail SET_SPOOL_ID, no scan) must
     drop the lane's deduction baseline — it describes the removed spool. A

--- a/middleware/tests/test_config.py
+++ b/middleware/tests/test_config.py
@@ -24,6 +24,7 @@ from config import (  # noqa: E402
     _apply_scanner_defaults,
     _validate_scanners,
     _validate_happy_hare,
+    _validate_mobile,
     _derive_toolheads,
     _migrate_legacy_config,
     has_afc_scanners,
@@ -387,6 +388,116 @@ class TestHasHappyHareScanners(unittest.TestCase):
 
     def test_returns_false_when_no_scanners(self):
         assert has_happy_hare_scanners({}) is False
+
+
+
+class TestHappyHareNumGates(unittest.TestCase):
+    """num_gates drives the mobile gate picker; strict validation."""
+
+    def _hh(self, **kw):
+        base = {"enabled": True, "printer_name": "muffin"}
+        base.update(kw)
+        return {"scanners": {}, "spoolman_url": "http://s:7912", "happy_hare": base}
+
+    def test_valid_num_gates_ok(self):
+        _validate_happy_hare(self._hh(num_gates=8))
+
+    def test_absent_num_gates_ok(self):
+        _validate_happy_hare(self._hh())
+
+    def test_invalid_num_gates_rejected(self):
+        for bad in (0, 33, -1, "four", True, 2.5):
+            with self.assertRaises(SystemExit, msg=f"accepted {bad!r}"):
+                _validate_happy_hare(self._hh(num_gates=bad))
+
+
+class TestMobileHappyHareAction(unittest.TestCase):
+    """mobile.action happy_hare_stage gating."""
+
+    def _cfg(self, scanners=None, hh_enabled=True, spoolman="http://s:7912",
+             num_gates=4, toolheads=None):
+        cfg = {
+            "scanners": scanners or {},
+            "spoolman_url": spoolman,
+            "happy_hare": {"enabled": hh_enabled, "printer_name": "muffin",
+                           "num_gates": num_gates},
+            "mobile": {"enabled": True, "action": "happy_hare_stage"},
+        }
+        if toolheads:
+            cfg["toolheads"] = toolheads
+        return cfg
+
+    def test_allowed_when_hh_enabled(self):
+        _validate_mobile(self._cfg())
+
+    def test_rejected_without_hh_enabled(self):
+        with self.assertRaises(SystemExit):
+            _validate_mobile(self._cfg(hh_enabled=False))
+
+    def test_rejected_with_toolhead_stage_scanners(self):
+        # Both flows stage into the same pending slot — the ASSIGN_SPOOL
+        # watcher would steal the HH-staged spool
+        with self.assertRaises(SystemExit):
+            _validate_mobile(self._cfg(
+                scanners={"abc": {"action": "toolhead_stage"}}))
+
+    def test_rejected_with_toolhead_scanners(self):
+        with self.assertRaises(SystemExit):
+            _validate_mobile(self._cfg(
+                scanners={"abc": {"action": "toolhead", "toolhead": "T0"}}))
+
+    def test_rejected_with_afc_scanners(self):
+        # AFC + publish_lane_data starts the ASSIGN_SPOOL consumer that
+        # would steal the HH-staged spool; lanes also suppress gate targets
+        with self.assertRaises(SystemExit):
+            _validate_mobile(self._cfg(
+                scanners={"abc": {"action": "afc_lane", "lane": "lane1"}}))
+
+    def test_allowed_with_hh_scanners(self):
+        _validate_mobile(self._cfg(
+            scanners={"abc": {"action": "happy_hare_stage"}}))
+
+    def test_rejected_without_spoolman_url(self):
+        with self.assertRaises(SystemExit):
+            _validate_mobile(self._cfg(spoolman=""))
+
+    def test_rejected_without_num_gates(self):
+        with self.assertRaises(SystemExit):
+            _validate_mobile(self._cfg(num_gates=None))
+
+    def test_rejected_with_explicit_toolheads(self):
+        with self.assertRaises(SystemExit):
+            _validate_mobile(self._cfg(toolheads=["T0", "T1"]))
+
+
+
+class TestGateDerivationEndToEnd(unittest.TestCase):
+    """load_config derives G0..G{n-1} for HH-mobile configs — the linchpin
+    of the phone gate picker, tested through the real loader."""
+
+    def _load(self, yaml_text):
+        import tempfile, config as config_mod
+        with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_text)
+            path = f.name
+        old = config_mod.CONFIG_PATH
+        config_mod.CONFIG_PATH = path
+        try:
+            return config_mod.load_config()
+        finally:
+            config_mod.CONFIG_PATH = old
+            os.unlink(path)
+
+    def test_hh_mobile_config_derives_gate_targets(self):
+        cfg = self._load(
+            "mqtt: {broker: b, port: 1883, username: '', password: ''}\n"
+            "spoolman_url: http://s:7912\n"
+            "moonraker_url: http://m:7125\n"
+            "scanners: {vethh: {action: happy_hare_stage}}\n"
+            "happy_hare: {enabled: true, num_gates: 3}\n"
+            "mobile: {enabled: true, action: happy_hare_stage}\n"
+        )
+        self.assertEqual(cfg["toolheads"], ["G0", "G1", "G2"])
 
 
 if __name__ == "__main__":

--- a/middleware/tests/test_happy_hare.py
+++ b/middleware/tests/test_happy_hare.py
@@ -24,6 +24,7 @@ from happy_hare import bind_spool_to_current_gate  # noqa: E402
 
 
 def _reset(*, enabled=True, printer_name="muffin"):
+    happy_hare._CONFIRM_DELAY_S = 0.0
     app_state.cfg = {
         "moonraker_url": "http://moonraker:7125",
         "happy_hare": {"enabled": enabled, "printer_name": printer_name},
@@ -41,6 +42,9 @@ def _mmu_status(**overrides):
         "spoolman_support": "pull",
         "gate": 4,
         "num_gates": 8,
+        # Post-bind view used by the confirmation poll: gate 4 -> spool 42,
+        # gate 2 -> spool 7 (the ids the bind tests use)
+        "gate_spool_id": [-1, -1, 7, -1, 42, -1, -1, -1],
     }
     base.update(overrides)
     return base
@@ -59,28 +63,51 @@ class TestBindHappyPath(unittest.TestCase):
     def setUp(self):
         _reset()
 
-    def test_bind_patches_spoolman_with_gate_and_printer_name(self):
-        with patch("moonraker_client.requests.get", return_value=_mock_response(_mmu_status())), \
-             patch("happy_hare.send_gcode"):
-            result = bind_spool_to_current_gate(spool_id=42)
-        assert result is True
-        app_state.spoolman_client.update_spool_extras.assert_called_once_with(
-            42, {"mmu_gate": 4, "printer_name": "muffin"}
-        )
-
-    def test_bind_fires_mmu_spoolman_sync(self):
+    def test_bind_sends_mmu_spoolman_spoolid_gate(self):
+        # Binding goes through HH's own set_spool_gate primitive — the
+        # middleware must NOT write Spoolman extras itself (the old direct
+        # PATCH wrote extra.mmu_gate, a key no HH version reads)
         with patch("moonraker_client.requests.get", return_value=_mock_response(_mmu_status())), \
              patch("happy_hare.send_gcode") as mock_gcode:
-            bind_spool_to_current_gate(spool_id=42)
-        mock_gcode.assert_called_once_with("http://moonraker:7125", "MMU_SPOOLMAN SYNC=1")
+            result = bind_spool_to_current_gate(spool_id=42)
+        assert result is True
+        mock_gcode.assert_called_once_with(
+            "http://moonraker:7125", "MMU_SPOOLMAN SPOOLID=42 GATE=4")
+        app_state.spoolman_client.update_spool_extras.assert_not_called()
 
-    def test_bind_sync_failure_does_not_fail_overall_bind(self):
-        # The PATCH already landed; a missing sync just means Happy Hare
-        # picks it up on the next periodic pull. Still report success.
+    def test_single_precheck_fetch_per_bind(self):
+        # One precheck fetch + one confirmation poll — the old double
+        # precheck (checks run twice) must not come back
+        with patch("moonraker_client.requests.get",
+                   return_value=_mock_response(_mmu_status())) as mock_get, \
+             patch("happy_hare.send_gcode"):
+            assert bind_spool_to_current_gate(spool_id=42) is True
+        assert mock_get.call_count == 2
+
+    def test_unconfirmed_bind_reported_as_failure(self):
+        # Gate map never shows the spool (mmu_server failed downstream) —
+        # gcode acceptance alone must not count as success
+        stale = _mmu_status(gate_spool_id=[-1] * 8)
+        with patch("moonraker_client.requests.get",
+                   return_value=_mock_response(stale)), \
+             patch("happy_hare.send_gcode"):
+            assert bind_spool_to_current_gate(spool_id=42) is False
+
+    def test_gcode_failure_fails_bind(self):
+        # The gcode IS the bind now — if it fails, nothing happened
         with patch("moonraker_client.requests.get", return_value=_mock_response(_mmu_status())), \
              patch("happy_hare.send_gcode", side_effect=Exception("boom")):
             result = bind_spool_to_current_gate(spool_id=42)
+        assert result is False
+
+    def test_bind_works_without_spoolman_client(self):
+        # HH talks to Spoolman itself; the middleware needs no client to bind
+        app_state.spoolman_client = None
+        with patch("moonraker_client.requests.get", return_value=_mock_response(_mmu_status())), \
+             patch("happy_hare.send_gcode") as mock_gcode:
+            result = bind_spool_to_current_gate(spool_id=42)
         assert result is True
+        mock_gcode.assert_called_once()
 
 
 class TestBindGuards(unittest.TestCase):
@@ -98,12 +125,14 @@ class TestBindGuards(unittest.TestCase):
         assert result is False
         self._assert_no_patch_called()
 
-    def test_skipped_when_printer_name_empty(self):
+    def test_empty_printer_name_no_longer_blocks_bind(self):
+        # printer_name is legacy config — HH stamps its own printer identity
         _reset(printer_name="")
-        with patch("moonraker_client.requests.get", return_value=_mock_response(_mmu_status())):
+        with patch("moonraker_client.requests.get", return_value=_mock_response(_mmu_status())), \
+             patch("happy_hare.send_gcode") as mock_gcode:
             result = bind_spool_to_current_gate(spool_id=42)
-        assert result is False
-        self._assert_no_patch_called()
+        assert result is True
+        mock_gcode.assert_called_once()
 
     def test_skipped_when_moonraker_unreachable(self):
         import requests
@@ -154,12 +183,6 @@ class TestBindGuards(unittest.TestCase):
             result = bind_spool_to_current_gate(spool_id=42)
         assert result is False
 
-    def test_returns_false_when_spoolman_patch_fails(self):
-        app_state.spoolman_client.update_spool_extras = MagicMock(return_value=False)
-        with patch("moonraker_client.requests.get", return_value=_mock_response(_mmu_status())), \
-             patch("happy_hare.send_gcode"):
-            result = bind_spool_to_current_gate(spool_id=42)
-        assert result is False
 
 
 class TestModeCheckCaching(unittest.TestCase):
@@ -186,9 +209,9 @@ class TestModeCheckCaching(unittest.TestCase):
         with patch("moonraker_client.requests.get",
                    return_value=_mock_response(_mmu_status())) as mock_get, \
              patch("happy_hare.send_gcode"):
-            assert bind_spool_to_current_gate(spool_id=1) is True
+            assert bind_spool_to_current_gate(spool_id=42) is True
             first_call_count = mock_get.call_count
-            assert bind_spool_to_current_gate(spool_id=2) is True
+            assert bind_spool_to_current_gate(spool_id=42) is True
             # We expect a second call (the bind path always fetches gate info)
             # but the mode-check shouldn't add an extra one — the assertion is
             # cleaner via the public flag.
@@ -207,7 +230,7 @@ class TestModeCheckCaching(unittest.TestCase):
         with patch("moonraker_client.requests.get",
                    return_value=_mock_response(_mmu_status(spoolman_support="pull"))), \
              patch("happy_hare.send_gcode"):
-            assert bind_spool_to_current_gate(spool_id=1) is True
+            assert bind_spool_to_current_gate(spool_id=42) is True
         assert happy_hare._cached_pull_mode is True
 
     def test_missing_spoolman_support_field_does_not_cache(self):
@@ -220,6 +243,90 @@ class TestModeCheckCaching(unittest.TestCase):
                    return_value=_mock_response(bad_status)):
             assert bind_spool_to_current_gate(spool_id=1) is False
         assert happy_hare._cached_pull_mode is False
+
+
+
+class TestBindSpoolToGate(unittest.TestCase):
+    """Gate-targeted bind (mobile assign flow) — no gate selection needed."""
+
+    def setUp(self):
+        _reset()
+
+    def test_binds_explicit_gate_ignoring_current_selection(self):
+        # Current gate is -1 (nothing selected) — explicit target still binds
+        with patch("moonraker_client.requests.get",
+                   return_value=_mock_response(_mmu_status(gate=-1))), \
+             patch("happy_hare.send_gcode") as mock_gcode:
+            assert happy_hare.bind_spool_to_gate(2, spool_id=7) is True
+        mock_gcode.assert_called_once_with(
+            "http://moonraker:7125", "MMU_SPOOLMAN SPOOLID=7 GATE=2")
+        app_state.spoolman_client.update_spool_extras.assert_not_called()
+
+    def test_gate_out_of_range_rejected(self):
+        with patch("moonraker_client.requests.get",
+                   return_value=_mock_response(_mmu_status(num_gates=4))):
+            assert happy_hare.bind_spool_to_gate(4, spool_id=7) is False
+        app_state.spoolman_client.update_spool_extras.assert_not_called()
+
+    def test_negative_and_bool_gates_rejected(self):
+        with patch("moonraker_client.requests.get",
+                   return_value=_mock_response(_mmu_status())):
+            assert happy_hare.bind_spool_to_gate(-1, spool_id=7) is False
+            assert happy_hare.bind_spool_to_gate(True, spool_id=7) is False
+
+    def test_wrong_mode_rejected(self):
+        with patch("moonraker_client.requests.get",
+                   return_value=_mock_response(_mmu_status(spoolman_support="push"))):
+            assert happy_hare.bind_spool_to_gate(1, spool_id=7) is False
+
+
+class TestOnWsMmu(unittest.TestCase):
+    """printer.mmu deltas drive the active_tool marker for /api/status."""
+
+    def setUp(self):
+        _reset()
+        app_state.indx_active_tool = None
+
+    def test_gate_pickup_sets_active_tool(self):
+        happy_hare.on_ws_mmu({"gate": 3})
+        assert app_state.indx_active_tool == 3
+
+    def test_unknown_and_bypass_map_to_none(self):
+        app_state.indx_active_tool = 3
+        happy_hare.on_ws_mmu({"gate": -1})
+        assert app_state.indx_active_tool is None
+        app_state.indx_active_tool = 3
+        happy_hare.on_ws_mmu({"gate": -2})
+        assert app_state.indx_active_tool is None
+
+    def test_absent_gate_key_leaves_state_unchanged(self):
+        app_state.indx_active_tool = 2
+        happy_hare.on_ws_mmu({"filament": "loaded"})
+        assert app_state.indx_active_tool == 2
+
+
+    def test_gate_spool_id_map_mirrors_occupancy(self):
+        app_state.active_spools = {}
+        happy_hare.on_ws_mmu({"gate_spool_id": [42, -1, 7, -1]})
+        assert app_state.active_spools == {"G0": 42, "G1": None, "G2": 7, "G3": None}
+
+    def test_gate_map_delta_without_gate_key_updates_occupancy_only(self):
+        app_state.active_spools = {}
+        app_state.indx_active_tool = 1
+        happy_hare.on_ws_mmu({"gate_spool_id": [5]})
+        assert app_state.active_spools["G0"] == 5
+        assert app_state.indx_active_tool == 1
+
+    def test_garbage_gate_map_entries_become_none(self):
+        app_state.active_spools = {}
+        happy_hare.on_ws_mmu({"gate_spool_id": [0, True, "x", 9]})
+        assert app_state.active_spools == {"G0": None, "G1": None, "G2": None, "G3": 9}
+
+    def test_garbage_gate_ignored(self):
+        app_state.indx_active_tool = 2
+        happy_hare.on_ws_mmu({"gate": "three"})
+        happy_hare.on_ws_mmu({"gate": True})
+        assert app_state.indx_active_tool == 2
 
 
 if __name__ == "__main__":

--- a/middleware/tests/test_moonraker_ws.py
+++ b/middleware/tests/test_moonraker_ws.py
@@ -203,6 +203,33 @@ class TestMoonrakerWebsocket(unittest.TestCase):
         self.ws._has_save_variables = True
         self.assertNotIn("save_variables", self.ws._build_subscribe_objects())
 
+
+    def test_mmu_subscribed_when_discovered_and_callback_set(self):
+        self.ws.on_mmu = lambda data: None
+        self.ws._has_mmu = True
+        self.assertIn("mmu", self.ws._build_subscribe_objects())
+
+    def test_mmu_not_subscribed_when_not_discovered(self):
+        self.ws.on_mmu = lambda data: None
+        self.ws._has_mmu = False
+        self.assertNotIn("mmu", self.ws._build_subscribe_objects())
+
+    def test_mmu_not_subscribed_without_callback(self):
+        self.ws._has_mmu = True
+        self.assertNotIn("mmu", self.ws._build_subscribe_objects())
+
+    def test_dispatch_routes_mmu_delta(self):
+        received = []
+        self.ws.on_mmu = received.append
+        self.ws._dispatch_status({"mmu": {"gate": 2}})
+        self.assertEqual(received, [{"gate": 2}])
+
+    def test_dispatch_skips_non_dict_mmu(self):
+        received = []
+        self.ws.on_mmu = received.append
+        self.ws._dispatch_status({"mmu": "garbage"})
+        self.assertEqual(received, [])
+
     def test_objects_list_discovers_save_variables(self):
         """printer.objects.list response records save_variables availability."""
         mock_ws = MagicMock()

--- a/middleware/tests/test_rest_api.py
+++ b/middleware/tests/test_rest_api.py
@@ -182,6 +182,15 @@ class TestMobileScan(unittest.TestCase):
         # Pending spool was stored in app_state
         self.assertIsNotNone(app_state.pending_spool_toolhead)
 
+    def test_toolhead_stage_pending_uid_stored_as_sent(self):
+        # Frozen iOS contract: /api/status echoes the pending dict and the
+        # shipped app reads the uid back — it must keep the case the app sent
+        _reset_app_state(mobile_enabled=True, mobile_action="toolhead_stage")
+        scan = _make_scan_event(uid="AABBCCDD")
+        with patch("rest_api.detect_and_parse", return_value=scan):
+            self._post({"uid": "AABBCCDD", "present": True, "tag_data_valid": True})
+        self.assertEqual(app_state.pending_spool_toolhead["uid"], "AABBCCDD")
+
     def test_toolhead_stage_replaced_flag_set_on_second_scan(self):
         _reset_app_state(mobile_enabled=True, mobile_action="toolhead_stage")
         # Pre-populate a pending spool to simulate scanning twice

--- a/middleware/tests/test_rest_api.py
+++ b/middleware/tests/test_rest_api.py
@@ -69,6 +69,7 @@ def _reset_app_state(
     app_state.active_spools = {}
     app_state.pending_spool_afc = None
     app_state.pending_spool_toolhead = None
+    app_state.pending_spool_toolhead_gen = 0
     app_state.state_lock = threading.Lock()
     import tempfile
     app_state.TRACKING_FILE = os.path.join(tempfile.gettempdir(), "ss-test-tracking.json")
@@ -434,6 +435,160 @@ class TestUnlockTarget(unittest.TestCase):
         client.post("/api/unlock/T0")
         self.assertFalse(app_state.lane_locks["T0"])
         self.assertTrue(app_state.lane_locks["lane1"])
+
+
+class TestMobileScanHappyHare(unittest.TestCase):
+    """mobile.action happy_hare_stage: scan stages for the gate picker (#82/#91
+    HH-for-mobile). The bind writes to Spoolman, so scans resolve the spool
+    at scan time and reject unknown tags with a visible message."""
+
+    def setUp(self):
+        _reset_app_state(mobile_enabled=True, mobile_action="happy_hare_stage")
+        app_state.cfg["happy_hare"] = {"enabled": True, "printer_name": "muffin",
+                                       "num_gates": 4}
+        app_state.cfg["toolheads"] = ["G0", "G1", "G2", "G3"]
+
+    def _post(self, payload):
+        return client.post("/api/mobile-scan", json=payload)
+
+    def test_scan_stages_with_uid_resolved_spool(self):
+        scan = _make_scan_event(uid="AABB11")
+        scan.scanner_spoolman_id = 42
+        app_state.spoolman_client = MagicMock()
+        app_state.spoolman_client.find_by_nfc.return_value = {"id": 42}
+        with patch("rest_api.detect_and_parse", return_value=scan):
+            resp = self._post({"uid": "AABB11", "present": True,
+                               "tag_data_valid": True, "spoolman_id": 42})
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.json()["success"])
+        self.assertTrue(resp.json()["pending"])
+        self.assertEqual(resp.json()["spool_id"], 42)
+        self.assertEqual(app_state.pending_spool_toolhead["spoolman_id"], 42)
+        self.assertEqual(app_state.pending_spool_toolhead["uid"], "AABB11")
+
+    def test_uid_resolution_beats_stale_payload_id(self):
+        # A relinked tag: payload still carries the OLD spool id — the uid
+        # lookup is authoritative and must win
+        scan = _make_scan_event(uid="AABB11")
+        scan.scanner_spoolman_id = 42
+        app_state.spoolman_client = MagicMock()
+        app_state.spoolman_client.find_by_nfc.return_value = {"id": 77}
+        with patch("rest_api.detect_and_parse", return_value=scan):
+            resp = self._post({"uid": "AABB11", "present": True,
+                               "tag_data_valid": True, "spoolman_id": 42})
+        self.assertEqual(resp.json()["spool_id"], 77)
+        self.assertEqual(app_state.pending_spool_toolhead["spoolman_id"], 77)
+
+    def test_scan_without_id_resolves_via_spoolman_lookup(self):
+        scan = _make_scan_event(uid="AABB11")
+        scan.scanner_spoolman_id = None
+        app_state.spoolman_client = MagicMock()
+        app_state.spoolman_client.find_by_nfc.return_value = {"id": 7}
+        with patch("rest_api.detect_and_parse", return_value=scan):
+            resp = self._post({"uid": "AABB11", "present": True,
+                               "tag_data_valid": True})
+        self.assertTrue(resp.json()["success"])
+        self.assertEqual(app_state.pending_spool_toolhead["spoolman_id"], 7)
+
+    def test_unknown_spool_rejected_with_message(self):
+        scan = _make_scan_event(uid="AABB11")
+        scan.scanner_spoolman_id = None
+        app_state.spoolman_client = MagicMock()
+        app_state.spoolman_client.find_by_nfc.return_value = None
+        with patch("rest_api.detect_and_parse", return_value=scan):
+            resp = self._post({"uid": "AABB11", "present": True,
+                               "tag_data_valid": True})
+        self.assertEqual(resp.status_code, 200)
+        self.assertFalse(resp.json()["success"])
+        self.assertIn("Spoolman", resp.json()["message"])
+        self.assertIsNone(app_state.pending_spool_toolhead)
+
+
+class TestAssignGate(unittest.TestCase):
+    """Gate-targeted assign for happy_hare_stage — same uid/409 contract as
+    the toolhead flow; the endpoint itself consumes the stage and restores
+    it on a failed bind."""
+
+    def setUp(self):
+        _reset_app_state(mobile_enabled=True, mobile_action="happy_hare_stage")
+        app_state.cfg["happy_hare"] = {"enabled": True, "printer_name": "muffin",
+                                       "num_gates": 4}
+        app_state.cfg["toolheads"] = ["G0", "G1", "G2", "G3"]
+        self.pending = {"spoolman_id": 42, "uid": "AABB11", "color_hex": "FF0000",
+                        "material": "PLA", "remaining_g": 500.0}
+        app_state.pending_spool_toolhead = dict(self.pending)
+
+    def _assign(self, toolhead="G1", uid="AABB11"):
+        body = {"toolhead": toolhead}
+        if uid is not None:
+            body["uid"] = uid
+        return client.post("/api/assign-tool", json=body)
+
+    def test_assign_binds_and_consumes_stage(self):
+        with patch("happy_hare.bind_spool_to_gate", return_value=True) as mock_bind:
+            resp = self._assign("G1")
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.json()["success"])
+        self.assertEqual(resp.json()["toolhead"], "G1")
+        self.assertEqual(resp.json()["spool_id"], 42)
+        mock_bind.assert_called_once_with(1, 42)
+        self.assertIsNone(app_state.pending_spool_toolhead)
+
+    def test_lowercase_gate_name_accepted(self):
+        with patch("happy_hare.bind_spool_to_gate", return_value=True) as mock_bind:
+            resp = self._assign("g2")
+        self.assertTrue(resp.json()["success"])
+        mock_bind.assert_called_once_with(2, 42)
+
+    def test_no_pending_returns_409(self):
+        app_state.pending_spool_toolhead = None
+        resp = self._assign("G1")
+        self.assertEqual(resp.status_code, 409)
+        self.assertEqual(resp.json()["detail"]["code"], "no_pending_spool")
+
+    def test_stale_uid_returns_409_and_keeps_stage(self):
+        resp = self._assign("G1", uid="DIFFERENT")
+        self.assertEqual(resp.status_code, 409)
+        self.assertEqual(resp.json()["detail"]["code"], "pending_spool_changed")
+        self.assertIsNotNone(app_state.pending_spool_toolhead)
+
+    def test_invalid_gate_name_rejected(self):
+        for bad in ("T0", "G9", "gate1"):
+            resp = self._assign(bad)
+            self.assertEqual(resp.status_code, 200, bad)
+            self.assertFalse(resp.json()["success"], bad)
+        self.assertIsNotNone(app_state.pending_spool_toolhead)
+
+    def test_failed_bind_restores_stage_and_returns_502(self):
+        with patch("happy_hare.bind_spool_to_gate", return_value=False):
+            resp = self._assign("G1")
+        self.assertEqual(resp.status_code, 502)
+        self.assertEqual(app_state.pending_spool_toolhead["spoolman_id"], 42)
+
+    def test_failed_bind_does_not_overwrite_newer_scan(self):
+        newer = {"spoolman_id": 99, "uid": "CCDD22"}
+        def bind_and_stage(gate, spool_id):
+            app_state.pending_spool_toolhead = newer
+            app_state.pending_spool_toolhead_gen += 1
+            return False
+        with patch("happy_hare.bind_spool_to_gate", side_effect=bind_and_stage):
+            resp = self._assign("G1")
+        self.assertEqual(resp.status_code, 502)
+        self.assertIs(app_state.pending_spool_toolhead, newer)
+
+    def test_failed_bind_does_not_resurrect_consumed_newer_scan(self):
+        # ABA: during our slow failing bind, a newer scan is staged AND
+        # consumed by a concurrent assign — the slot is None again, but
+        # restoring our stale claim would resurrect a ghost spool
+        def bind_stage_and_consume(gate, spool_id):
+            app_state.pending_spool_toolhead = {"spoolman_id": 99, "uid": "CCDD22"}
+            app_state.pending_spool_toolhead_gen += 1
+            app_state.pending_spool_toolhead = None   # concurrent assign consumed it
+            return False
+        with patch("happy_hare.bind_spool_to_gate", side_effect=bind_stage_and_consume):
+            resp = self._assign("G1")
+        self.assertEqual(resp.status_code, 502)
+        self.assertIsNone(app_state.pending_spool_toolhead)
 
 
 class TestDeductionApplied(unittest.TestCase):

--- a/middleware/tests/test_toolchanger_status.py
+++ b/middleware/tests/test_toolchanger_status.py
@@ -17,7 +17,11 @@ sys.modules.setdefault("watchdog.observers", MagicMock())
 sys.modules.setdefault("watchdog.events", MagicMock())
 
 import app_state  # noqa: E402
-from toolchanger_status import _fetch_pending_tool, _assign_spool_to_tool  # noqa: E402
+from toolchanger_status import (  # noqa: E402
+    _fetch_pending_tool,
+    _assign_spool_to_tool,
+    _process_pending_tool,
+)
 
 
 def _reset_app_state(moonraker_url="http://moonraker:7125"):
@@ -28,6 +32,7 @@ def _reset_app_state(moonraker_url="http://moonraker:7125"):
     }
     app_state.lane_locks = {}
     app_state.active_spools = {}
+    app_state.active_spool_tracking = {}
     app_state.pending_spool_afc = None
     app_state.pending_spool_toolhead = None
     app_state.state_lock = threading.Lock()
@@ -248,6 +253,130 @@ class TestAssignSpoolToTool(unittest.TestCase):
             if "json" in c[1] and c[1]["json"].get("namespace") == "lane_data"
         ]
         assert len(lane_data_calls) == 0
+
+
+class TestProcessPendingTool(unittest.TestCase):
+    """A failed ASSIGN_SPOOL must not eat the staged spool (#108): the slot is
+    restored on failure unless a newer scan already took it."""
+
+    def setUp(self):
+        _reset_app_state()
+
+    @patch("toolchanger_status._assign_spool_to_tool", return_value=False)
+    def test_failed_assignment_restores_pending_spool(self, mock_assign):
+        pending = {"spoolman_id": 7, "color_hex": "FF0000", "material": "PLA",
+                   "remaining_g": 300.0}
+        app_state.pending_spool_toolhead = pending
+
+        _process_pending_tool("T0", "Macro assign")
+
+        mock_assign.assert_called_once_with("T0", pending)
+        self.assertIs(app_state.pending_spool_toolhead, pending)
+
+    @patch("toolchanger_status._assign_spool_to_tool")
+    def test_failed_assignment_does_not_overwrite_newer_scan(self, mock_assign):
+        old = {"spoolman_id": 7, "color_hex": "FF0000", "material": "PLA",
+               "remaining_g": 300.0}
+        new = {"spoolman_id": 9, "color_hex": "00FF00", "material": "PETG",
+               "remaining_g": 800.0}
+        app_state.pending_spool_toolhead = old
+
+        def assign_and_stage_newer(tool_name, pending):
+            # A scan lands while the (slow) assign network call is running
+            app_state.pending_spool_toolhead = new
+            return False
+
+        mock_assign.side_effect = assign_and_stage_newer
+        _process_pending_tool("T0", "Macro assign")
+
+        self.assertIs(app_state.pending_spool_toolhead, new)
+
+    @patch("toolchanger_status._assign_spool_to_tool", return_value=True)
+    def test_successful_assignment_leaves_slot_empty(self, mock_assign):
+        app_state.pending_spool_toolhead = {"spoolman_id": 7, "color_hex": "FF0000",
+                                            "material": "PLA", "remaining_g": 300.0}
+
+        _process_pending_tool("T0", "Macro assign WS")
+
+        self.assertIsNone(app_state.pending_spool_toolhead)
+
+    @patch("toolchanger_status._assign_spool_to_tool")
+    def test_no_pending_spool_does_not_assign(self, mock_assign):
+        _process_pending_tool("T0", "Macro assign")
+        mock_assign.assert_not_called()
+
+
+class TestAssignRecordsTracking(unittest.TestCase):
+    """A staged scan consumed by ASSIGN_SPOOL records a deduction baseline —
+    previously only dedicated toolhead/afc_lane scans got one (#109)."""
+
+    def setUp(self):
+        _reset_app_state()
+
+    @patch("requests.post")
+    def test_success_records_baseline_with_lowercased_uid(self, mock_post):
+        mock_post.return_value = MagicMock(raise_for_status=lambda: None)
+        pending = {"spoolman_id": 10, "color_hex": "FF0000", "material": "PLA",
+                   "remaining_g": 300.0, "uid": "AABB11", "device_id": "f3d360",
+                   "diameter_mm": 1.75, "density": 1.24,
+                   "tag_format": "openprinttag"}
+
+        result = _assign_spool_to_tool("T0", pending)
+
+        self.assertTrue(result)
+        rec = app_state.active_spool_tracking.get("T0")
+        self.assertIsNotNone(rec)
+        self.assertEqual(rec.uid, "aabb11")
+        self.assertEqual(rec.weight_g, 300.0)
+        self.assertEqual(rec.tag_format, "openprinttag")
+
+    @patch("requests.post")
+    def test_no_uid_records_nothing(self, mock_post):
+        mock_post.return_value = MagicMock(raise_for_status=lambda: None)
+        pending = {"spoolman_id": 10, "color_hex": "FF0000", "material": "PLA",
+                   "remaining_g": 300.0}
+
+        _assign_spool_to_tool("T0", pending)
+
+        self.assertNotIn("T0", app_state.active_spool_tracking)
+
+    @patch("requests.post")
+    def test_no_weight_records_nothing(self, mock_post):
+        # A baseline without a weight can't drive a deduction — skip it
+        mock_post.return_value = MagicMock(raise_for_status=lambda: None)
+        pending = {"spoolman_id": 10, "color_hex": "FF0000", "material": "PLA",
+                   "remaining_g": None, "uid": "AABB11"}
+
+        _assign_spool_to_tool("T0", pending)
+
+        self.assertNotIn("T0", app_state.active_spool_tracking)
+
+    @patch("requests.post")
+    def test_unrecordable_assignment_clears_previous_baseline(self, mock_post):
+        # Spool B assigned with no weight while spool A's baseline is on the
+        # tool — B's usage must not be deducted from A's uid
+        mock_post.return_value = MagicMock(raise_for_status=lambda: None)
+        app_state.active_spool_tracking["T0"] = app_state.ActiveSpool(
+            uid="spool_a", weight_g=400.0)
+        pending = {"spoolman_id": 10, "color_hex": "FF0000", "material": "PLA",
+                   "remaining_g": None, "uid": "SPOOLB"}
+
+        result = _assign_spool_to_tool("T0", pending)
+
+        self.assertTrue(result)
+        self.assertNotIn("T0", app_state.active_spool_tracking)
+
+    @patch("requests.post")
+    def test_failed_activation_records_nothing(self, mock_post):
+        import requests as req
+        mock_post.side_effect = req.ConnectionError("refused")
+        pending = {"spoolman_id": 10, "color_hex": "FF0000", "material": "PLA",
+                   "remaining_g": 300.0, "uid": "AABB11"}
+
+        result = _assign_spool_to_tool("T0", pending)
+
+        self.assertFalse(result)
+        self.assertNotIn("T0", app_state.active_spool_tracking)
 
 
 class TestLaneDataTemps(unittest.TestCase):

--- a/middleware/tests/test_tracking_store.py
+++ b/middleware/tests/test_tracking_store.py
@@ -16,7 +16,7 @@ sys.modules.setdefault("paho.mqtt", MagicMock())
 sys.modules.setdefault("paho.mqtt.client", MagicMock())
 
 import app_state  # noqa: E402
-from tracking_store import load_tracking, save_tracking  # noqa: E402
+from tracking_store import load_tracking, record_tracking, save_tracking  # noqa: E402
 
 
 class TestTrackingStore(unittest.TestCase):
@@ -74,6 +74,47 @@ class TestTrackingStore(unittest.TestCase):
     def test_save_never_raises(self):
         app_state.TRACKING_FILE = "/nonexistent-root-dir/tracking.json"
         save_tracking()  # must not raise
+
+
+class TestRecordTracking(unittest.TestCase):
+    """record_tracking is the single write path for deduction baselines —
+    it lowercases the uid, requires a weight, and persists (#109)."""
+
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".json", delete=False)
+        self.tmp.close()
+        os.unlink(self.tmp.name)
+        app_state.TRACKING_FILE = self.tmp.name
+        app_state.state_lock = threading.Lock()
+        app_state.active_spool_tracking = {}
+
+    def tearDown(self):
+        if os.path.exists(self.tmp.name):
+            os.unlink(self.tmp.name)
+
+    def test_records_lowercased_uid_and_persists(self):
+        ok = record_tracking("T0", "AABB11", "f3d360", 300.0, 1.75, 1.24, "openprinttag")
+        self.assertTrue(ok)
+        self.assertEqual(app_state.active_spool_tracking["T0"].uid, "aabb11")
+        with open(self.tmp.name) as f:
+            self.assertIn("aabb11", json.load(f)["T0"]["uid"])
+
+    def test_missing_weight_rejected(self):
+        self.assertFalse(record_tracking("T0", "aabb11", "", None))
+        self.assertNotIn("T0", app_state.active_spool_tracking)
+        self.assertFalse(os.path.exists(self.tmp.name))
+
+    def test_missing_uid_or_target_rejected(self):
+        self.assertFalse(record_tracking("T0", "", "", 300.0))
+        self.assertFalse(record_tracking("", "aabb11", "", 300.0))
+        self.assertEqual(app_state.active_spool_tracking, {})
+
+    def test_defaults_applied(self):
+        record_tracking("lane1", "aabb11", "", 250.0)
+        rec = app_state.active_spool_tracking["lane1"]
+        self.assertEqual(rec.diameter_mm, 1.75)
+        self.assertEqual(rec.density, 1.24)
+        self.assertEqual(rec.tag_format, "unknown")
 
 
 class TestClearTracking(unittest.TestCase):

--- a/middleware/toolchanger_status.py
+++ b/middleware/toolchanger_status.py
@@ -131,11 +131,15 @@ def _publish_tool_lane_data(moonraker: str, macro: str, tool_number_str: str,
         logger.exception(f"[toolhead_stage] Failed to publish lane_data for {macro}")
 
 
-def _assign_spool_to_tool(tool_name: str, pending: dict) -> None:
-    """Pushes cached spool data to the specified tool via Klipper gcode commands."""
+def _assign_spool_to_tool(tool_name: str, pending: dict) -> bool:
+    """Pushes cached spool data to the specified tool via Klipper gcode commands.
+
+    Returns False on hard failure (no Moonraker, Spoolman activation failed)
+    so the caller can restore the pending spool; cosmetic failures (color
+    gcode) are logged and do not fail the assignment."""
     moonraker = app_state.cfg.get("moonraker_url", "")
     if not moonraker:
-        return
+        return False
 
     macro = tool_name.upper()
     match = _TOOL_PATTERN.match(macro)
@@ -149,7 +153,7 @@ def _assign_spool_to_tool(tool_name: str, pending: dict) -> None:
     # Spoolman path — activate, set gcode var, persist, with rollback on failure
     if spoolman_id is not None:
         if not _activate_spoolman(moonraker, macro, tool_number_str, spoolman_id):
-            return
+            return False
 
     # Color — always set from tag data regardless of Spoolman
     spool_color = display_spoolcolor(color_hex)
@@ -175,6 +179,55 @@ def _assign_spool_to_tool(tool_name: str, pending: dict) -> None:
     if app_state.cfg.get("publish_lane_data", False):
         _publish_tool_lane_data(moonraker, macro, tool_number_str, spoolman_id,
                                 color_hex, material, remaining_g, temps=pending)
+
+    # Deduction baseline for UPDATE_TAG (#109) — staged scans carry the uid;
+    # without this, spools assigned via ASSIGN_SPOOL never get a baseline.
+    # When the new spool can't be recorded (no uid or unknown weight), the
+    # previous spool's baseline must still die — a successful assignment
+    # means it no longer describes what's mounted.
+    uid = pending.get("uid")
+    if uid and remaining_g is not None:
+        from tracking_store import record_tracking
+        record_tracking(macro, uid, pending.get("device_id", ""), remaining_g,
+                        pending.get("diameter_mm"), pending.get("density"),
+                        pending.get("tag_format"))
+    else:
+        from tracking_store import clear_tracking
+        clear_tracking(macro)
+    return True
+
+
+def _process_pending_tool(tool_name: str, source: str) -> None:
+    """Claim the staged spool and assign it, restoring it on a failed assign.
+
+    The slot is cleared before the network calls so a concurrent scan can
+    stage freely; on failure the claimed spool is put back only if no newer
+    scan has taken the slot in the meantime (#108)."""
+    with app_state.state_lock:
+        pending = app_state.pending_spool_toolhead
+        app_state.pending_spool_toolhead = None
+
+    if not pending:
+        logger.warning(
+            f"{source}: {tool_name} requested but no spool scanned yet — "
+            "scan a tag first, then run ASSIGN_SPOOL"
+        )
+        return
+
+    logger.info(f"{source}: assigning cached spool data to {tool_name}")
+    if _assign_spool_to_tool(tool_name, pending):
+        return
+
+    with app_state.state_lock:
+        if app_state.pending_spool_toolhead is None:
+            app_state.pending_spool_toolhead = pending
+            restored = True
+        else:
+            restored = False
+    if restored:
+        logger.warning(f"{source}: assignment to {tool_name} failed — pending spool restored, rescan not needed")
+    else:
+        logger.warning(f"{source}: assignment to {tool_name} failed; a newer scan already replaced the pending spool")
 
 
 def _fetch_pending_tool() -> str | None:
@@ -231,19 +284,7 @@ class ToolchangerStatusSync:
         tool_name = pending_tool.strip()
         logger.info(f"Macro assign WS: tool {tool_name} requested")
 
-        pending: dict | None = None
-        with app_state.state_lock:
-            if app_state.pending_spool_toolhead:
-                pending = app_state.pending_spool_toolhead
-                app_state.pending_spool_toolhead = None
-
-        if pending:
-            logger.info(f"Macro assign WS: assigning cached spool data to {tool_name}")
-            _assign_spool_to_tool(tool_name, pending)
-        else:
-            logger.warning(
-                f"Macro assign WS: {tool_name} requested but no spool scanned yet"
-            )
+        _process_pending_tool(tool_name, "Macro assign WS")
 
         _clear_pending_tool()
 
@@ -304,23 +345,7 @@ class ToolchangerStatusSync:
                     tool_name = pending_tool.strip()
                     logger.info(f"Macro assign: tool {tool_name} requested")
 
-                    # Check for pending spool data
-                    pending: dict | None = None
-                    with app_state.state_lock:
-                        if app_state.pending_spool_toolhead:
-                            pending = app_state.pending_spool_toolhead
-                            app_state.pending_spool_toolhead = None
-
-                    if pending:
-                        logger.info(
-                            f"Macro assign: assigning cached spool data to {tool_name}"
-                        )
-                        _assign_spool_to_tool(tool_name, pending)
-                    else:
-                        logger.warning(
-                            f"Macro assign: {tool_name} requested but no spool scanned yet — "
-                            "scan a tag first, then run ASSIGN_SPOOL"
-                        )
+                    _process_pending_tool(tool_name, "Macro assign")
 
                     # Clear the macro variable
                     _clear_pending_tool()

--- a/middleware/tracking_store.py
+++ b/middleware/tracking_store.py
@@ -23,6 +23,37 @@ import app_state
 logger = logging.getLogger(__name__)
 
 
+def record_tracking(
+    target: str,
+    uid: str,
+    device_id: str = "",
+    remaining: float | None = None,
+    diameter_mm: float | None = None,
+    density: float | None = None,
+    tag_format: str | None = None,
+) -> bool:
+    """Record the deduction baseline for the spool mounted on *target* and
+    persist it. Requires a uid and a known weight — a baseline without a
+    weight can't drive a deduction, so nothing useful would be stored.
+
+    The uid is stored lowercased: tracking records are matched against
+    scanner/mobile uids that arrive in either case."""
+    if not target or not uid or remaining is None:
+        return False
+
+    with app_state.state_lock:
+        app_state.active_spool_tracking[target] = app_state.ActiveSpool(
+            uid=uid.lower(),
+            device_id=device_id or "",
+            weight_g=remaining,
+            diameter_mm=diameter_mm or 1.75,
+            density=density or 1.24,
+            tag_format=tag_format or "unknown",
+        )
+    save_tracking()
+    return True
+
+
 def load_tracking() -> None:
     """Load persisted tracking records into app_state at startup."""
     if not os.path.exists(app_state.TRACKING_FILE):


### PR DESCRIPTION
Promote dev to master for the v1.8.6 release.

- Happy Hare from the mobile app: gate picker, staged gate assignment, live gate map in /api/status (#117)
- Fix: Happy Hare binding wrote a Spoolman field no HH version reads — now binds via MMU_SPOOLMAN SPOOLID/GATE with confirmation (#117)
- Staged scans (ASSIGN_SPOOL / staged AFC loads) record deduction baselines; failed assignments restore the staged spool (#108, #109)
- AFC staged-load consumption edge cases fixed across both sync paths (#116)
- Bondtech INDX section in the Klipper setup guide

See CHANGELOG for details.